### PR TITLE
Use OCI client errors instead of SearchError

### DIFF
--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -246,22 +246,29 @@ func (c *client) findInstanceByNodeNameIsVnic(nodeName string) (*baremetal.Insta
 			return nil, err
 		}
 		for _, attachment := range vnicAttachments.Attachments {
-			if attachment.State == baremetal.ResourceAttached {
-				vnic, err := c.GetVnic(attachment.VnicID)
+			if attachment.State != baremetal.ResourceAttached {
+				glog.Warningf("VNIC attachment `%s` for instance `%s` has a state of `%s`", attachment.ID, nodeName, attachment.State)
+				continue
+			}
+			vnic, err := c.GetVnic(attachment.VnicID)
+			if err != nil {
+				return nil, err
+			}
+
+			// TOOD(horwitz): why is this checking if the node name is the public ip address?!
+			if vnic.PublicIPAddress == nodeName ||
+				(vnic.HostnameLabel != "" && strings.HasPrefix(nodeName, vnic.HostnameLabel)) {
+				instance, err := c.GetInstance(attachment.InstanceID)
 				if err != nil {
 					return nil, err
 				}
 
-				if vnic.PublicIPAddress == nodeName ||
-					(vnic.HostnameLabel != "" && strings.HasPrefix(nodeName, vnic.HostnameLabel)) {
-					instance, err := c.GetInstance(attachment.InstanceID)
-					if err != nil {
-						return nil, err
-					}
-					if instance.State == baremetal.ResourceRunning {
-						running = append(running, *instance)
-					}
+				if instance.State != baremetal.ResourceRunning {
+					glog.Warningf("Instance `%s` is state `%s` is not running", instance.ID, instance.State)
+					continue
 				}
+
+				running = append(running, *instance)
 			}
 		}
 		if hasNextPage := SetNextPageOption(vnicAttachments.NextPage, &opts.ListOptions.PageListOptions); !hasNextPage {
@@ -272,10 +279,7 @@ func (c *client) findInstanceByNodeNameIsVnic(nodeName string) (*baremetal.Insta
 	count := len(running)
 	switch {
 	case count == 0:
-		return nil, &SearchError{
-			Err:      fmt.Sprintf("could not find instance for node name %q", nodeName),
-			NotFound: true,
-		}
+		return nil, NewNotFoundError(fmt.Sprintf("could not find instance for node name %q", nodeName))
 	case count > 1:
 		return nil, fmt.Errorf("expected one instance vnic ip/hostname %q but got %d", nodeName, count)
 	}
@@ -459,10 +463,8 @@ func (c *client) GetLoadBalancerByName(name string) (*baremetal.LoadBalancer, er
 			break
 		}
 	}
-	return nil, &SearchError{
-		Err:      fmt.Sprintf("could not find load balancer with name '%s'", name),
-		NotFound: true,
-	}
+
+	return nil, NewNotFoundError(fmt.Sprintf("could not find load balancer with name '%s'", name))
 }
 
 // GetCertificateByName gets a certificate by its name.
@@ -472,15 +474,14 @@ func (c *client) GetCertificateByName(loadBalancerID string, name string) (*bare
 	if err != nil {
 		return nil, err
 	}
+
 	for _, cert := range r.Certificates {
 		if cert.CertificateName == name {
 			return &cert, nil
 		}
 	}
-	return nil, &SearchError{
-		Err:      fmt.Sprintf("certificate with name %q for load balancer %q not found", name, loadBalancerID),
-		NotFound: true,
-	}
+
+	return nil, NewNotFoundError(fmt.Sprintf("certificate with name %q for load balancer %q not found", name, loadBalancerID))
 }
 
 // CreateAndAwaitBackendSet creates the given BackendSet for the given
@@ -557,20 +558,23 @@ func (c *client) GetSubnetsForInternalIPs(ips []string) ([]*baremetal.Subnet, er
 			return nil, err
 		}
 		for _, attachment := range r.Attachments {
-			if attachment.State == baremetal.ResourceAttached {
-				vnic, err := c.GetVnic(attachment.VnicID)
+			if attachment.State != baremetal.ResourceAttached {
+				glog.Warningf("VNIC attachment `%s` for instance `%s` has a state and not attached", attachment.ID, attachment.InstanceID, attachment.State)
+				continue
+			}
+
+			vnic, err := c.GetVnic(attachment.VnicID)
+			if err != nil {
+				return nil, err
+			}
+			if vnic.PrivateIPAddress != "" && ipSet.Has(vnic.PrivateIPAddress) &&
+				!subnetOCIDs.Has(vnic.SubnetID) {
+				subnet, err := c.GetSubnet(vnic.SubnetID)
 				if err != nil {
 					return nil, err
 				}
-				if vnic.PrivateIPAddress != "" && ipSet.Has(vnic.PrivateIPAddress) &&
-					!subnetOCIDs.Has(vnic.SubnetID) {
-					subnet, err := c.GetSubnet(vnic.SubnetID)
-					if err != nil {
-						return nil, err
-					}
-					subnets = append(subnets, subnet)
-					subnetOCIDs.Insert(vnic.SubnetID)
-				}
+				subnets = append(subnets, subnet)
+				subnetOCIDs.Insert(vnic.SubnetID)
 			}
 		}
 		if hasNexPage := SetNextPageOption(r.NextPage, &opts.PageListOptions); !hasNexPage {

--- a/pkg/oci/client/error_test.go
+++ b/pkg/oci/client/error_test.go
@@ -17,6 +17,8 @@ package client
 import (
 	"errors"
 	"testing"
+
+	baremetal "github.com/oracle/bmcs-go-sdk"
 )
 
 func TestIsNotFound(t *testing.T) {
@@ -26,13 +28,17 @@ func TestIsNotFound(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "search-error-not-found",
-			err:      &SearchError{NotFound: true},
+			name:     "api-not-found",
+			err:      NewNotFoundError("it was not found :("),
 			expected: true,
 		},
 		{
-			name:     "search-error-found",
-			err:      &SearchError{NotFound: false},
+			name: "random-api-error",
+			err: &baremetal.Error{
+				Status:  "500",
+				Code:    "500",
+				Message: "unrelated internal server error",
+			},
 			expected: false,
 		},
 		{


### PR DESCRIPTION
The OCI errors provide a lot of context to API errors. Wrapping them in the SearchError means we lose that context, so in this PR I removed SearchError in favor of baremetal.Error.

I also snuck in a couple warning messages when a resources state isn't what we expected.