### PR TITLE
Disable auto retries in the client

### DIFF
--- a/pkg/oci/ccm.go
+++ b/pkg/oci/ccm.go
@@ -54,8 +54,6 @@ func NewCloudProvider(cfg *client.Config) (cloudprovider.Interface, error) {
 		return nil, err
 	}
 
-	c = c.Compartment(cfg.Global.CompartmentOCID)
-
 	err = c.Validate()
 	if err != nil {
 		glog.Errorf("cloudprovider.Validate() failed to communicate with OCI: %v", err)


### PR DESCRIPTION
The auto retry logic in the baremetal client caused me a lot of headaches the other day debugging an issue where I didn't set the compartment ID correctly in the integration test. This exact scenario isn't likely in the CCM since it does a validate call; however, it did surface the fact that the client retries errors that are not able to be retried; like bad requests when a required query param is missing. Since the client only has logging when you set the DEBUG env var, it appears like the client has "frozen" for a while or that the single request is taking forever, but in reality it's retrying a bunch of times behind the scenes. 

We should instead rely on the CCM logic to retry errors since the underlying implementations rely on the work queue controller pattern to re-queue events that error. 