### PR TITLE
Add hyphen to lb prefix if it's missing

### DIFF
--- a/pkg/oci/load_balancer_util.go
+++ b/pkg/oci/load_balancer_util.go
@@ -168,8 +168,12 @@ func getListenerName(protocol string, port int, sslConfig *baremetal.SSLConfigur
 
 // GetLoadBalancerName gets the name of the load balancer based on the service
 func GetLoadBalancerName(service *api.Service) string {
-	return os.Getenv(lbNamePrefixEnvVar) +
-		fmt.Sprintf("%s-%s", service.Name, cloudprovider.GetLoadBalancerName(service))
+	prefix := os.Getenv(lbNamePrefixEnvVar)
+	if prefix != "" && !strings.HasSuffix(prefix, "-") {
+		// Add the trailing hyphen if it's missing
+		prefix += "-"
+	}
+	return fmt.Sprintf("%s%s-%s", prefix, service.Name, cloudprovider.GetLoadBalancerName(service))
 }
 
 // Extract a list of all the external IP addresses for the available Kubernetes nodes


### PR DESCRIPTION
To make things a little simpler, I added logic to add a hyphen to the end of the load balancer name prefix if it's missing and added test coverage. 


Open question: I personally don't care for how the `cloudprovider.GetLoadBalancerName` method does things. It's very specific to GCE (adds an `a` prefix) and AWS (limits to 32 characters). I think we should drop that since OCI has different requirements (255 is the max if i'm not mistaken) so we should do `"(prefix-)<service.Name>-<service.UID>".substr(0, 255)`. Thoughts?