### PR TITLE
Fixes #27 - ensure we use the load balancer subnet ids

### DIFF
--- a/pkg/oci/load_balancer.go
+++ b/pkg/oci/load_balancer.go
@@ -178,6 +178,13 @@ func (cp *CloudProvider) EnsureLoadBalancer(clusterName string, service *api.Ser
 		}
 	}
 
+	// Existing load balancers cannot change subnets. This ensures that the spec matches
+	// what the actual load balancer has listed as the subnet ids. If the load balancer
+	// was just created then these values would be equal; however, if the load balancer
+	// already existed and the default subnet ids changed, then this would ensure
+	// we are setting the security rules on the correct subnets.
+	spec.Subnets = lb.SubnetIDs
+
 	certificateName := getCertificateName(lb)
 
 	sslConfigMap, err := spec.GetSSLConfig(certificateName)


### PR DESCRIPTION
Since the config values can change for subnet ids (say you exhaust the ips in that subnet), we want to ensure that we use the actual subnet ids of the load balancer when we are configuring the security rules. Currently, if we change the default subnet ids to ones where the existing load balancer(s) don't exist, then the security rules will not be updated in the correct subnets and instead be added to incorrect subnets. Also, if the subnet annotations change then the same thing would happen.

Subnet's should be immutable for load balancers since that's how they are in the API. 