### PR TITLE
update security lists on backendset changes

### DIFF
--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -53,8 +53,6 @@ func (f *Framework) Init() error {
 		return err
 	}
 
-	f.Client = f.Client.Compartment(f.Config.Global.CompartmentOCID)
-
 	f.nodeSubnetOne = os.Getenv("NODE_SUBNET_ONE")
 	if f.nodeSubnetOne == "" {
 		return errors.New("env var `NODE_SUBNET_ONE` is required")
@@ -77,6 +75,8 @@ func (f *Framework) NodeSubnets() []string {
 }
 
 func (f *Framework) WaitForInstance(id string) error {
+	glog.Infof("Waiting for instance `%s` to be running", id)
+
 	sleepTime := 30 * time.Second
 	for {
 		instance, err := f.Client.GetInstance(id)
@@ -110,7 +110,9 @@ func (f *Framework) CreateInstance(availabilityDomain string, subnetID string) (
 }
 
 func (f *Framework) Cleanup() {
+	glog.Info("Running instance cleanup")
 	for _, instance := range f.Instances {
+		glog.Infof("Terminating instance for cleanup `%s`", instance.ID)
 		err := f.Client.TerminateInstance(instance.ID, nil)
 		if client.IsNotFound(err) {
 			continue
@@ -120,4 +122,5 @@ func (f *Framework) Cleanup() {
 		}
 	}
 	f.Instances = []*baremetal.Instance{}
+	glog.Info("Instance cleanup is done")
 }

--- a/test/integration/loadbalancer/loadbalancer_test.go
+++ b/test/integration/loadbalancer/loadbalancer_test.go
@@ -56,7 +56,7 @@ func TestLoadBalancer(t *testing.T) {
 
 		err = fw.WaitForInstance(instance.ID)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		addresses, err := fw.Client.GetNodeAddressesForInstance(instance.ID)
@@ -77,7 +77,7 @@ func TestLoadBalancer(t *testing.T) {
 	loadbalancers, _ := cp.LoadBalancer()
 	status, err := loadbalancers.EnsureLoadBalancer("foo", service, nodes)
 	if err != nil {
-		t.Errorf("Unable to ensure the load balancer: %v", err)
+		t.Fatalf("Unable to ensure the load balancer: %v", err)
 	}
 
 	defer func() {
@@ -85,7 +85,7 @@ func TestLoadBalancer(t *testing.T) {
 
 		err := loadbalancers.EnsureLoadBalancerDeleted("foo", service)
 		if err != nil {
-			t.Errorf("Unable to delete the load balancer during cleanup: %v", err)
+			t.Fatalf("Unable to delete the load balancer during cleanup: %v", err)
 		}
 	}()
 
@@ -93,30 +93,30 @@ func TestLoadBalancer(t *testing.T) {
 
 	err = validateLoadBalancer(fw.Client, service, nodes)
 	if err != nil {
-		t.Errorf("validation error: %v", err)
+		t.Fatalf("validation error: %v", err)
 	}
 
 	// Decrease the number of backends to 1
 	lessNodes := []*api.Node{nodes[0]}
 	status, err = loadbalancers.EnsureLoadBalancer("foo", service, lessNodes)
 	if err != nil {
-		t.Errorf("Unable to ensure load balancer: %v", err)
+		t.Fatalf("Unable to ensure load balancer: %v", err)
 	}
 
 	err = validateLoadBalancer(fw.Client, service, lessNodes)
 	if err != nil {
-		t.Errorf("validation error: %v", err)
+		t.Fatalf("validation error: %v", err)
 	}
 
 	// Go back to 2 nodes
 	status, err = loadbalancers.EnsureLoadBalancer("foo", service, nodes)
 	if err != nil {
-		t.Errorf("Unable to ensure the load balancer: %v", err)
+		t.Fatalf("Unable to ensure the load balancer: %v", err)
 	}
 
 	err = validateLoadBalancer(fw.Client, service, nodes)
 	if err != nil {
-		t.Errorf("validation error: %v", err)
+		t.Fatalf("validation error: %v", err)
 	}
 }
 


### PR DESCRIPTION
This PR has a few bug fixes. 

1. BackendSet changes were not triggered security list updates, so I added support for that.
2. The OCI api has a bug if you update the security lists with `null` in the json for egress or ingress lists even though the API says they aren't required.
3. `Compartment(str)` on the client was removed but not removed from the test framework.

I also added logic to not update security lists unless they changed.