### PR TITLE
Add support for provider id to have optional cloud prefix

### DIFF
--- a/pkg/oci/ccm.go
+++ b/pkg/oci/ccm.go
@@ -19,6 +19,7 @@ package oci
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -30,9 +31,20 @@ import (
 	"github.com/oracle/oci-cloud-controller-manager/pkg/oci/client"
 )
 
-// ProviderName uniquely identifies the Oracle Bare Metal Cloud Services (OCI)
-// cloud-provider.
-const ProviderName = "oci"
+const (
+	// ProviderName uniquely identifies the Oracle Bare Metal Cloud Services (OCI)
+	// cloud-provider.
+	ProviderName   = "oci"
+	providerPrefix = ProviderName + "://"
+)
+
+// mapProviderIDToInstanceID parses the provider id and returns the instance ocid.
+func mapProviderIDToInstanceID(providerID string) string {
+	if strings.HasPrefix(providerID, providerPrefix) {
+		return strings.TrimPrefix(providerID, providerPrefix)
+	}
+	return providerID
+}
 
 // CloudProvider is an implementation of the cloud-provider interface for OCI.
 type CloudProvider struct {

--- a/pkg/oci/ccm_test.go
+++ b/pkg/oci/ccm_test.go
@@ -1,0 +1,28 @@
+package oci
+
+import "testing"
+
+func TestMapProviderIDToInstanceID(t *testing.T) {
+	testCases := map[string]struct {
+		providerID string
+		expected   string
+	}{
+		"no cloud prefix": {
+			providerID: "testid",
+			expected:   "testid",
+		},
+		"cloud prefix": {
+			providerID: providerPrefix + "testid",
+			expected:   "testid",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := mapProviderIDToInstanceID(tc.providerID)
+			if result != tc.expected {
+				t.Errorf("Expected instance id %q, but got %q", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/oci/instances.go
+++ b/pkg/oci/instances.go
@@ -62,7 +62,8 @@ func (cp *CloudProvider) NodeAddresses(name types.NodeName) ([]api.NodeAddress, 
 // in this method to obtain nodeaddresses.
 func (cp *CloudProvider) NodeAddressesByProviderID(providerID string) ([]api.NodeAddress, error) {
 	glog.V(4).Infof("NodeAddressesByProviderID(%q) called", providerID)
-	return cp.client.GetNodeAddressesForInstance(providerID)
+	instanceID := mapProviderIDToInstanceID(providerID)
+	return cp.client.GetNodeAddressesForInstance(instanceID)
 }
 
 // ExternalID returns the cloud provider ID of the node with the specified NodeName.
@@ -114,7 +115,8 @@ func (cp *CloudProvider) InstanceType(name types.NodeName) (string, error) {
 func (cp *CloudProvider) InstanceTypeByProviderID(providerID string) (string, error) {
 	glog.V(4).Infof("InstanceTypeByProviderID(%q) called", providerID)
 
-	inst, err := cp.client.GetInstance(providerID)
+	instanceID := mapProviderIDToInstanceID(providerID)
+	inst, err := cp.client.GetInstance(instanceID)
 	if err != nil {
 		return "", err
 	}
@@ -139,6 +141,7 @@ func (cp *CloudProvider) CurrentNodeName(hostname string) (types.NodeName, error
 // instance will be immediately deleted by the cloud controller manager.
 func (cp *CloudProvider) InstanceExistsByProviderID(providerID string) (bool, error) {
 	glog.V(4).Infof("InstanceExistsByProviderID(%q) called", providerID)
-	r, err := cp.client.GetInstance(providerID)
+	instanceID := mapProviderIDToInstanceID(providerID)
+	r, err := cp.client.GetInstance(instanceID)
 	return (r != nil), err
 }

--- a/pkg/oci/zones.go
+++ b/pkg/oci/zones.go
@@ -45,7 +45,8 @@ func (cp *CloudProvider) GetZone() (zone cloudprovider.Zone, err error) {
 // particularly used in the context of external cloud providers where node
 // initialization must be down outside the kubelets.
 func (cp *CloudProvider) GetZoneByProviderID(providerID string) (cloudprovider.Zone, error) {
-	instance, err := cp.client.GetInstance(providerID)
+	instanceID := mapProviderIDToInstanceID(providerID)
+	instance, err := cp.client.GetInstance(instanceID)
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}


### PR DESCRIPTION
Currently, if you leave off the `--provider-id` flag on the kubelet the provider id will be prefixed with `oci://`. We should support both options otherwise things break. 

Current error:
```
E1004 15:06:21.868803       9 service_controller.go:749] Failed to process service. Retrying in 20s: Failed to ensure load balancer for service kube-system/kube-proxy-lb: update backendsets: get subnets for nodes: list vnic attachments: Status: 400; Code: InvalidParameter; OPC Request ID: /CE45F460B2BE85E84A7BCD3CB1935520/9DC9CDC2FD80DCB35E536DD556DA19A6; Message: Invalid OCID: oci://ocid1.instance.oc1.phx.stuff
```