### PR TITLE
Add apiVersion to service account

### DIFF
--- a/manifests/oci-cloud-controller-manager.yaml
+++ b/manifests/oci-cloud-controller-manager.yaml
@@ -1,4 +1,5 @@
 ---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cloud-controller-manager


### PR DESCRIPTION
After upgrading my test cluster to 1.8 I was getting the following error when trying to apply the manifest (built by `make manifests`). Interestingly I was about to `kubectl create -f` it previously though.

```
❯ kubectl apply -f dist/oci-cloud-controller-manager.yaml
error: error validating "dist/oci-cloud-controller-manager.yaml": error validating data: apiVersion not set; if you choose to ignore these errors, turn validation off with --validate=false
```