### PR TITLE
Fix $VERSION in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,7 @@ run-dev:
 	    --cluster-cidr=10.244.0.0/16              \
 	    --cloud-provider=external                 \
 	    -v=4
+
+.PHONY: version
+version:
+	@echo ${VERSION}

--- a/wercker.yml
+++ b/wercker.yml
@@ -8,7 +8,7 @@ build:
     - script:
       name: write VERSION.txt
       code: |
-        git describe --always --dirty > ${WERCKER_OUTPUT_DIR}/VERSION.txt
+        make version > ${WERCKER_OUTPUT_DIR}/VERSION.txt
         cat ${WERCKER_OUTPUT_DIR}/VERSION.txt
 
     - script:


### PR DESCRIPTION
Recent git versions changed the format of `git describe` causing a mismatch between versions generated in CI and locally.