### PR TITLE
Fix for ingress rule deletion issue

### DIFF
--- a/pkg/oci/load_balancer_security_lists.go
+++ b/pkg/oci/load_balancer_security_lists.go
@@ -279,7 +279,7 @@ func getLoadBalancerIngressRules(lbSecurityList *baremetal.SecurityList, sourceC
 			if inUse {
 				// This rule is no longer needed for this service, but is still used
 				// by another service, so we must still keep it.
-				glog.V(4).Infof("Port %d still inuse by another service.", port)
+				glog.V(4).Infof("Port %d still in use by another service.", port)
 				ingressRules = append(ingressRules, rule)
 				continue
 			}


### PR DESCRIPTION
Currently, if a service of type load balancer is deleted, then all security list rules relating to this service are deleted, even if some of those rules are shared with other existing services.
The deletion code will now check for this case and act accordingly.