### PR TITLE
Add security rules for a services health check port

### DIFF
--- a/pkg/oci/load_balancer_security_lists.go
+++ b/pkg/oci/load_balancer_security_lists.go
@@ -220,8 +220,8 @@ func getNodeIngressRules(rules []baremetal.IngressSecurityRule, lbSubnets []*bar
 
 	for _, rule := range rules {
 		if rule.TCPOptions == nil || rule.TCPOptions.SourcePortRange != nil || rule.TCPOptions.DestinationPortRange == nil ||
-			(rule.TCPOptions.DestinationPortRange.Min != port &&
-				rule.TCPOptions.DestinationPortRange.Max != port) {
+			rule.TCPOptions.DestinationPortRange.Min != port ||
+			rule.TCPOptions.DestinationPortRange.Max != port {
 			// this rule doesn't apply to this service so nothing to do but keep it
 			ingressRules = append(ingressRules, rule)
 			continue
@@ -234,23 +234,21 @@ func getNodeIngressRules(rules []baremetal.IngressSecurityRule, lbSubnets []*bar
 			continue
 		}
 
-		if rule.TCPOptions.DestinationPortRange.Min == port && rule.TCPOptions.DestinationPortRange.Max == port {
-			inUse, err := healthCheckPortInUse(serviceLister, int32(port))
-			if err != nil {
-				// Unable to determine if this port is in use by another service, so I guess
-				// we better err on the safe side and keep the rule.
-				glog.Errorf("failed to determine if port: %d is still in use: %v", port, err)
-				ingressRules = append(ingressRules, rule)
-				continue
-			}
+		inUse, err := healthCheckPortInUse(serviceLister, int32(port))
+		if err != nil {
+			// Unable to determine if this port is in use by another service, so I guess
+			// we better err on the safe side and keep the rule.
+			glog.Errorf("failed to determine if port: %d is still in use: %v", port, err)
+			ingressRules = append(ingressRules, rule)
+			continue
+		}
 
-			if inUse {
-				// This rule is no longer needed for this service, but is still used
-				// by another service, so we must still keep it.
-				glog.V(4).Infof("Port %d still in use by another service.", port)
-				ingressRules = append(ingressRules, rule)
-				continue
-			}
+		if inUse {
+			// This rule is no longer needed for this service, but is still used
+			// by another service, so we must still keep it.
+			glog.V(4).Infof("Port %d still in use by another service.", port)
+			ingressRules = append(ingressRules, rule)
+			continue
 		}
 
 		// else the actual cidr no longer exists so we don't need to do
@@ -277,8 +275,8 @@ func getLoadBalancerIngressRules(rules []baremetal.IngressSecurityRule, sourceCI
 	ingressRules := []baremetal.IngressSecurityRule{}
 	for _, rule := range rules {
 		if rule.TCPOptions == nil || rule.TCPOptions.SourcePortRange != nil || rule.TCPOptions.DestinationPortRange == nil ||
-			(rule.TCPOptions.DestinationPortRange.Min != port &&
-				rule.TCPOptions.DestinationPortRange.Max != port) {
+			rule.TCPOptions.DestinationPortRange.Min != port ||
+			rule.TCPOptions.DestinationPortRange.Max != port {
 			// this rule doesn't apply to this service so nothing to do but keep it
 			ingressRules = append(ingressRules, rule)
 			continue
@@ -291,23 +289,21 @@ func getLoadBalancerIngressRules(rules []baremetal.IngressSecurityRule, sourceCI
 			continue
 		}
 
-		if rule.TCPOptions.DestinationPortRange.Min == port && rule.TCPOptions.DestinationPortRange.Max == port {
-			inUse, err := portInUse(serviceLister, int32(port))
-			if err != nil {
-				// Unable to determine if this port is in use by another service, so I guess
-				// we better err on the safe side and keep the rule.
-				glog.Errorf("failed to determine if port: %d is still in use: %v", port, err)
-				ingressRules = append(ingressRules, rule)
-				continue
-			}
+		inUse, err := portInUse(serviceLister, int32(port))
+		if err != nil {
+			// Unable to determine if this port is in use by another service, so I guess
+			// we better err on the safe side and keep the rule.
+			glog.Errorf("failed to determine if port: %d is still in use: %v", port, err)
+			ingressRules = append(ingressRules, rule)
+			continue
+		}
 
-			if inUse {
-				// This rule is no longer needed for this service, but is still used
-				// by another service, so we must still keep it.
-				glog.V(4).Infof("Port %d still in use by another service.", port)
-				ingressRules = append(ingressRules, rule)
-				continue
-			}
+		if inUse {
+			// This rule is no longer needed for this service, but is still used
+			// by another service, so we must still keep it.
+			glog.V(4).Infof("Port %d still in use by another service.", port)
+			ingressRules = append(ingressRules, rule)
+			continue
 		}
 
 		// else the actual cidr no longer exists so we don't need to do
@@ -337,8 +333,8 @@ func getLoadBalancerEgressRules(rules []baremetal.EgressSecurityRule, nodeSubnet
 	egressRules := []baremetal.EgressSecurityRule{}
 	for _, rule := range rules {
 		if rule.TCPOptions == nil || rule.TCPOptions.SourcePortRange != nil || rule.TCPOptions.DestinationPortRange == nil ||
-			(rule.TCPOptions.DestinationPortRange.Min != port &&
-				rule.TCPOptions.DestinationPortRange.Max != port) {
+			rule.TCPOptions.DestinationPortRange.Min != port ||
+			rule.TCPOptions.DestinationPortRange.Max != port {
 			// this rule doesn't apply to this service so nothing to do but keep it
 			egressRules = append(egressRules, rule)
 			continue
@@ -351,23 +347,21 @@ func getLoadBalancerEgressRules(rules []baremetal.EgressSecurityRule, nodeSubnet
 			continue
 		}
 
-		if rule.TCPOptions.DestinationPortRange.Min == port && rule.TCPOptions.DestinationPortRange.Max == port {
-			inUse, err := healthCheckPortInUse(serviceLister, int32(port))
-			if err != nil {
-				// Unable to determine if this port is in use by another service, so I guess
-				// we better err on the safe side and keep the rule.
-				glog.Errorf("failed to determine if port: %d is still in use: %v", port, err)
-				egressRules = append(egressRules, rule)
-				continue
-			}
+		inUse, err := healthCheckPortInUse(serviceLister, int32(port))
+		if err != nil {
+			// Unable to determine if this port is in use by another service, so I guess
+			// we better err on the safe side and keep the rule.
+			glog.Errorf("failed to determine if port: %d is still in use: %v", port, err)
+			egressRules = append(egressRules, rule)
+			continue
+		}
 
-			if inUse {
-				// This rule is no longer needed for this service, but is still used
-				// by another service, so we must still keep it.
-				glog.V(4).Infof("Port %d still in use by another service.", port)
-				egressRules = append(egressRules, rule)
-				continue
-			}
+		if inUse {
+			// This rule is no longer needed for this service, but is still used
+			// by another service, so we must still keep it.
+			glog.V(4).Infof("Port %d still in use by another service.", port)
+			egressRules = append(egressRules, rule)
+			continue
 		}
 
 		// else the actual cidr no longer exists so we don't need to do

--- a/pkg/oci/load_balancer_security_lists.go
+++ b/pkg/oci/load_balancer_security_lists.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	listersv1 "k8s.io/client-go/listers/core/v1"
+	apiservice "k8s.io/kubernetes/pkg/api/v1/service"
 )
 
 const (
@@ -45,13 +46,13 @@ type securityListManager interface {
 	// 		from LB subnets to backend subnets on the backend port
 	// Egress rules added:
 	// 		from LB subnets to backend subnets on the backend port
-	Update(lbSubnets []*baremetal.Subnet, backendSubnets []*baremetal.Subnet, sourceCIDRs []string, listenerPort uint64, backendPort uint64) error
+	Update(lbSubnets []*baremetal.Subnet, backendSubnets []*baremetal.Subnet, sourceCIDRs []string, listenerPort uint64, backendPort uint64, healthCheckPort uint64) error
 	// Delete the security list rules associated with the listener & backends.
 	//
 	// If the listener is nil, then only the egress rules from the LB's to the backends and the
 	// ingress rules from the LB's to the backends will be cleaned up.
 	// If the listener is not nil, then the ingress rules to the LB's will be cleaned up.
-	Delete(lbSubnets []*baremetal.Subnet, backendSubnets []*baremetal.Subnet, listenerPort uint64, backendPort uint64) error
+	Delete(lbSubnets []*baremetal.Subnet, backendSubnets []*baremetal.Subnet, listenerPort uint64, backendPort uint64, healthCheckPort uint64) error
 }
 
 type securityListManagerImpl struct {
@@ -71,14 +72,15 @@ func (s *securityListManagerImpl) Update(
 	backendSubnets []*baremetal.Subnet,
 	sourceCIDRs []string,
 	listenerPort uint64,
-	backendPort uint64) error {
+	backendPort uint64,
+	healthCheckPort uint64) error {
 
-	err := s.updateLoadBalancerRules(lbSubnets, backendSubnets, sourceCIDRs, listenerPort, backendPort)
+	err := s.updateLoadBalancerRules(lbSubnets, backendSubnets, sourceCIDRs, listenerPort, backendPort, healthCheckPort)
 	if err != nil {
 		return err
 	}
 
-	return s.updateBackendRules(lbSubnets, backendSubnets, backendPort)
+	return s.updateBackendRules(lbSubnets, backendSubnets, backendPort, healthCheckPort)
 }
 
 func (s *securityListManagerImpl) Delete(
@@ -86,27 +88,29 @@ func (s *securityListManagerImpl) Delete(
 	backendSubnets []*baremetal.Subnet,
 	listenerPort uint64,
 	backendPort uint64,
-) error {
+	healthCheckPort uint64) error {
+
 	noSubnets := []*baremetal.Subnet{}
 	noSourceCIDRs := []string{}
 
-	err := s.updateLoadBalancerRules(lbSubnets, noSubnets, noSourceCIDRs, listenerPort, backendPort)
+	err := s.updateLoadBalancerRules(lbSubnets, noSubnets, noSourceCIDRs, listenerPort, backendPort, healthCheckPort)
 	if err != nil {
 		return err
 	}
 
-	return s.updateBackendRules(noSubnets, backendSubnets, backendPort)
+	return s.updateBackendRules(noSubnets, backendSubnets, backendPort, healthCheckPort)
 }
 
 // updateBackendRules handles adding ingress rules to the backend subnets from the load balancer subnets.
-func (s *securityListManagerImpl) updateBackendRules(lbSubnets []*baremetal.Subnet, nodeSubnets []*baremetal.Subnet, backendPort uint64) error {
+func (s *securityListManagerImpl) updateBackendRules(lbSubnets []*baremetal.Subnet, nodeSubnets []*baremetal.Subnet, backendPort uint64, healthCheckPort uint64) error {
 	for _, subnet := range nodeSubnets {
 		secList, err := s.client.GetDefaultSecurityList(subnet)
 		if err != nil {
 			return fmt.Errorf("get security list for subnet `%s`: %v", subnet.ID, err)
 		}
 
-		ingressRules := getNodeIngressRules(secList, lbSubnets, backendPort)
+		ingressRules := getNodeIngressRules(secList.IngressSecurityRules, lbSubnets, backendPort, s.serviceLister)
+		ingressRules = getNodeIngressRules(ingressRules, lbSubnets, healthCheckPort, s.serviceLister)
 
 		if !securityListRulesChanged(secList, ingressRules, secList.EgressSecurityRules) {
 			glog.V(4).Infof("No changes for node subnet security list `%s`", secList.ID)
@@ -124,18 +128,19 @@ func (s *securityListManagerImpl) updateBackendRules(lbSubnets []*baremetal.Subn
 
 // updateLoadBalancerRules handles updating the ingress and egress rules for the load balance subnets.
 // If the listener is nil, then only egress rules from the load balancer to the backend subnets will be checked.
-func (s *securityListManagerImpl) updateLoadBalancerRules(lbSubnets []*baremetal.Subnet, nodeSubnets []*baremetal.Subnet, sourceCIDRs []string, listenerPort uint64, backendPort uint64) error {
+func (s *securityListManagerImpl) updateLoadBalancerRules(lbSubnets []*baremetal.Subnet, nodeSubnets []*baremetal.Subnet, sourceCIDRs []string, listenerPort uint64, backendPort uint64, healthCheckPort uint64) error {
 	for _, lbSubnet := range lbSubnets {
 		lbSecurityList, err := s.client.GetDefaultSecurityList(lbSubnet)
 		if err != nil {
 			return fmt.Errorf("get lb security list for subnet `%s`: %v", lbSubnet.ID, err)
 		}
 
-		lbEgressRules := getLoadBalancerEgressRules(lbSecurityList, nodeSubnets, backendPort)
+		lbEgressRules := getLoadBalancerEgressRules(lbSecurityList.EgressSecurityRules, nodeSubnets, backendPort, s.serviceLister)
+		lbEgressRules = getLoadBalancerEgressRules(lbEgressRules, nodeSubnets, healthCheckPort, s.serviceLister)
 
 		lbIngressRules := lbSecurityList.IngressSecurityRules
 		if listenerPort != 0 {
-			lbIngressRules = getLoadBalancerIngressRules(lbSecurityList, sourceCIDRs, listenerPort, s.serviceLister)
+			lbIngressRules = getLoadBalancerIngressRules(lbIngressRules, sourceCIDRs, listenerPort, s.serviceLister)
 		}
 
 		if !securityListRulesChanged(lbSecurityList, lbIngressRules, lbEgressRules) {
@@ -205,7 +210,7 @@ func (s *securityListManagerImpl) updateSecurityListRules(securityListID string,
 	return err
 }
 
-func getNodeIngressRules(securityList *baremetal.SecurityList, lbSubnets []*baremetal.Subnet, port uint64) []baremetal.IngressSecurityRule {
+func getNodeIngressRules(rules []baremetal.IngressSecurityRule, lbSubnets []*baremetal.Subnet, port uint64, serviceLister listersv1.ServiceLister) []baremetal.IngressSecurityRule {
 	desired := sets.NewString()
 	for _, lbSubnet := range lbSubnets {
 		desired.Insert(lbSubnet.CIDRBlock)
@@ -213,7 +218,7 @@ func getNodeIngressRules(securityList *baremetal.SecurityList, lbSubnets []*bare
 
 	ingressRules := []baremetal.IngressSecurityRule{}
 
-	for _, rule := range securityList.IngressSecurityRules {
+	for _, rule := range rules {
 		if rule.TCPOptions == nil || rule.TCPOptions.SourcePortRange != nil || rule.TCPOptions.DestinationPortRange == nil ||
 			(rule.TCPOptions.DestinationPortRange.Min != port &&
 				rule.TCPOptions.DestinationPortRange.Max != port) {
@@ -228,6 +233,26 @@ func getNodeIngressRules(securityList *baremetal.SecurityList, lbSubnets []*bare
 			desired.Delete(rule.Source)
 			continue
 		}
+
+		if rule.TCPOptions.DestinationPortRange.Min == port && rule.TCPOptions.DestinationPortRange.Max == port {
+			inUse, err := healthCheckPortInUse(serviceLister, int32(port))
+			if err != nil {
+				// Unable to determine if this port is in use by another service, so I guess
+				// we better err on the safe side and keep the rule.
+				glog.Errorf("failed to determine if port: %d is still in use: %v", port, err)
+				ingressRules = append(ingressRules, rule)
+				continue
+			}
+
+			if inUse {
+				// This rule is no longer needed for this service, but is still used
+				// by another service, so we must still keep it.
+				glog.V(4).Infof("Port %d still in use by another service.", port)
+				ingressRules = append(ingressRules, rule)
+				continue
+			}
+		}
+
 		// else the actual cidr no longer exists so we don't need to do
 		// anything but ignore / delete it.
 	}
@@ -246,11 +271,11 @@ func getNodeIngressRules(securityList *baremetal.SecurityList, lbSubnets []*bare
 	return ingressRules
 }
 
-func getLoadBalancerIngressRules(lbSecurityList *baremetal.SecurityList, sourceCIDRs []string, port uint64, serviceLister listersv1.ServiceLister) []baremetal.IngressSecurityRule {
+func getLoadBalancerIngressRules(rules []baremetal.IngressSecurityRule, sourceCIDRs []string, port uint64, serviceLister listersv1.ServiceLister) []baremetal.IngressSecurityRule {
 	desired := sets.NewString(sourceCIDRs...)
 
 	ingressRules := []baremetal.IngressSecurityRule{}
-	for _, rule := range lbSecurityList.IngressSecurityRules {
+	for _, rule := range rules {
 		if rule.TCPOptions == nil || rule.TCPOptions.SourcePortRange != nil || rule.TCPOptions.DestinationPortRange == nil ||
 			(rule.TCPOptions.DestinationPortRange.Min != port &&
 				rule.TCPOptions.DestinationPortRange.Max != port) {
@@ -303,14 +328,14 @@ func getLoadBalancerIngressRules(lbSecurityList *baremetal.SecurityList, sourceC
 	return ingressRules
 }
 
-func getLoadBalancerEgressRules(lbSecurityList *baremetal.SecurityList, nodeSubnets []*baremetal.Subnet, port uint64) []baremetal.EgressSecurityRule {
+func getLoadBalancerEgressRules(rules []baremetal.EgressSecurityRule, nodeSubnets []*baremetal.Subnet, port uint64, serviceLister listersv1.ServiceLister) []baremetal.EgressSecurityRule {
 	nodeCIDRs := sets.NewString()
 	for _, subnet := range nodeSubnets {
 		nodeCIDRs.Insert(subnet.CIDRBlock)
 	}
 
 	egressRules := []baremetal.EgressSecurityRule{}
-	for _, rule := range lbSecurityList.EgressSecurityRules {
+	for _, rule := range rules {
 		if rule.TCPOptions == nil || rule.TCPOptions.SourcePortRange != nil || rule.TCPOptions.DestinationPortRange == nil ||
 			(rule.TCPOptions.DestinationPortRange.Min != port &&
 				rule.TCPOptions.DestinationPortRange.Max != port) {
@@ -325,6 +350,26 @@ func getLoadBalancerEgressRules(lbSecurityList *baremetal.SecurityList, nodeSubn
 			nodeCIDRs.Delete(rule.Destination)
 			continue
 		}
+
+		if rule.TCPOptions.DestinationPortRange.Min == port && rule.TCPOptions.DestinationPortRange.Max == port {
+			inUse, err := healthCheckPortInUse(serviceLister, int32(port))
+			if err != nil {
+				// Unable to determine if this port is in use by another service, so I guess
+				// we better err on the safe side and keep the rule.
+				glog.Errorf("failed to determine if port: %d is still in use: %v", port, err)
+				egressRules = append(egressRules, rule)
+				continue
+			}
+
+			if inUse {
+				// This rule is no longer needed for this service, but is still used
+				// by another service, so we must still keep it.
+				glog.V(4).Infof("Port %d still in use by another service.", port)
+				egressRules = append(egressRules, rule)
+				continue
+			}
+		}
+
 		// else the actual cidr no longer exists so we don't need to do
 		// anything but ignore / delete it.
 	}
@@ -390,16 +435,38 @@ func portInUse(serviceLister listersv1.ServiceLister, port int32) (bool, error) 
 	return false, nil
 }
 
+func healthCheckPortInUse(serviceLister listersv1.ServiceLister, port int32) (bool, error) {
+	serviceList, err := serviceLister.List(labels.Everything())
+	if err != nil {
+		return false, err
+	}
+	for _, service := range serviceList {
+		if service.Spec.Type == api.ServiceTypeLoadBalancer {
+			healthCheckPath, healthCheckPort := apiservice.GetServiceHealthCheckPathPort(service)
+			if healthCheckPath != "" {
+				if port == healthCheckPort {
+					return true, nil
+				}
+			} else {
+				if port == lbNodesHealthCheckPort {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
 // securityListManagerNOOP implements the securityListManager interface but does
 // no logic, so that it can be used to not handle security lists if the user doesn't wish
 // to use that feature.
 type securityListManagerNOOP struct{}
 
-func (s *securityListManagerNOOP) Update(lbSubnets []*baremetal.Subnet, backendSubnets []*baremetal.Subnet, sourceCIDRs []string, listenerPort uint64, backendPort uint64) error {
+func (s *securityListManagerNOOP) Update(lbSubnets []*baremetal.Subnet, backendSubnets []*baremetal.Subnet, sourceCIDRs []string, listenerPort uint64, backendPort uint64, healthCheckPort uint64) error {
 	return nil
 }
 
-func (s *securityListManagerNOOP) Delete(lbSubnets []*baremetal.Subnet, backendSubnets []*baremetal.Subnet, listenerPort uint64, backendPort uint64) error {
+func (s *securityListManagerNOOP) Delete(lbSubnets []*baremetal.Subnet, backendSubnets []*baremetal.Subnet, listenerPort uint64, backendPort uint64, healthCheckPort uint64) error {
 	return nil
 }
 

--- a/pkg/oci/load_balancer_security_lists_test.go
+++ b/pkg/oci/load_balancer_security_lists_test.go
@@ -43,6 +43,7 @@ func TestGetNodeIngressRules(t *testing.T) {
 		securityList *baremetal.SecurityList
 		lbSubnets    []*baremetal.Subnet
 		port         uint64
+		services     []*v1.Service
 		expected     []baremetal.IngressSecurityRule
 	}{
 		{
@@ -56,7 +57,8 @@ func TestGetNodeIngressRules(t *testing.T) {
 				{CIDRBlock: "1"},
 				{CIDRBlock: "2"},
 			},
-			port: 80,
+			port:     80,
+			services: []*v1.Service{},
 			expected: []baremetal.IngressSecurityRule{
 				makeIngressSecurityRule("existing", 9000),
 				makeIngressSecurityRule("1", 80),
@@ -75,7 +77,8 @@ func TestGetNodeIngressRules(t *testing.T) {
 				{CIDRBlock: "1"},
 				{CIDRBlock: "2"},
 			},
-			port: 80,
+			port:     80,
+			services: []*v1.Service{},
 			expected: []baremetal.IngressSecurityRule{
 				makeIngressSecurityRule("existing", 9000),
 				makeIngressSecurityRule("1", 80),
@@ -95,7 +98,8 @@ func TestGetNodeIngressRules(t *testing.T) {
 				{CIDRBlock: "1"},
 				{CIDRBlock: "3"},
 			},
-			port: 80,
+			port:     80,
+			services: []*v1.Service{},
 			expected: []baremetal.IngressSecurityRule{
 				makeIngressSecurityRule("existing", 9000),
 				makeIngressSecurityRule("1", 80),
@@ -114,16 +118,68 @@ func TestGetNodeIngressRules(t *testing.T) {
 			},
 			lbSubnets: []*baremetal.Subnet{},
 			port:      80,
+			services:  []*v1.Service{},
 			expected: []baremetal.IngressSecurityRule{
 				makeIngressSecurityRule("existing", 9000),
 				makeIngressSecurityRule("existing", 9001),
+			},
+		}, {
+			name: "do not delete a port rule which is used by another services (default) health check",
+			securityList: &baremetal.SecurityList{
+				IngressSecurityRules: []baremetal.IngressSecurityRule{
+					makeIngressSecurityRule("0.0.0.0/0", lbNodesHealthCheckPort),
+				},
+			},
+			lbSubnets: []*baremetal.Subnet{},
+			port:      lbNodesHealthCheckPort,
+			services: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-default-health-check-port"},
+					Spec: v1.ServiceSpec{
+						Type:  v1.ServiceTypeLoadBalancer,
+						Ports: []v1.ServicePort{{Port: 80}},
+					},
+				},
+			},
+			expected: []baremetal.IngressSecurityRule{
+				makeIngressSecurityRule("0.0.0.0/0", lbNodesHealthCheckPort),
+			},
+		}, {
+			name: "do not delete a port rule which is used by another services (custom) health check",
+			securityList: &baremetal.SecurityList{
+				IngressSecurityRules: []baremetal.IngressSecurityRule{
+					makeIngressSecurityRule("0.0.0.0/0", 12345),
+				},
+			},
+			lbSubnets: []*baremetal.Subnet{},
+			port:      12345,
+			services: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-custom-health-check-port"},
+					Spec: v1.ServiceSpec{
+						Type:  v1.ServiceTypeLoadBalancer,
+						Ports: []v1.ServicePort{{Port: 80}},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						HealthCheckNodePort:   12345,
+					},
+				},
+			},
+			expected: []baremetal.IngressSecurityRule{
+				makeIngressSecurityRule("0.0.0.0/0", 12345),
 			},
 		},
 	}
 
 	for _, tc := range testCases {
+		serviceCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		serviceLister := v1listers.NewServiceLister(serviceCache)
+		for i := range tc.services {
+			if err := serviceCache.Add(tc.services[i]); err != nil {
+				t.Fatalf("%s unexpected service add error: %v", tc.name, err)
+			}
+		}
 		t.Run(tc.name, func(t *testing.T) {
-			rules := getNodeIngressRules(tc.securityList, tc.lbSubnets, tc.port)
+			rules := getNodeIngressRules(tc.securityList.IngressSecurityRules, tc.lbSubnets, tc.port, serviceLister)
 			if !reflect.DeepEqual(rules, tc.expected) {
 				t.Errorf("expected rules\n%+v\nbut got\n%+v", tc.expected, rules)
 			}
@@ -250,7 +306,7 @@ func TestGetLoadBalancerIngressRules(t *testing.T) {
 			}
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			rules := getLoadBalancerIngressRules(tc.securityList, tc.sourceCIDRs, tc.port, serviceLister)
+			rules := getLoadBalancerIngressRules(tc.securityList.IngressSecurityRules, tc.sourceCIDRs, tc.port, serviceLister)
 			if !reflect.DeepEqual(rules, tc.expected) {
 				t.Errorf("expected rules\n%+v\nbut got\n%+v", tc.expected, rules)
 			}
@@ -264,6 +320,7 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 		securityList *baremetal.SecurityList
 		subnets      []*baremetal.Subnet
 		port         uint64
+		services     []*v1.Service
 		expected     []baremetal.EgressSecurityRule
 	}{
 		{
@@ -277,7 +334,8 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 				{CIDRBlock: "1"},
 				{CIDRBlock: "2"},
 			},
-			port: 80,
+			port:     80,
+			services: []*v1.Service{},
 			expected: []baremetal.EgressSecurityRule{
 				makeEgressSecurityRule("existing", 9000),
 				makeEgressSecurityRule("1", 80),
@@ -296,7 +354,8 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 				{CIDRBlock: "1"},
 				{CIDRBlock: "2"},
 			},
-			port: 80,
+			port:     80,
+			services: []*v1.Service{},
 			expected: []baremetal.EgressSecurityRule{
 				makeEgressSecurityRule("existing", 9000),
 				makeEgressSecurityRule("1", 80),
@@ -316,7 +375,8 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 				{CIDRBlock: "1"},
 				{CIDRBlock: "3"},
 			},
-			port: 80,
+			port:     80,
+			services: []*v1.Service{},
 			expected: []baremetal.EgressSecurityRule{
 				makeEgressSecurityRule("existing", 9000),
 				makeEgressSecurityRule("1", 80),
@@ -333,18 +393,70 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 					makeEgressSecurityRule("existing", 9001),
 				},
 			},
-			subnets: []*baremetal.Subnet{},
-			port:    80,
+			subnets:  []*baremetal.Subnet{},
+			port:     80,
+			services: []*v1.Service{},
 			expected: []baremetal.EgressSecurityRule{
 				makeEgressSecurityRule("existing", 9000),
 				makeEgressSecurityRule("existing", 9001),
+			},
+		}, {
+			name: "do not delete a port rule which is used by another services (default) health check",
+			securityList: &baremetal.SecurityList{
+				EgressSecurityRules: []baremetal.EgressSecurityRule{
+					makeEgressSecurityRule("0.0.0.0/0", lbNodesHealthCheckPort),
+				},
+			},
+			subnets: []*baremetal.Subnet{},
+			port:    lbNodesHealthCheckPort,
+			services: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-default-health-check-port"},
+					Spec: v1.ServiceSpec{
+						Type:  v1.ServiceTypeLoadBalancer,
+						Ports: []v1.ServicePort{{Port: 80}},
+					},
+				},
+			},
+			expected: []baremetal.EgressSecurityRule{
+				makeEgressSecurityRule("0.0.0.0/0", lbNodesHealthCheckPort),
+			},
+		}, {
+			name: "do not delete a port rule which is used by another services (custom) health check",
+			securityList: &baremetal.SecurityList{
+				EgressSecurityRules: []baremetal.EgressSecurityRule{
+					makeEgressSecurityRule("0.0.0.0/0", 12345),
+				},
+			},
+			subnets: []*baremetal.Subnet{},
+			port:    12345,
+			services: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-custom-health-check-port"},
+					Spec: v1.ServiceSpec{
+						Type:  v1.ServiceTypeLoadBalancer,
+						Ports: []v1.ServicePort{{Port: 80}},
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+						HealthCheckNodePort:   12345,
+					},
+				},
+			},
+			expected: []baremetal.EgressSecurityRule{
+				makeEgressSecurityRule("0.0.0.0/0", 12345),
 			},
 		},
 	}
 
 	for _, tc := range testCases {
+		serviceCache := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		serviceLister := v1listers.NewServiceLister(serviceCache)
+		for i := range tc.services {
+			if err := serviceCache.Add(tc.services[i]); err != nil {
+				t.Fatalf("%s unexpected service add error: %v", tc.name, err)
+			}
+		}
 		t.Run(tc.name, func(t *testing.T) {
-			rules := getLoadBalancerEgressRules(tc.securityList, tc.subnets, tc.port)
+			rules := getLoadBalancerEgressRules(tc.securityList.EgressSecurityRules, tc.subnets, tc.port, serviceLister)
 			if !reflect.DeepEqual(rules, tc.expected) {
 				t.Errorf("expected rules\n%+v\nbut got\n%+v", tc.expected, rules)
 			}

--- a/pkg/oci/load_balancer_security_lists_test.go
+++ b/pkg/oci/load_balancer_security_lists_test.go
@@ -144,29 +144,6 @@ func TestGetNodeIngressRules(t *testing.T) {
 			expected: []baremetal.IngressSecurityRule{
 				makeIngressSecurityRule("0.0.0.0/0", lbNodesHealthCheckPort),
 			},
-		}, {
-			name: "do not delete a port rule which is used by another services (custom) health check",
-			securityList: &baremetal.SecurityList{
-				IngressSecurityRules: []baremetal.IngressSecurityRule{
-					makeIngressSecurityRule("0.0.0.0/0", 12345),
-				},
-			},
-			lbSubnets: []*baremetal.Subnet{},
-			port:      12345,
-			services: []*v1.Service{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-custom-health-check-port"},
-					Spec: v1.ServiceSpec{
-						Type:  v1.ServiceTypeLoadBalancer,
-						Ports: []v1.ServicePort{{Port: 80}},
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
-						HealthCheckNodePort:   12345,
-					},
-				},
-			},
-			expected: []baremetal.IngressSecurityRule{
-				makeIngressSecurityRule("0.0.0.0/0", 12345),
-			},
 		},
 	}
 
@@ -420,29 +397,6 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 			},
 			expected: []baremetal.EgressSecurityRule{
 				makeEgressSecurityRule("0.0.0.0/0", lbNodesHealthCheckPort),
-			},
-		}, {
-			name: "do not delete a port rule which is used by another services (custom) health check",
-			securityList: &baremetal.SecurityList{
-				EgressSecurityRules: []baremetal.EgressSecurityRule{
-					makeEgressSecurityRule("0.0.0.0/0", 12345),
-				},
-			},
-			subnets: []*baremetal.Subnet{},
-			port:    12345,
-			services: []*v1.Service{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-custom-health-check-port"},
-					Spec: v1.ServiceSpec{
-						Type:  v1.ServiceTypeLoadBalancer,
-						Ports: []v1.ServicePort{{Port: 80}},
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
-						HealthCheckNodePort:   12345,
-					},
-				},
-			},
-			expected: []baremetal.EgressSecurityRule{
-				makeEgressSecurityRule("0.0.0.0/0", 12345),
 			},
 		},
 	}


### PR DESCRIPTION
This commit adds the following security list rules for a services healthcheck port:

1. Egress from the load balancers sec-lists on the required default/custom port.
2. Ingress to the workers sec-lists on the required default/custom port.