### PR TITLE
Add oci proxy support

### DIFF
--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -152,10 +152,10 @@ func New(cfg *Config) (Interface, error) {
 	}
 
 	// Handles the case where we want to talk to OCI via a proxy.
-	servicePrincipalProxy := os.Getenv("OCI_PROXY")
+	ociProxy := os.Getenv("OCI_PROXY")
 	trustedCACertPath := os.Getenv("TRUSTED_CA_CERT_PATH")
-	if servicePrincipalProxy != "" && trustedCACertPath != "" {
-		glog.Infof("using oci proxy server: %s", servicePrincipalProxy)
+	if ociProxy != "" && trustedCACertPath != "" {
+		glog.Infof("using oci proxy server: %s", ociProxy)
 		glog.Infof("configuring oci client with a new trusted ca: %s", trustedCACertPath)
 		trustedCACert, err := ioutil.ReadFile(trustedCACertPath)
 		if err != nil {
@@ -166,9 +166,9 @@ func New(cfg *Config) (Interface, error) {
 		if !ok {
 			return nil, fmt.Errorf("failed to parse root certificate")
 		}
-		proxyURL, err := url.Parse(servicePrincipalProxy)
+		proxyURL, err := url.Parse(ociProxy)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse proxy url")
+			return nil, fmt.Errorf("failed to parse oci proxy url")
 		}
 		transport := http.Transport{
 			TLSClientConfig: &tls.Config{RootCAs: caCertPool},

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -168,10 +168,10 @@ func New(cfg *Config) (Interface, error) {
 		}
 
 		if ociProxy != "" {
-			glog.Infof("using oci proxy server: %s", ociProxy)
+			glog.Infof("using OCI proxy server: %s", ociProxy)
 			proxyURL, err := url.Parse(ociProxy)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse oci proxy url: %s, err: %v", ociProxy, err)
+				return nil, fmt.Errorf("failed to parse OCI proxy url: %s, err: %v", ociProxy, err)
 			}
 			transport.Proxy = func(req *http.Request) (*url.URL, error) {
 				return proxyURL, nil
@@ -179,7 +179,7 @@ func New(cfg *Config) (Interface, error) {
 		}
 
 		if trustedCACertPath != "" {
-			glog.Infof("configuring oci client with a new trusted ca: %s", trustedCACertPath)
+			glog.Infof("configuring OCI client with a new trusted ca: %s", trustedCACertPath)
 			trustedCACert, err := ioutil.ReadFile(trustedCACertPath)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read root certificate: %s, err: %v", trustedCACertPath, err)


### PR DESCRIPTION
If both the OCI_PROXY and TRUSTED_CA_CERT_PATH environment variables are set, then the CCM will now set the proxy and install the trusted cert on the OCI client.