### PR TITLE
Add basic E2E tests of Zones and Instances interfaces

### DIFF
--- a/manifests/cloud-provider-example.yaml
+++ b/manifests/cloud-provider-example.yaml
@@ -11,6 +11,9 @@ auth:
   key_passphrase: supersecretpassword
   fingerprint: 8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74
 
+# vcn configures the Virtual Cloud Network (VCN) within which the cluster resides.
+vcn: ocid1.vcn.oc1..aaaaaaaask7mpk4mij3pnm6yvnntte25ffadxiivpokxevfxgtsu6ftkqhrq
+
 loadBalancer:
   # disableSecurityListManagement disables the automatic creation of ingress
   # rules for the node subnets and egress rules for the load balancers to the

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -167,7 +167,7 @@ func New(cfg *Config) (Interface, error) {
 
 	vcnID := cfg.VCNID
 	if vcnID == "" {
-		glog.Infof("No vcnID provided in cloud provider config. Falling back to looking up VCN via LB subnet.")
+		glog.Infof("No vcn provided in cloud provider config. Falling back to looking up VCN via LB subnet.")
 		subnet, err := ociClient.GetSubnet(cfg.LoadBalancer.Subnet1)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get load balancer subnet 1: %v", err)

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -196,7 +196,7 @@ func (c *client) Validate() error {
 // GetInstanceByNodeName gets the OCID of instance with a display name equal to
 // the given node name.
 func (c *client) GetInstanceByNodeName(nodeName string) (*baremetal.Instance, error) {
-	glog.V(4).Infof("getInstanceByNodeName(%q) called", nodeName)
+	glog.V(4).Infof("GetInstanceByNodeName(%q) called", nodeName)
 	if nodeName == "" {
 		return nil, fmt.Errorf("blank nodeName passed to getInstanceByNodeName()")
 	}

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -54,6 +54,10 @@ type LoadBalancerConfig struct {
 type Config struct {
 	Auth         AuthConfig         `yaml:"auth"`
 	LoadBalancer LoadBalancerConfig `yaml:"loadBalancer"`
+
+	// VCNID is the OCID of the Virtual Cloud Network (VCN) within which the
+	// cluster resides.
+	VCNID string `yaml:"vcn"`
 }
 
 // Validate validates the OCI cloud-provider config.

--- a/pkg/oci/client/config.go
+++ b/pkg/oci/client/config.go
@@ -31,7 +31,7 @@ type AuthConfig struct {
 	UserOCID             string `yaml:"user"`
 	PrivateKey           string `yaml:"key"`
 	Fingerprint          string `yaml:"fingerprint"`
-	PrivateKeyPassphrase string `yaml:"key_passphrase"`
+	PrivateKeyPassphrase string `yaml:"key_passphrase"` // TODO(apryde): the yaml should be keyPassphrase
 }
 
 // LoadBalancerConfig holds the configuration options for OCI load balancers.

--- a/pkg/oci/client/config_validate.go
+++ b/pkg/oci/client/config_validate.go
@@ -19,7 +19,7 @@ import (
 )
 
 // validateAuthConfig provides basic validation of AuthConfig instances.
-func validateAuthConfig(c AuthConfig, fldPath *field.Path) field.ErrorList {
+func validateAuthConfig(c *AuthConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if c.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), ""))
@@ -41,7 +41,7 @@ func validateAuthConfig(c AuthConfig, fldPath *field.Path) field.ErrorList {
 
 // validateLoadBalancerConfig provides basic validation of LoadBalancerConfig
 // instances.
-func validateLoadBalancerConfig(c LoadBalancerConfig, fldPath *field.Path) field.ErrorList {
+func validateLoadBalancerConfig(c *LoadBalancerConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if c.Subnet1 == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("subnet1"), ""))
@@ -55,7 +55,7 @@ func validateLoadBalancerConfig(c LoadBalancerConfig, fldPath *field.Path) field
 // ValidateConfig validates the OCI Cloud Provider config file.
 func ValidateConfig(c *Config) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateAuthConfig(c.Auth, field.NewPath("auth"))...)
-	allErrs = append(allErrs, validateLoadBalancerConfig(c.LoadBalancer, field.NewPath("loadBalancer"))...)
+	allErrs = append(allErrs, validateAuthConfig(&c.Auth, field.NewPath("auth"))...)
+	allErrs = append(allErrs, validateLoadBalancerConfig(&c.LoadBalancer, field.NewPath("loadBalancer"))...)
 	return allErrs
 }

--- a/pkg/oci/client/config_validate.go
+++ b/pkg/oci/client/config_validate.go
@@ -21,6 +21,9 @@ import (
 // validateAuthConfig provides basic validation of AuthConfig instances.
 func validateAuthConfig(c *AuthConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if c == nil {
+		return append(allErrs, field.Required(fldPath, ""))
+	}
 	if c.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), ""))
 	}
@@ -43,6 +46,9 @@ func validateAuthConfig(c *AuthConfig, fldPath *field.Path) field.ErrorList {
 // instances.
 func validateLoadBalancerConfig(c *LoadBalancerConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if c == nil {
+		return append(allErrs, field.Required(fldPath, ""))
+	}
 	if c.Subnet1 == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("subnet1"), ""))
 	}

--- a/pkg/oci/zones.go
+++ b/pkg/oci/zones.go
@@ -38,7 +38,7 @@ func mapAvailabilityDomainToFailureDomain(AD string) string {
 
 // GetZone returns the Zone containing the current failure zone and locality
 // region that the program is running in.
-func (cp *CloudProvider) GetZone() (zone cloudprovider.Zone, err error) {
+func (cp *CloudProvider) GetZone() (cloudprovider.Zone, error) {
 	return cloudprovider.Zone{}, errors.New("unimplemented")
 }
 

--- a/pkg/oci/zones_test.go
+++ b/pkg/oci/zones_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMapAvailabilityDomainToFailureDomain(t *testing.T) {
-	var testCases = [string]string{
+	var testCases = map[string]string{
 		"NWuj:PHX-AD-1": "PHX-AD-1",
 		"NWuj:PHX-AD-2": "PHX-AD-2",
 		"NWuj:PHX-AD-3": "PHX-AD-3",

--- a/pkg/oci/zones_test.go
+++ b/pkg/oci/zones_test.go
@@ -18,22 +18,20 @@ import (
 	"testing"
 )
 
-var mapAvailabilityDomainToFailureDomainTestCases = []struct {
-	ad string
-	fd string
-}{
-	{ad: "NWuj:PHX-AD-1", fd: "PHX-AD-1"},
-	{ad: "NWuj:PHX-AD-2", fd: "PHX-AD-2"},
-	{ad: "NWuj:PHX-AD-3", fd: "PHX-AD-3"},
-	{ad: "", fd: ""},
-	{ad: "PHX-AD-3", fd: "PHX-AD-3"},
-}
-
 func TestMapAvailabilityDomainToFailureDomain(t *testing.T) {
-	for _, tt := range mapAvailabilityDomainToFailureDomainTestCases {
-		v := mapAvailabilityDomainToFailureDomain(tt.ad)
-		if v != tt.fd {
-			t.Errorf("mapAvailabilityDomainToFailureDomain(%q) => %q, want %q", tt.ad, v, tt.fd)
-		}
+	var testCases = [string]string{
+		"NWuj:PHX-AD-1": "PHX-AD-1",
+		"NWuj:PHX-AD-2": "PHX-AD-2",
+		"NWuj:PHX-AD-3": "PHX-AD-3",
+		"":              "",
+		"PHX-AD-3":      "PHX-AD-3",
+	}
+	for ad, fd := range testCases {
+		t.Run(ad, func(t *testing.T) {
+			v := mapAvailabilityDomainToFailureDomain(ad)
+			if v != fd {
+				t.Errorf("mapAvailabilityDomainToFailureDomain(%q) => %q, want %q", ad, v, fd)
+			}
+		})
 	}
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -58,8 +58,8 @@ func init() {
 type Framework struct {
 	BaseName string
 
-	SkipInitCloudProvider bool                    // Whether to skip initialising a cloud provider
-	CloudProvider         cloudprovider.Interface // Every test has a cloud provider unless initialisation is skipped
+	InitCloudProvider bool                    // Whether to initialise a cloud provider interface for testing
+	CloudProvider     cloudprovider.Interface // Every test has a cloud provider unless initialisation is skipped
 
 	ClientSet         clientset.Interface
 	InternalClientset internalclientset.Interface
@@ -77,7 +77,6 @@ type Framework struct {
 // NewDefaultFramework constructs a new e2e test Framework with default options.
 func NewDefaultFramework(baseName string) *Framework {
 	f := NewFramework(baseName, nil)
-	f.SkipInitCloudProvider = true
 	return f
 }
 
@@ -187,7 +186,7 @@ func (f *Framework) BeforeEach() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	if !f.SkipInitCloudProvider {
+	if f.InitCloudProvider {
 		cloud, err := cloudprovider.InitCloudProvider(oci.ProviderName(), cloudConfigFile)
 		Expect(err).NotTo(HaveOccurred())
 		f.CloudProvider = cloud
@@ -216,11 +215,6 @@ func (f *Framework) AfterEach() {
 			}
 		}
 	}
-
-	// Paranoia -- prevent reuse!
-	f.Namespace = nil
-	f.ClientSet = nil
-	f.namespacesToDelete = nil
 
 	// if we had errors deleting, report them now.
 	if len(nsDeletionErrors) != 0 {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -32,6 +32,9 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+
+	oci "github.com/oracle/oci-cloud-controller-manager/pkg/oci" // register oci cloud provider
 )
 
 const (
@@ -39,27 +42,31 @@ const (
 	Poll = 2 * time.Second
 )
 
-// path to kubeconfig on disk.
 var (
-	kubeconfig      string
-	deleteNamespace bool
+	kubeconfig      string // path to kubeconfig file
+	deleteNamespace bool   // whether or not to delete test namespaces
+	cloudConfigFile string // path to cloud provider config file
 )
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to Kubeconfig file with authorization and master location information.")
 	flag.BoolVar(&deleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")
+	flag.StringVar(&cloudConfigFile, "cloud-config", "", "The path to the cloud provider configuration file. Empty string for no configuration file.")
 }
 
 // Framework is used in the execution of e2e tests.
 type Framework struct {
 	BaseName string
 
+	SkipInitCloudProvider bool                    // Whether to skip initialising a cloud provider
+	CloudProvider         cloudprovider.Interface // Every test has a cloud provider unless initialisation is skipped
+
 	ClientSet         clientset.Interface
 	InternalClientset internalclientset.Interface
 
-	// Namespace in which test resources are created.
-	Namespace          *v1.Namespace
-	namespacesToDelete []*v1.Namespace // Some tests have more than one.
+	SkipNamespaceCreation bool            // Whether to skip creating a namespace
+	Namespace             *v1.Namespace   // Every test has at least one namespace unless creation is skipped
+	namespacesToDelete    []*v1.Namespace // Some tests have more than one.
 
 	// To make sure that this framework cleans up after itself, no matter what,
 	// we install a Cleanup action before each test and clear it after.  If we
@@ -69,7 +76,17 @@ type Framework struct {
 
 // NewDefaultFramework constructs a new e2e test Framework with default options.
 func NewDefaultFramework(baseName string) *Framework {
-	return NewFramework(baseName, nil)
+	f := NewFramework(baseName, nil)
+	f.SkipInitCloudProvider = true
+	return f
+}
+
+// NewFrameworkWithCloudProvider constructs a new e2e test Framework for testing
+// cloudprovider.Interface directly.
+func NewFrameworkWithCloudProvider(baseName string) *Framework {
+	f := NewFramework(baseName, nil)
+	f.SkipNamespaceCreation = true
+	return f
 }
 
 // NewFramework constructs a new e2e test Framework.
@@ -159,6 +176,7 @@ func (f *Framework) BeforeEach() {
 	// The fact that we need this feels like a bug in ginkgo.
 	// https://github.com/onsi/ginkgo/issues/222
 	f.cleanupHandle = AddCleanupAction(f.AfterEach)
+
 	if f.ClientSet == nil {
 		By("Creating a kubernetes client")
 		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
@@ -169,23 +187,27 @@ func (f *Framework) BeforeEach() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	By("Building a namespace api object")
-	namespace, err := f.CreateNamespace(f.BaseName, map[string]string{
-		"e2e-framework": f.BaseName,
-	})
-	Expect(err).NotTo(HaveOccurred())
+	if !f.SkipInitCloudProvider {
+		cloud, err := cloudprovider.InitCloudProvider(oci.ProviderName(), cloudConfigFile)
+		Expect(err).NotTo(HaveOccurred())
+		f.CloudProvider = cloud
+	}
 
-	f.Namespace = namespace
+	if !f.SkipNamespaceCreation {
+		By("Building a namespace api object")
+		namespace, err := f.CreateNamespace(f.BaseName, map[string]string{
+			"e2e-framework": f.BaseName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		f.Namespace = namespace
+	}
 }
 
 // AfterEach deletes the namespace(s).
 func (f *Framework) AfterEach() {
 	RemoveCleanupAction(f.cleanupHandle)
 
-	// DeleteNamespace at the very end in defer, to avoid any expectation
-	// failures preventing deleting the namespace.
 	nsDeletionErrors := map[string]error{}
-
 	if deleteNamespace {
 		for _, ns := range f.namespacesToDelete {
 			By(fmt.Sprintf("Destroying namespace %q for this suite.", ns.Name))

--- a/test/e2e/instances.go
+++ b/test/e2e/instances.go
@@ -38,7 +38,7 @@ func assertNodeAddressesContainValidIPs(addrs []v1.NodeAddress) {
 }
 
 var _ = Describe("Instances", func() {
-	f := framework.NewFrameworkWithCloudProvider("zones")
+	f := framework.NewFrameworkWithCloudProvider("instances")
 
 	var (
 		cs        clientset.Interface

--- a/test/e2e/instances.go
+++ b/test/e2e/instances.go
@@ -1,0 +1,132 @@
+// Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+
+	"github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
+)
+
+func assertNodeAddressesContainValidIPs(addrs []v1.NodeAddress) {
+	for _, addr := range addrs {
+		if addr.Type == v1.NodeExternalIP || addr.Type == v1.NodeInternalIP {
+			ip := net.ParseIP(addr.Address)
+			ExpectWithOffset(1, ip).NotTo(BeNil())
+		}
+	}
+}
+
+var _ = Describe("Instances", func() {
+	f := framework.NewFrameworkWithCloudProvider("zones")
+
+	var (
+		cs        clientset.Interface
+		instances cloudprovider.Instances
+		node      v1.Node
+	)
+	BeforeEach(func() {
+		var enabled bool
+		instances, enabled = f.CloudProvider.Instances()
+		Expect(enabled).To(BeTrue())
+
+		cs = f.ClientSet
+		nodes := framework.GetReadySchedulableNodesOrDie(cs)
+		Expect(len(nodes.Items)).NotTo(BeZero())
+		node = nodes.Items[0]
+	})
+
+	It("should be possible to get node addresses", func() {
+		nodeName := apitypes.NodeName(node.Name)
+		Expect(nodeName).NotTo(BeEmpty())
+
+		By("calling NodeAddresses()")
+		addresses, err := instances.NodeAddresses(nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(addresses)).NotTo(BeZero())
+		framework.Logf("%q: addresses=%v", nodeName, addresses)
+		assertNodeAddressesContainValidIPs(addresses)
+
+		providerID := node.Spec.ProviderID
+		Expect(providerID).NotTo(BeEmpty())
+
+		By("calling NodeAddressesByProviderID()")
+		addresses2, err := instances.NodeAddressesByProviderID(providerID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(addresses2)).NotTo(BeZero())
+		framework.Logf("%q (%s): addresses=%v", node.Name, providerID, addresses2)
+		assertNodeAddressesContainValidIPs(addresses2)
+
+		Expect(addresses).To(ConsistOf(addresses2))
+	})
+
+	It("should be possible to get the provider ID of an instance", func() {
+		nodeName := apitypes.NodeName(node.Name)
+		Expect(nodeName).NotTo(BeEmpty())
+
+		By("calling ExternalID()")
+		providerID, err := instances.ExternalID(nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(providerID).NotTo(BeEmpty())
+		framework.Logf("%q: providerID=%q", nodeName, providerID)
+
+		By("calling InstanceID()")
+		providerID2, err := instances.InstanceID(nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(providerID2).NotTo(BeEmpty())
+		framework.Logf("%q: providerID=%q", nodeName, providerID2)
+
+		Expect(providerID).To(Equal(providerID2))
+	})
+
+	It("should be possible to get the type of an instance", func() {
+		nodeName := apitypes.NodeName(node.Name)
+		Expect(nodeName).NotTo(BeEmpty())
+
+		By("calling InstanceType()")
+		instanceType, err := instances.InstanceType(nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instanceType).NotTo(BeEmpty())
+		framework.Logf("%q: instanceType=%q", nodeName, instanceType)
+
+		providerID := node.Spec.ProviderID
+		Expect(providerID).NotTo(BeEmpty())
+
+		By("calling InstanceTypeByProviderID()")
+		instanceType2, err := instances.InstanceTypeByProviderID(providerID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instanceType2).NotTo(BeEmpty())
+		framework.Logf("%q (%s): instanceType=%q", node.Name, providerID, instanceType2)
+
+		Expect(instanceType).To(Equal(instanceType2))
+	})
+
+	It("should be possible to check an instance exists", func() {
+		providerID := node.Spec.ProviderID
+		Expect(providerID).NotTo(BeEmpty())
+		By("calling InstanceExistsByProviderID()")
+		exists, err := instances.InstanceExistsByProviderID(providerID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+	})
+})

--- a/test/e2e/load_balancer.go
+++ b/test/e2e/load_balancer.go
@@ -163,12 +163,11 @@ var _ = Describe("Service [Slow]", func() {
 // routing (i.e. avoidance of a second hop).
 var _ = Describe("ESIPP [Slow]", func() {
 	f := framework.NewDefaultFramework("esipp")
-	loadBalancerCreateTimeout := framework.LoadBalancerCreateTimeoutDefault
 
+	loadBalancerCreateTimeout := framework.LoadBalancerCreateTimeoutDefault
 	serviceLBNames := []string{}
 
 	var cs clientset.Interface
-
 	BeforeEach(func() {
 		cs = f.ClientSet
 	})

--- a/test/e2e/zones.go
+++ b/test/e2e/zones.go
@@ -53,7 +53,9 @@ var _ = Describe("Zones", func() {
 		zone, err := zones.GetZoneByProviderID(providerID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(zone.Region).NotTo(BeEmpty())
+		framework.Logf("%q: Region=%q", providerID, zone.Region)
 		Expect(zone.FailureDomain).NotTo(BeEmpty())
+		framework.Logf("%q: FailureDomain=%q", providerID, zone.FailureDomain)
 	})
 
 	It("should be possible to get a non-empty zone by node name", func() {
@@ -64,6 +66,8 @@ var _ = Describe("Zones", func() {
 		zone, err := zones.GetZoneByNodeName(nodeName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(zone.Region).NotTo(BeEmpty())
+		framework.Logf("%q: Region=%q", nodeName, zone.Region)
 		Expect(zone.FailureDomain).NotTo(BeEmpty())
+		framework.Logf("%q: FailureDomain=%q", nodeName, zone.FailureDomain)
 	})
 })

--- a/test/e2e/zones.go
+++ b/test/e2e/zones.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+
+	"github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
+)
+
+var _ = Describe("Zones", func() {
+	f := framework.NewFrameworkWithCloudProvider("zones")
+
+	var (
+		cs    clientset.Interface
+		zones cloudprovider.Zones
+		node  v1.Node
+	)
+	BeforeEach(func() {
+		var enabled bool
+		zones, enabled = f.CloudProvider.Zones()
+		Expect(enabled).To(BeTrue())
+
+		cs = f.ClientSet
+		nodes := framework.GetReadySchedulableNodesOrDie(cs)
+		Expect(len(nodes.Items)).NotTo(BeZero())
+		node = nodes.Items[0]
+	})
+
+	It("should be possible to get a non-empty zone by provider ID", func() {
+		providerID := node.Spec.ProviderID
+		Expect(providerID).NotTo(BeEmpty())
+
+		By("calling GetZoneByProviderID()")
+		zone, err := zones.GetZoneByProviderID(providerID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(zone.Region).NotTo(BeEmpty())
+		Expect(zone.FailureDomain).NotTo(BeEmpty())
+	})
+
+	It("should be possible to get a non-empty zone by node name", func() {
+		nodeName := apitypes.NodeName(node.Name)
+		Expect(nodeName).NotTo(BeEmpty())
+
+		By("calling GetZoneByNodeName()")
+		zone, err := zones.GetZoneByNodeName(nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(zone.Region).NotTo(BeEmpty())
+		Expect(zone.FailureDomain).NotTo(BeEmpty())
+	})
+})


### PR DESCRIPTION
This PR adds basic "happy path" coverage of the `cloudprovider.Zones` and `cloudprovider.Instances` interfaces. 

The tests aren't really "end-to-end" as they test via the interfaces, however, I felt keeping them in the same suite was the easiest route. Happy to split out if that would be preferable.

I have tried to maintain some level of provider agnosticism as I'm not clear on the cloud provider working group's testing strategy.

I have also tried to avoid any coupling to the old OCI SDK as once we have sufficient testing in place we will be migrating to the new SDK.

```
❯ ginkgo -v -progress test/e2e  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
Running Suite: CCM E2E suite
============================
Random Seed: 1520001611
Will run 9 of 9 specs

<snip>

Ran 9 of 9 Specs in 1195.239 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Ginkgo ran 1 suite in 20m4.788510961s
Test Suite Passed
```