### PR TITLE
Move Config out of client pkg

### DIFF
--- a/pkg/oci/client/load_balancer.go
+++ b/pkg/oci/client/load_balancer.go
@@ -30,7 +30,7 @@ const workRequestPollInterval = 5 * time.Second
 type LoadBalancerInterface interface {
 	CreateLoadBalancer(ctx context.Context, details loadbalancer.CreateLoadBalancerDetails) (string, error)
 	GetLoadBalancer(ctx context.Context, id string) (*loadbalancer.LoadBalancer, error)
-	GetLoadBalancerByName(ctx context.Context, name string) (*loadbalancer.LoadBalancer, error)
+	GetLoadBalancerByName(ctx context.Context, compartmentID, name string) (*loadbalancer.LoadBalancer, error)
 	DeleteLoadBalancer(ctx context.Context, id string) (string, error)
 
 	GetCertificateByName(ctx context.Context, lbID, name string) (*loadbalancer.Certificate, error)
@@ -60,11 +60,11 @@ func (c *client) GetLoadBalancer(ctx context.Context, id string) (*loadbalancer.
 	return &resp.LoadBalancer, nil
 }
 
-func (c *client) GetLoadBalancerByName(ctx context.Context, name string) (*loadbalancer.LoadBalancer, error) {
+func (c *client) GetLoadBalancerByName(ctx context.Context, compartmentID, name string) (*loadbalancer.LoadBalancer, error) {
 	var page *string
 	for {
 		resp, err := c.loadbalancer.ListLoadBalancers(ctx, loadbalancer.ListLoadBalancersRequest{
-			CompartmentId: &c.config.Auth.CompartmentOCID,
+			CompartmentId: &compartmentID,
 			DisplayName:   &name,
 			Page:          page,
 		})

--- a/pkg/oci/config.go
+++ b/pkg/oci/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package oci
 
 import (
 	"errors"

--- a/pkg/oci/config_test.go
+++ b/pkg/oci/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package oci
 
 import (
 	"strings"

--- a/pkg/oci/config_validate.go
+++ b/pkg/oci/config_validate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package oci
 
 import (
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/pkg/oci/config_validate_test.go
+++ b/pkg/oci/config_validate_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package oci
 
 import (
 	"reflect"

--- a/pkg/oci/instances.go
+++ b/pkg/oci/instances.go
@@ -78,12 +78,12 @@ func extractNodeAddressesFromVNIC(vnic *core.Vnic) ([]api.NodeAddress, error) {
 func (cp *CloudProvider) NodeAddresses(ctx context.Context, name types.NodeName) ([]api.NodeAddress, error) {
 	glog.V(4).Infof("NodeAddresses(%q) called", name)
 
-	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, mapNodeNameToInstanceName(name))
+	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, mapNodeNameToInstanceName(name))
 	if err != nil {
 		return nil, errors.Wrap(err, "GetInstanceByNodeName")
 	}
 
-	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, *inst.Id)
+	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, cp.config.Auth.CompartmentOCID, *inst.Id)
 	if err != nil {
 		return nil, errors.Wrap(err, "GetPrimaryVNICForInstance")
 	}
@@ -98,7 +98,7 @@ func (cp *CloudProvider) NodeAddresses(ctx context.Context, name types.NodeName)
 func (cp *CloudProvider) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]api.NodeAddress, error) {
 	glog.V(4).Infof("NodeAddressesByProviderID(%q) called", providerID)
 	instanceID := util.MapProviderIDToInstanceID(providerID)
-	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, instanceID)
+	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, cp.config.Auth.CompartmentOCID, instanceID)
 	if err != nil {
 		return nil, errors.Wrap(err, "GetPrimaryVNICForInstance")
 	}
@@ -112,7 +112,7 @@ func (cp *CloudProvider) ExternalID(ctx context.Context, nodeName types.NodeName
 	glog.V(4).Infof("ExternalID(%q) called", nodeName)
 
 	instName := mapNodeNameToInstanceName(nodeName)
-	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, instName)
+	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, instName)
 	if client.IsNotFound(err) {
 		glog.Infof("Instance %q was not found. Unable to get ExternalID: %v", instName, err)
 		return "", cloudprovider.InstanceNotFound
@@ -131,7 +131,7 @@ func (cp *CloudProvider) InstanceID(ctx context.Context, nodeName types.NodeName
 	glog.V(4).Infof("InstanceID(%q) called", nodeName)
 
 	name := mapNodeNameToInstanceName(nodeName)
-	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, name)
+	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, name)
 	if err != nil {
 		if client.IsNotFound(err) {
 			return "", cloudprovider.InstanceNotFound
@@ -145,7 +145,7 @@ func (cp *CloudProvider) InstanceID(ctx context.Context, nodeName types.NodeName
 func (cp *CloudProvider) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
 	glog.V(4).Infof("InstanceType(%q) called", name)
 
-	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, mapNodeNameToInstanceName(name))
+	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, mapNodeNameToInstanceName(name))
 	if err != nil {
 		return "", errors.Wrap(err, "GetInstanceByNodeName")
 	}

--- a/pkg/oci/zones.go
+++ b/pkg/oci/zones.go
@@ -63,7 +63,7 @@ func (cp *CloudProvider) GetZoneByProviderID(ctx context.Context, providerID str
 // in the context of external cloud providers where node initialization must be
 // down outside the kubelets.
 func (cp *CloudProvider) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
-	instance, err := cp.client.Compute().GetInstanceByNodeName(ctx, mapNodeNameToInstanceName(nodeName))
+	instance, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, mapNodeNameToInstanceName(nodeName))
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}


### PR DESCRIPTION
Moves `Config` out of the oci client package in preparation for config changes.