### PR TITLE
Move auth.compartment to compartment in config

### DIFF
--- a/manifests/cloud-provider-example.yaml
+++ b/manifests/cloud-provider-example.yaml
@@ -1,7 +1,6 @@
 auth:
   region: us-phoenix-1
   tenancy: ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq
-  compartment: ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq
   user: ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q
   key: |
     -----BEGIN RSA PRIVATE KEY-----
@@ -10,6 +9,9 @@ auth:
   # Omit if there is not a password for the key
   key_passphrase: supersecretpassword
   fingerprint: 8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74
+
+# compartment configures Compartment within which the cluster resides.
+compartment: ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq
 
 # vcn configures the Virtual Cloud Network (VCN) within which the cluster resides.
 vcn: ocid1.vcn.oc1..aaaaaaaask7mpk4mij3pnm6yvnntte25ffadxiivpokxevfxgtsu6ftkqhrq

--- a/pkg/oci/ccm.go
+++ b/pkg/oci/ccm.go
@@ -68,8 +68,8 @@ var _ cloudprovider.Interface = &CloudProvider{}
 // NewCloudProvider creates a new oci.CloudProvider.
 func NewCloudProvider(config *Config) (cloudprovider.Interface, error) {
 	c, err := client.New(common.NewRawConfigurationProvider(
-		config.Auth.TenancyOCID,
-		config.Auth.UserOCID,
+		config.Auth.TenancyID,
+		config.Auth.UserID,
 		config.Auth.Region,
 		config.Auth.Fingerprint,
 		config.Auth.PrivateKey,
@@ -79,13 +79,13 @@ func NewCloudProvider(config *Config) (cloudprovider.Interface, error) {
 		return nil, err
 	}
 
-	if config.Auth.CompartmentOCID == "" {
+	if config.CompartmentID == "" {
 		glog.Info("Compartment not supplied in config: attempting to infer from instance metadata")
 		metadata, err := instancemeta.New().Get()
 		if err != nil {
 			return nil, err
 		}
-		config.Auth.CompartmentOCID = metadata.CompartmentOCID
+		config.CompartmentID = metadata.CompartmentOCID
 	}
 
 	if config.VCNID == "" {
@@ -109,6 +109,8 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
+		cfg.Complete()
+
 		if err = cfg.Validate(); err != nil {
 			return nil, err
 		}

--- a/pkg/oci/config_test.go
+++ b/pkg/oci/config_test.go
@@ -30,7 +30,6 @@ const validConfig = `
 auth:
   region: us-phoenix-1
   tenancy: ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq
-  compartment: ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq
   user: ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q
   key: |
     -----BEGIN RSA PRIVATE KEY-----
@@ -61,6 +60,8 @@ auth:
     D/yEDdXVK/lIzNt7kIMFhtoYGrwv1JQGfK5Wh2bi+AwbBDZ45/17
     -----END RSA PRIVATE KEY-----
   fingerprint: 97:84:f7:26:a3:7b:74:d0:bd:4e:08:a7:79:c9:d0:1d
+
+compartment: ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq
 
 loadBalancer:
   disableSecurityListManagement: false
@@ -132,8 +133,8 @@ func TestReadConfigShouldSetCompartmentOCIDWhenProvidedValidConfig(t *testing.T)
 	}
 	expected := "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq"
 
-	if cfg.Auth.CompartmentOCID != expected {
-		t.Errorf("Got Auth.CompartmentOCID = %s; want Auth.CompartmentOCID = %s",
-			cfg.Auth.CompartmentOCID, expected)
+	if cfg.CompartmentID != expected {
+		t.Errorf("Got CompartmentID = %s; want CompartmentID = %s",
+			cfg.CompartmentID, expected)
 	}
 }

--- a/pkg/oci/config_validate.go
+++ b/pkg/oci/config_validate.go
@@ -27,10 +27,10 @@ func validateAuthConfig(c *AuthConfig, fldPath *field.Path) field.ErrorList {
 	if c.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), ""))
 	}
-	if c.TenancyOCID == "" {
+	if c.TenancyID == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("tenancy"), ""))
 	}
-	if c.UserOCID == "" {
+	if c.UserID == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("user"), ""))
 	}
 	if c.PrivateKey == "" {

--- a/pkg/oci/config_validate_test.go
+++ b/pkg/oci/config_validate_test.go
@@ -31,12 +31,12 @@ func TestValidateConfig(t *testing.T) {
 			name: "valid",
 			in: &Config{
 				Auth: AuthConfig{
-					Region:          "us-phoenix-1",
-					TenancyOCID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-					UserOCID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
-					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
-					Fingerprint:     "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
+					Region:        "us-phoenix-1",
+					TenancyID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					CompartmentID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
+					UserID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					PrivateKey:    "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Fingerprint:   "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
 				LoadBalancer: LoadBalancerConfig{
 					Subnet1: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
@@ -48,11 +48,11 @@ func TestValidateConfig(t *testing.T) {
 			name: "missing_region",
 			in: &Config{
 				Auth: AuthConfig{
-					TenancyOCID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-					UserOCID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
-					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
-					Fingerprint:     "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
+					TenancyID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					CompartmentID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
+					UserID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					PrivateKey:    "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Fingerprint:   "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
 				LoadBalancer: LoadBalancerConfig{
 					Subnet1: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
@@ -66,11 +66,11 @@ func TestValidateConfig(t *testing.T) {
 			name: "missing_tenancy",
 			in: &Config{
 				Auth: AuthConfig{
-					Region:          "us-phoenix-1",
-					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-					UserOCID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
-					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
-					Fingerprint:     "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
+					Region:        "us-phoenix-1",
+					CompartmentID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
+					UserID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					PrivateKey:    "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Fingerprint:   "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
 				LoadBalancer: LoadBalancerConfig{
 					Subnet1: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
@@ -85,8 +85,8 @@ func TestValidateConfig(t *testing.T) {
 			in: &Config{
 				Auth: AuthConfig{
 					Region:      "us-phoenix-1",
-					TenancyOCID: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					UserOCID:    "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					TenancyID:   "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					UserID:      "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
 					PrivateKey:  "-----BEGIN RSA PRIVATE KEY----- (etc)",
 					Fingerprint: "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
@@ -100,11 +100,11 @@ func TestValidateConfig(t *testing.T) {
 			name: "missing_user",
 			in: &Config{
 				Auth: AuthConfig{
-					Region:          "us-phoenix-1",
-					TenancyOCID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
-					Fingerprint:     "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
+					Region:        "us-phoenix-1",
+					TenancyID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					CompartmentID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
+					PrivateKey:    "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Fingerprint:   "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
 				LoadBalancer: LoadBalancerConfig{
 					Subnet1: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
@@ -118,11 +118,11 @@ func TestValidateConfig(t *testing.T) {
 			name: "missing_key",
 			in: &Config{
 				Auth: AuthConfig{
-					Region:          "us-phoenix-1",
-					TenancyOCID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-					UserOCID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
-					Fingerprint:     "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
+					Region:        "us-phoenix-1",
+					TenancyID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					CompartmentID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
+					UserID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					Fingerprint:   "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
 				LoadBalancer: LoadBalancerConfig{
 					Subnet1: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
@@ -136,11 +136,11 @@ func TestValidateConfig(t *testing.T) {
 			name: "missing_figerprint",
 			in: &Config{
 				Auth: AuthConfig{
-					Region:          "us-phoenix-1",
-					TenancyOCID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-					UserOCID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
-					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Region:        "us-phoenix-1",
+					TenancyID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					CompartmentID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
+					UserID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					PrivateKey:    "-----BEGIN RSA PRIVATE KEY----- (etc)",
 				},
 				LoadBalancer: LoadBalancerConfig{
 					Subnet1: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
@@ -154,12 +154,12 @@ func TestValidateConfig(t *testing.T) {
 			name: "missing_subnet1",
 			in: &Config{
 				Auth: AuthConfig{
-					Region:          "us-phoenix-1",
-					TenancyOCID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-					UserOCID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
-					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
-					Fingerprint:     "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
+					Region:        "us-phoenix-1",
+					TenancyID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					CompartmentID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
+					UserID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					PrivateKey:    "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Fingerprint:   "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
 				LoadBalancer: LoadBalancerConfig{
 					Subnet2: "ocid1.subnet.oc1.phx.aaaaaaaahuxrgvs65iwdz7ekwgg3l5gyah7ww5klkwjcso74u3e4i64hvtvq",
@@ -172,12 +172,12 @@ func TestValidateConfig(t *testing.T) {
 			name: "missing_subnet2",
 			in: &Config{
 				Auth: AuthConfig{
-					Region:          "us-phoenix-1",
-					TenancyOCID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
-					CompartmentOCID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
-					UserOCID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
-					PrivateKey:      "-----BEGIN RSA PRIVATE KEY----- (etc)",
-					Fingerprint:     "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
+					Region:        "us-phoenix-1",
+					TenancyID:     "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",
+					CompartmentID: "ocid1.compartment.oc1..aaaaaaaa3um2atybwhder4qttfhgon4j3hcxgmsvnyvx4flfjyewkkwfzwnq",
+					UserID:        "ocid1.user.oc1..aaaaaaaai77mql2xerv7cn6wu3nhxang3y4jk56vo5bn5l5lysl34avnui3q",
+					PrivateKey:    "-----BEGIN RSA PRIVATE KEY----- (etc)",
+					Fingerprint:   "8c:bf:17:7b:5f:e0:7d:13:75:11:d6:39:0d:e2:84:74",
 				},
 				LoadBalancer: LoadBalancerConfig{
 					Subnet1: "ocid1.tenancy.oc1..aaaaaaaatyn7scrtwtqedvgrxgr2xunzeo6uanvyhzxqblctwkrpisvke4kq",

--- a/pkg/oci/instances.go
+++ b/pkg/oci/instances.go
@@ -78,12 +78,12 @@ func extractNodeAddressesFromVNIC(vnic *core.Vnic) ([]api.NodeAddress, error) {
 func (cp *CloudProvider) NodeAddresses(ctx context.Context, name types.NodeName) ([]api.NodeAddress, error) {
 	glog.V(4).Infof("NodeAddresses(%q) called", name)
 
-	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, mapNodeNameToInstanceName(name))
+	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.CompartmentID, cp.config.VCNID, mapNodeNameToInstanceName(name))
 	if err != nil {
 		return nil, errors.Wrap(err, "GetInstanceByNodeName")
 	}
 
-	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, cp.config.Auth.CompartmentOCID, *inst.Id)
+	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, cp.config.CompartmentID, *inst.Id)
 	if err != nil {
 		return nil, errors.Wrap(err, "GetPrimaryVNICForInstance")
 	}
@@ -98,7 +98,7 @@ func (cp *CloudProvider) NodeAddresses(ctx context.Context, name types.NodeName)
 func (cp *CloudProvider) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]api.NodeAddress, error) {
 	glog.V(4).Infof("NodeAddressesByProviderID(%q) called", providerID)
 	instanceID := util.MapProviderIDToInstanceID(providerID)
-	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, cp.config.Auth.CompartmentOCID, instanceID)
+	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, cp.config.CompartmentID, instanceID)
 	if err != nil {
 		return nil, errors.Wrap(err, "GetPrimaryVNICForInstance")
 	}
@@ -112,7 +112,7 @@ func (cp *CloudProvider) ExternalID(ctx context.Context, nodeName types.NodeName
 	glog.V(4).Infof("ExternalID(%q) called", nodeName)
 
 	instName := mapNodeNameToInstanceName(nodeName)
-	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, instName)
+	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.CompartmentID, cp.config.VCNID, instName)
 	if client.IsNotFound(err) {
 		glog.Infof("Instance %q was not found. Unable to get ExternalID: %v", instName, err)
 		return "", cloudprovider.InstanceNotFound
@@ -131,7 +131,7 @@ func (cp *CloudProvider) InstanceID(ctx context.Context, nodeName types.NodeName
 	glog.V(4).Infof("InstanceID(%q) called", nodeName)
 
 	name := mapNodeNameToInstanceName(nodeName)
-	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, name)
+	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.CompartmentID, cp.config.VCNID, name)
 	if err != nil {
 		if client.IsNotFound(err) {
 			return "", cloudprovider.InstanceNotFound
@@ -145,7 +145,7 @@ func (cp *CloudProvider) InstanceID(ctx context.Context, nodeName types.NodeName
 func (cp *CloudProvider) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
 	glog.V(4).Infof("InstanceType(%q) called", name)
 
-	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, mapNodeNameToInstanceName(name))
+	inst, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.CompartmentID, cp.config.VCNID, mapNodeNameToInstanceName(name))
 	if err != nil {
 		return "", errors.Wrap(err, "GetInstanceByNodeName")
 	}

--- a/pkg/oci/load_balancer.go
+++ b/pkg/oci/load_balancer.go
@@ -83,7 +83,7 @@ func (cp *CloudProvider) GetLoadBalancer(ctx context.Context, clusterName string
 	name := GetLoadBalancerName(service)
 	glog.V(4).Infof("Fetching load balancer with name %q", name)
 
-	lb, err := cp.client.LoadBalancer().GetLoadBalancerByName(ctx, cp.config.Auth.CompartmentOCID, name)
+	lb, err := cp.client.LoadBalancer().GetLoadBalancerByName(ctx, cp.config.CompartmentID, name)
 	if err != nil {
 		if client.IsNotFound(err) {
 			glog.V(2).Infof("Load balancer %q does not exist", name)
@@ -232,7 +232,7 @@ func (cp *CloudProvider) createLoadBalancer(ctx context.Context, spec *LBSpec) (
 	if err != nil {
 		return nil, errors.Wrap(err, "getting subnets for load balancers")
 	}
-	nodeSubnets, err := getSubnetsForNodes(ctx, spec.nodes, cp.client, cp.config.Auth.CompartmentOCID)
+	nodeSubnets, err := getSubnetsForNodes(ctx, spec.nodes, cp.client, cp.config.CompartmentID)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting subnets for nodes")
 	}
@@ -249,7 +249,7 @@ func (cp *CloudProvider) createLoadBalancer(ctx context.Context, spec *LBSpec) (
 		return nil, errors.Wrap(err, "get certificates")
 	}
 	details := loadbalancer.CreateLoadBalancerDetails{
-		CompartmentId: &cp.config.Auth.CompartmentOCID,
+		CompartmentId: &cp.config.CompartmentID,
 		DisplayName:   &spec.Name,
 		ShapeName:     &spec.Shape,
 		IsPrivate:     &spec.Internal,
@@ -286,7 +286,7 @@ func (cp *CloudProvider) EnsureLoadBalancer(ctx context.Context, clusterName str
 
 	glog.V(4).Infof("Ensure load balancer %q called for %q with %d nodes.", lbName, service.Name, len(nodes))
 
-	lb, err := cp.client.LoadBalancer().GetLoadBalancerByName(ctx, cp.config.Auth.CompartmentOCID, lbName)
+	lb, err := cp.client.LoadBalancer().GetLoadBalancerByName(ctx, cp.config.CompartmentID, lbName)
 	if err != nil && !client.IsNotFound(err) {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (cp *CloudProvider) updateLoadBalancer(ctx context.Context, lb *loadbalance
 	if err != nil {
 		return errors.Wrapf(err, "getting load balancer subnets")
 	}
-	nodeSubnets, err := getSubnetsForNodes(ctx, spec.nodes, cp.client, cp.config.Auth.CompartmentOCID)
+	nodeSubnets, err := getSubnetsForNodes(ctx, spec.nodes, cp.client, cp.config.CompartmentID)
 	if err != nil {
 		return errors.Wrap(err, "get subnets for nodes")
 	}
@@ -512,7 +512,7 @@ func (cp *CloudProvider) EnsureLoadBalancerDeleted(ctx context.Context, clusterN
 	name := GetLoadBalancerName(service)
 	glog.Infof("Attempting to delete load balancer %q", name)
 
-	lb, err := cp.client.LoadBalancer().GetLoadBalancerByName(ctx, cp.config.Auth.CompartmentOCID, name)
+	lb, err := cp.client.LoadBalancer().GetLoadBalancerByName(ctx, cp.config.CompartmentID, name)
 	if err != nil {
 		if client.IsNotFound(err) {
 			glog.Infof("Could not find load balancer with name %q. Nothing to do.", name)
@@ -533,7 +533,7 @@ func (cp *CloudProvider) EnsureLoadBalancerDeleted(ctx context.Context, clusterN
 	if err != nil {
 		return errors.Wrap(err, "fetching nodes by internal ips")
 	}
-	nodeSubnets, err := getSubnetsForNodes(ctx, nodes, cp.client, cp.config.Auth.CompartmentOCID)
+	nodeSubnets, err := getSubnetsForNodes(ctx, nodes, cp.client, cp.config.CompartmentID)
 	if err != nil {
 		return errors.Wrap(err, "getting subnets for nodes")
 	}

--- a/pkg/oci/zones.go
+++ b/pkg/oci/zones.go
@@ -63,7 +63,7 @@ func (cp *CloudProvider) GetZoneByProviderID(ctx context.Context, providerID str
 // in the context of external cloud providers where node initialization must be
 // down outside the kubelets.
 func (cp *CloudProvider) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
-	instance, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.Auth.CompartmentOCID, cp.config.VCNID, mapNodeNameToInstanceName(nodeName))
+	instance, err := cp.client.Compute().GetInstanceByNodeName(ctx, cp.config.CompartmentID, cp.config.VCNID, mapNodeNameToInstanceName(nodeName))
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}


### PR DESCRIPTION
Depreciates `auth.compartment` in favour of `compartment` but maintains backwards compatibility (for now).

Resolves: #170 