### PR TITLE
Allow load balancer functionality to be disabled

### DIFF
--- a/pkg/oci/config.go
+++ b/pkg/oci/config.go
@@ -42,6 +42,9 @@ type AuthConfig struct {
 
 // LoadBalancerConfig holds the configuration options for OCI load balancers.
 type LoadBalancerConfig struct {
+	// Disabled disables the creation of a load balancer.
+	Disabled bool `yaml:"disabled"`
+
 	// DisableSecurityListManagement disables the automatic creation of ingress
 	// rules for the node subnets and egress rules for the load balancers to the node subnets.
 	//
@@ -80,7 +83,7 @@ type Config struct {
 
 // Complete the config applying defaults / overrides.
 func (c *Config) Complete() {
-	if c.LoadBalancer.SecurityListManagementMode == "" {
+	if !c.LoadBalancer.Disabled && c.LoadBalancer.SecurityListManagementMode == "" {
 		c.LoadBalancer.SecurityListManagementMode = ManagementModeAll // default
 		if c.LoadBalancer.DisableSecurityListManagement {
 			glog.Warningf("cloud-provider config: \"loadBalancer.disableSecurityListManagement\" is DEPRECIATED and will be removed in a later release. Please set \"loadBalancer.SecurityListManagementMode: %s\".", ManagementModeNone)

--- a/pkg/oci/config_validate.go
+++ b/pkg/oci/config_validate.go
@@ -83,6 +83,8 @@ func validateLoadBalancerConfig(c *Config, fldPath *field.Path) field.ErrorList 
 func ValidateConfig(c *Config) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateAuthConfig(&c.Auth, field.NewPath("auth"))...)
-	allErrs = append(allErrs, validateLoadBalancerConfig(c, field.NewPath("loadBalancer"))...)
+	if !c.LoadBalancer.Disabled {
+		allErrs = append(allErrs, validateLoadBalancerConfig(c, field.NewPath("loadBalancer"))...)
+	}
 	return allErrs
 }


### PR DESCRIPTION
Resolves: #198

When the load balancer configuration is completely omitted, the load balancer functionality is disabled. @jhorwit2 suggested we look at using resource quotas:

`apiVersion: v1
kind: ResourceQuota
metadata:
  name: lb-count
spec:
  hard:
    services.loadbalancers: "0"`

When applied and a load balancer of type service is applied the service is rejected.
`Error from server (Forbidden): error when creating "echo-svc.yaml": services "echoheaders" is forbidden: exceeded quota: lb-count, requested: services.loadbalancers=1, used: services.loadbalancers=0, limited: services.loadbalancers=0`

Shall we simply leave this alone or include this PR as an additional enhancement?