### PR TITLE
Support managed routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # CHANGELOG
 
-## 0.5.0
+## 0.5
 
-* Allow load balancer functionality to be disabled. [#198]
-* Allow subnets in configuration to be optional. [#202]
+ * Implement `manageRoutes` to enable the cloud route controller
+   - This will make sure that `VNIC`s have `SkipSourceDestCheck`
+   - Also make sure that all route tables for all instances have the
+       appropriate route entries for cluster cidr ranges
 
-## 0.4.0
+## 0.4
 
  * Implement `loadbalancer.securityListManagementMode: Frontend` which only
    manages security list rules for load balancer ingress. [#180][16]
- * Depreciate `loadbalancer.disableSecurityListManagement` in favour of
+ * Deprecate `loadbalancer.disableSecurityListManagement` in favour of
    `loadbalancer.securityListManagementMode: None`. [#180][16]
  * Implement `loadbalancer.securityLists` to allow explicit configuration of the
    security lists that the CCM manages on a per-subnet basis [#164][17].
@@ -22,9 +24,9 @@
    either a public IP or a hostname [#167][14]
  * [BUG] Fix regression where compartment OCID was no longer looked up from
    metadata when not provided in cloud-provider config [#168][15]
- * Depreciate cloud-provider config property `auth.key_passphrase` replacing it
+ * Deprecate cloud-provider config property `auth.key_passphrase` replacing it
    with `auth.passphrase` [#142][12]
- * Depreciate cloud-provider config property `auth.compartment` replacing it
+ * Deprecate cloud-provider config property `auth.compartment` replacing it
    with `compartment` [#170][13]
 
 ## 0.3.1

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Key:
    cloud-provider.
  - ServiceController - responsible for creating load balancers when a service
    of `type: LoadBalancer` is created in Kubernetes.
+ - RouteController - response for managing the route tables for instances to
+   allow for podCIDRs to be directly accessible without an overlay
 
 ## Setup and Installation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,10 +46,14 @@ using [`dep`][2].
         -----END RSA PRIVATE KEY-----
       fingerprint: 97:84:f7:26:a3:7b:74:d0:bd:4e:08:a7:79:c9:d0:1d
 
+    vcn: ocid1.vcn.oc1.iad.aaaaaaaa7ucuzoltaumdgmq2wcwxjxznuzbugaweh4k4pjm77kldn27fgzha
+
     loadBalancer:
       disableSecurityListManagement: false
       subnet1: ocid1.subnet.oc1.phx.aaaaaaaasa53hlkzk6nzksqfccegk2qnkxmphkblst3riclzs4rhwg7rg57q
       subnet2: ocid1.subnet.oc1.phx.aaaaaaaahuxrgvs65iwdz7ekwgg3l5gyah7ww5klkwjcso74u3e4i64hvtvq
+
+    manageRoutes: true
     ```
  3. Ensure you have [`$KUBECONFIG`][4] to the Kubernetes configuration file for
     your cluster.

--- a/manifests/oci-cloud-controller-manager.yaml
+++ b/manifests/oci-cloud-controller-manager.yaml
@@ -41,6 +41,8 @@ spec:
             - --cloud-config=/etc/oci/cloud-provider.yaml
             - --cloud-provider=oci
             - --leader-elect-resource-lock=configmaps
+            - --allocate-node-cidrs=true
+            - --cluster-cidr=10.99.0.0/16
             - -v=2
           volumeMounts:
             - name: cfg

--- a/pkg/oci/ccm.go
+++ b/pkg/oci/ccm.go
@@ -186,7 +186,8 @@ func (cp *CloudProvider) Clusters() (cloudprovider.Clusters, bool) {
 // Routes returns a routes interface along with whether the interface is
 // supported.
 func (cp *CloudProvider) Routes() (cloudprovider.Routes, bool) {
-	return nil, false
+	glog.V(6).Infof("Claiming to support Routes: %s", cp.config.ManageRoutes)
+	return cp, cp.config.ManageRoutes
 }
 
 // ScrubDNS provides an opportunity for cloud-provider-specific code to process

--- a/pkg/oci/client/compute.go
+++ b/pkg/oci/client/compute.go
@@ -93,6 +93,18 @@ func (c *client) listVNICAttachments(ctx context.Context, req core.ListVnicAttac
 
 func (c *client) GetPrimaryVNICForInstance(ctx context.Context, compartmentID, instanceID string) (*core.Vnic, error) {
 	var page *string
+
+	if compartmentID == "" {
+		glog.V(6).Infof("No compartment specified, looking up instance: %s", instanceID)
+		instance, err := c.GetInstance(ctx, instanceID)
+
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		compartmentID = *instance.CompartmentId
+	}
+
 	for {
 		resp, err := c.listVNICAttachments(ctx, core.ListVnicAttachmentsRequest{
 			InstanceId:    &instanceID,

--- a/pkg/oci/client/compute.go
+++ b/pkg/oci/client/compute.go
@@ -94,16 +94,13 @@ func (c *client) listVNICAttachments(ctx context.Context, req core.ListVnicAttac
 func (c *client) GetPrimaryVNICForInstance(ctx context.Context, compartmentID, instanceID string) (*core.Vnic, error) {
 	var page *string
 
-	if compartmentID == "" {
-		glog.V(6).Infof("No compartment specified, looking up instance: %s", instanceID)
-		instance, err := c.GetInstance(ctx, instanceID)
-
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-
-		compartmentID = *instance.CompartmentId
+	glog.V(6).Infof("No compartment specified, looking up instance: %s", instanceID)
+	instance, err := c.GetInstance(ctx, instanceID)
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
+
+	compartmentID = *instance.CompartmentId
 
 	for {
 		resp, err := c.listVNICAttachments(ctx, core.ListVnicAttachmentsRequest{
@@ -111,7 +108,6 @@ func (c *client) GetPrimaryVNICForInstance(ctx context.Context, compartmentID, i
 			CompartmentId: &compartmentID,
 			Page:          page,
 		})
-
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/oci/client/load_balancer.go
+++ b/pkg/oci/client/load_balancer.go
@@ -273,7 +273,7 @@ func (c *client) AwaitWorkRequest(ctx context.Context, id string) (*loadbalancer
 			wr = twr
 			return true, nil
 		case loadbalancer.WorkRequestLifecycleStateFailed:
-			return false, errors.Errorf("WorkRequest %q failed: %s", id, twr.Message)
+			return false, errors.Errorf("WorkRequest %q failed: %q", id, twr.Message)
 		}
 		return false, nil
 	}, ctx.Done())

--- a/pkg/oci/client/metrics.go
+++ b/pkg/oci/client/metrics.go
@@ -44,6 +44,9 @@ const (
 	certificateResource    resource = "load_balancer_certificate"
 	workRequestResource    resource = "load_balancer_work_request"
 	securityListResource   resource = "security_list"
+	privateIPResource      resource = "ip_private"
+	publicIPResource       resource = "ip_public"
+	routeTableResource     resource = "route_table"
 )
 
 type verb string

--- a/pkg/oci/client/networking.go
+++ b/pkg/oci/client/networking.go
@@ -44,6 +44,7 @@ func (c *client) getVNIC(ctx context.Context, id string) (*core.Vnic, error) {
 	resp, err := c.network.GetVnic(ctx, core.GetVnicRequest{
 		VnicId: &id,
 	})
+
 	incRequestCounter(err, getVerb, vnicResource)
 
 	if err != nil {
@@ -115,16 +116,29 @@ func subnetCacheKeyFn(obj interface{}) (string, error) {
 }
 
 func (c *client) GetRouteTable(ctx context.Context, routeID string) (core.GetRouteTableResponse, error) {
-	req := core.GetRouteTableRequest{
+	resp, err := c.network.GetRouteTable(ctx, core.GetRouteTableRequest{
 		RtId: &routeID,
+	})
+	incRequestCounter(err, getVerb, routeTableResource)
+
+	if err != nil {
+		return core.GetRouteTableResponse{}, err
 	}
-	return c.network.GetRouteTable(ctx, req)
+
+	return resp, nil
 }
 
 func (c *client) GetIPFromOCID(ctx context.Context, ipID string) (core.GetPrivateIpResponse, error) {
-	return c.network.GetPrivateIp(ctx, core.GetPrivateIpRequest{
+	resp, err := c.network.GetPrivateIp(ctx, core.GetPrivateIpRequest{
 		PrivateIpId: &ipID,
 	})
+	incRequestCounter(err, getVerb, privateIPResource)
+
+	if err != nil {
+		return core.GetPrivateIpResponse{}, err
+	}
+
+	return resp, nil
 }
 
 func (c *client) GetOCIDFromIP(ctx context.Context, ipAddress string, subnetID string) (string, error) {
@@ -132,6 +146,7 @@ func (c *client) GetOCIDFromIP(ctx context.Context, ipAddress string, subnetID s
 		IpAddress: &ipAddress,
 		SubnetId:  &subnetID,
 	})
+	incRequestCounter(err, getVerb, privateIPResource)
 
 	if err != nil {
 		return "", err
@@ -153,6 +168,7 @@ func (c *client) UpdateRouteTable(ctx context.Context, routeID string, routeRule
 			RouteRules: routeRules,
 		},
 	})
+	incRequestCounter(err, updateVerb, routeTableResource)
 
 	return err
 }

--- a/pkg/oci/client/networking.go
+++ b/pkg/oci/client/networking.go
@@ -28,13 +28,13 @@ type NetworkingInterface interface {
 	GetSubnet(ctx context.Context, id string) (*core.Subnet, error)
 	GetSubnetFromCacheByIP(ip string) (*core.Subnet, error)
 
-	GetSecurityList(ctx context.Context, id string) (core.GetSecurityListResponse, error)
-	UpdateSecurityList(ctx context.Context, request core.UpdateSecurityListRequest) (core.UpdateSecurityListResponse, error)
+	GetSecurityList(ctx context.Context, id string) (*core.GetSecurityListResponse, error)
+	UpdateSecurityList(ctx context.Context, request core.UpdateSecurityListRequest) (*core.UpdateSecurityListResponse, error)
 
-	GetRouteTable(ctx context.Context, routeID string) (core.GetRouteTableResponse, error)
+	GetRouteTable(ctx context.Context, routeID string) (*core.GetRouteTableResponse, error)
 	UpdateRouteTable(ctx context.Context, routeID string, routeRules []core.RouteRule) error
 
-	GetIPFromOCID(ctx context.Context, ipID string) (core.GetPrivateIpResponse, error)
+	GetIPFromOCID(ctx context.Context, ipID string) (*core.GetPrivateIpResponse, error)
 	GetOCIDFromIP(ctx context.Context, ipAddress string, subnetID string) (string, error)
 
 	UpdateVnic(ctx context.Context, vnicID string, skipSourceCheck bool) error
@@ -96,49 +96,49 @@ func (c *client) GetSubnetFromCacheByIP(ip string) (*core.Subnet, error) {
 	return nil, nil
 }
 
-func (c *client) GetSecurityList(ctx context.Context, id string) (core.GetSecurityListResponse, error) {
+func (c *client) GetSecurityList(ctx context.Context, id string) (*core.GetSecurityListResponse, error) {
 	resp, err := c.network.GetSecurityList(ctx, core.GetSecurityListRequest{
 		SecurityListId: &id,
 	})
 	incRequestCounter(err, getVerb, securityListResource)
 
-	return resp, errors.WithStack(err)
+	return &resp, errors.WithStack(err)
 }
 
-func (c *client) UpdateSecurityList(ctx context.Context, request core.UpdateSecurityListRequest) (core.UpdateSecurityListResponse, error) {
+func (c *client) UpdateSecurityList(ctx context.Context, request core.UpdateSecurityListRequest) (*core.UpdateSecurityListResponse, error) {
 	resp, err := c.network.UpdateSecurityList(ctx, request)
 	incRequestCounter(err, updateVerb, securityListResource)
-	return resp, errors.WithStack(err)
+	return &resp, errors.WithStack(err)
 }
 
 func subnetCacheKeyFn(obj interface{}) (string, error) {
 	return *obj.(*core.Subnet).Id, nil
 }
 
-func (c *client) GetRouteTable(ctx context.Context, routeID string) (core.GetRouteTableResponse, error) {
+func (c *client) GetRouteTable(ctx context.Context, routeID string) (*core.GetRouteTableResponse, error) {
 	resp, err := c.network.GetRouteTable(ctx, core.GetRouteTableRequest{
 		RtId: &routeID,
 	})
 	incRequestCounter(err, getVerb, routeTableResource)
 
 	if err != nil {
-		return core.GetRouteTableResponse{}, err
+		return nil, err
 	}
 
-	return resp, nil
+	return &resp, nil
 }
 
-func (c *client) GetIPFromOCID(ctx context.Context, ipID string) (core.GetPrivateIpResponse, error) {
+func (c *client) GetIPFromOCID(ctx context.Context, ipID string) (*core.GetPrivateIpResponse, error) {
 	resp, err := c.network.GetPrivateIp(ctx, core.GetPrivateIpRequest{
 		PrivateIpId: &ipID,
 	})
 	incRequestCounter(err, getVerb, privateIPResource)
 
 	if err != nil {
-		return core.GetPrivateIpResponse{}, err
+		return nil, err
 	}
 
-	return resp, nil
+	return &resp, nil
 }
 
 func (c *client) GetOCIDFromIP(ctx context.Context, ipAddress string, subnetID string) (string, error) {

--- a/pkg/oci/config.go
+++ b/pkg/oci/config.go
@@ -29,13 +29,13 @@ type AuthConfig struct {
 	UseInstancePrincipals bool   `yaml:"useInstancePrincipals"`
 	Region                string `yaml:"region"`
 	TenancyID             string `yaml:"tenancy"`
-	// CompartmentID is DEPRECIATED and should be set on the top level Config
+	// CompartmentID is DEPRECATED and should be set on the top level Config
 	// struct.
 	CompartmentID string `yaml:"compartment"`
 	UserID        string `yaml:"user"`
 	PrivateKey    string `yaml:"key"`
 	Fingerprint   string `yaml:"fingerprint"`
-	// PrivateKeyPassphrase is DEPRECIATED in favour of Passphrase.
+	// PrivateKeyPassphrase is DEPRECATED in favour of Passphrase.
 	PrivateKeyPassphrase string `yaml:"key_passphrase"`
 	Passphrase           string `yaml:"passphrase"`
 }
@@ -79,6 +79,9 @@ type Config struct {
 	// VCNID is the OCID of the Virtual Cloud Network (VCN) within which the
 	// cluster resides.
 	VCNID string `yaml:"vcn"`
+
+	// Toggle managing routes
+	ManageRoutes bool `yaml:"manageRoutes"`
 }
 
 // Complete the config applying defaults / overrides.
@@ -86,16 +89,16 @@ func (c *Config) Complete() {
 	if !c.LoadBalancer.Disabled && c.LoadBalancer.SecurityListManagementMode == "" {
 		c.LoadBalancer.SecurityListManagementMode = ManagementModeAll // default
 		if c.LoadBalancer.DisableSecurityListManagement {
-			glog.Warningf("cloud-provider config: \"loadBalancer.disableSecurityListManagement\" is DEPRECIATED and will be removed in a later release. Please set \"loadBalancer.SecurityListManagementMode: %s\".", ManagementModeNone)
+			glog.Warningf("cloud-provider config: \"loadBalancer.disableSecurityListManagement\" is DEPRECATED and will be removed in a later release. Please set \"loadBalancer.SecurityListManagementMode: %s\".", ManagementModeNone)
 			c.LoadBalancer.SecurityListManagementMode = ManagementModeNone
 		}
 	}
 	if c.CompartmentID == "" && c.Auth.CompartmentID != "" {
-		glog.Warning("cloud-provider config: \"auth.compartment\" is DEPRECIATED and will be removed in a later release. Please set \"compartment\".")
+		glog.Warning("cloud-provider config: \"auth.compartment\" is DEPRECATED and will be removed in a later release. Please set \"compartment\".")
 		c.CompartmentID = c.Auth.CompartmentID
 	}
 	if c.Auth.Passphrase == "" && c.Auth.PrivateKeyPassphrase != "" {
-		glog.Warning("cloud-provider config: \"auth.key_passphrase\" is DEPRECIATED and will be removed in a later release. Please set \"auth.passphrase\".")
+		glog.Warning("cloud-provider config: \"auth.key_passphrase\" is DEPRECATED and will be removed in a later release. Please set \"auth.passphrase\".")
 		c.Auth.Passphrase = c.Auth.PrivateKeyPassphrase
 	}
 }

--- a/pkg/oci/load_balancer_security_lists.go
+++ b/pkg/oci/load_balancer_security_lists.go
@@ -184,7 +184,7 @@ func (s *baseSecurityListManager) getSecurityList(ctx context.Context, subnet *c
 		if err != nil {
 			return nil, "", err
 		}
-		responses[i] = response
+		responses[i] = *response
 	}
 
 	sort.Slice(responses, func(i, j int) bool {

--- a/pkg/oci/routes.go
+++ b/pkg/oci/routes.go
@@ -1,0 +1,285 @@
+// Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+
+	"github.com/golang/glog"
+	"github.com/oracle/oci-cloud-controller-manager/pkg/oci/util"
+	"github.com/oracle/oci-go-sdk/core"
+	"github.com/pkg/errors"
+	"strings"
+)
+
+var _ cloudprovider.Routes = &CloudProvider{}
+
+/*
+OCI doesn't have distinct add/remove/update route commands, only the ability to
+update the whole RouteTable.
+
+K8s dispatches up to 200 concurrent creates.
+
+As a result ADD/Create races with itself, especially in light of DELETE.
+
+Ultimately the reconciliation restores order in the galaxy, but only after some
+disruptions in the force.
+
+One _could_ add some locking on the Get/Update of RouteTable, but it's not
+clear that should be required.
+*/
+
+// CreateRoute for OCI, we have to udpate the whole RouteTable not just add the singular route
+func (cp *CloudProvider) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
+	glog.V(6).Info("Add Route: ", route)
+
+	node, err := cp.NodeLister.Get(string(route.TargetNode))
+
+	ocid := util.MapProviderIDToInstanceID(node.Spec.ProviderID)
+
+	glog.V(6).Info("instance ", ocid)
+
+	vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, "", ocid)
+
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	ipOcid, err := cp.client.Networking().GetOCIDFromIP(ctx, *vnic.PrivateIp, *vnic.SubnetId)
+
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	for routeTableID := range routeTableIds {
+		routeTable, err := cp.client.Networking().GetRouteTable(ctx, routeTableID)
+
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		for _, oRoute := range routeTable.RouteRules {
+			if *oRoute.CidrBlock == route.DestinationCIDR {
+				if *oRoute.NetworkEntityId == ipOcid {
+					// skipping existing route table entry
+					glog.V(6).Info("Skipping existing route entry: ", route.DestinationCIDR, " -> ", ipOcid)
+					continue
+				} else {
+					oRoute.NetworkEntityId = &ipOcid
+					glog.V(6).Info("Update existing route entry: ", route.DestinationCIDR, " -> ", ipOcid)
+					err := cp.client.Networking().UpdateRouteTable(ctx, routeTableID, routeTable.RouteRules)
+					if err != nil {
+						return errors.WithStack(err)
+					}
+					continue
+				}
+			}
+		}
+
+		// route rule doesn't exist in RouteTable
+		glog.V(6).Info("Add new route entry: ", route.DestinationCIDR, " -> ", ipOcid)
+		routeTable.RouteRules = append(routeTable.RouteRules, core.RouteRule{
+			CidrBlock:       &route.DestinationCIDR,
+			NetworkEntityId: &ipOcid,
+		})
+
+		err = cp.client.Networking().UpdateRouteTable(ctx, routeTableID, routeTable.RouteRules)
+
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
+// DeleteRoute delete a route entry, but OCI only has Update of the entire RouteTable
+func (cp *CloudProvider) DeleteRoute(ctx context.Context, clusterName string, route *cloudprovider.Route) error {
+	glog.V(6).Infof("Delete Route: %v", route)
+
+	for routeID := range routeTableIds {
+		oRoute, err := cp.client.Networking().GetRouteTable(ctx, routeID)
+
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		dirty := false
+
+		for i, r := range oRoute.RouteRules {
+			if *r.CidrBlock != route.DestinationCIDR {
+				continue
+			}
+
+			dirty = true
+
+			glog.V(6).Infof("Deleting Route: %s %s", route.DestinationCIDR, route.TargetNode)
+			oRoute.RouteRules = append(oRoute.RouteRules[:i], oRoute.RouteRules[i+1:]...)
+		}
+
+		if dirty {
+			glog.V(6).Infof("Updating Route: %s %v", routeID, oRoute.RouteRules)
+			err := cp.client.Networking().UpdateRouteTable(ctx, routeID, oRoute.RouteRules)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// subnet -> routetable
+// subnets cannot change their route tables, so it's safe to cache
+var subnetIds map[string]string
+
+// routetable -> exists
+// we may see new route tables if we see new subnets
+var routeTableIds map[string]bool
+
+// ListRoutes for OCI, discover all instances and their subnets and those route tables to iterate over
+func (cp *CloudProvider) ListRoutes(ctx context.Context, clusterName string) ([]*cloudprovider.Route, error) {
+	glog.V(6).Info("Listing Routes: ", clusterName)
+
+	if subnetIds == nil {
+		subnetIds = make(map[string]string)
+	}
+
+	newRouteTableIds := make(map[string]bool)
+
+	nodeList, err := cp.NodeLister.List(labels.Everything())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	ipToNodeLookup := make(map[string]*v1.Node)
+	for _, node := range nodeList {
+		instanceID := util.MapProviderIDToInstanceID(node.Spec.ProviderID)
+
+		vnic, err := cp.client.Compute().GetPrimaryVNICForInstance(ctx, "", instanceID)
+
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		if *vnic.SkipSourceDestCheck != true {
+			glog.V(6).Info("Set SkipSourceDestCheck on ", vnic)
+			err = cp.client.Networking().UpdateVnic(ctx, *vnic.Id, true)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		routeTable, ok := subnetIds[*vnic.SubnetId]
+
+		if !ok {
+			subnet, err := cp.client.Networking().GetSubnet(ctx, *vnic.SubnetId)
+
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+
+			routeTable = *subnet.RouteTableId
+			subnetIds[*vnic.SubnetId] = routeTable
+		}
+
+		glog.V(6).Infof("Found Route Table id %s", routeTable)
+		newRouteTableIds[routeTable] = true
+
+		ip := util.NodeInternalIP(node)
+		ipToNodeLookup[ip] = node
+	}
+
+	routeTableIds = newRouteTableIds
+
+	// ultimately we need to find all the routes from all route tables
+	// that are germane to this cluster, so if the destination cidr isn't
+	// in the cluster range skip, also if we find mismatch destinations set
+	// target to empty to invalidate and force a refresh
+	var destinationsMap = make(map[string]string)
+
+	for id := range routeTableIds {
+		glog.V(6).Infof("Listing routes for id %s", id)
+
+		oRoute, err := cp.client.Networking().GetRouteTable(ctx, id)
+
+		if err != nil {
+			glog.V(6).Infof("Failed to get routes for id %s", id)
+			return nil, errors.WithStack(err)
+		}
+
+		glog.V(6).Infof("Route entries: %v", oRoute.RouteRules)
+
+		for _, r := range oRoute.RouteRules {
+			if !strings.Contains(*r.NetworkEntityId, "privateip") {
+				glog.V(6).Infof("Skipping entry: %v", r)
+				continue
+			}
+
+			// TODO CACHE
+			ipDetails, err := cp.client.Networking().GetIPFromOCID(ctx, *r.NetworkEntityId)
+
+			if err != nil {
+				glog.V(6).Infof("Failed to resolve IP to OCID %v", *r.NetworkEntityId)
+				return nil, errors.WithStack(err)
+			}
+
+			node, foundNode := ipToNodeLookup[*ipDetails.IpAddress]
+
+			target, ok := destinationsMap[*r.CidrBlock]
+
+			glog.V(6).Infof("Evaluate entry: %v %s %s", node.Name, target, *r.CidrBlock)
+
+			if !ok {
+				if !foundNode {
+					destinationsMap[*r.CidrBlock] = ""
+				} else {
+					destinationsMap[*r.CidrBlock] = node.Name
+				}
+			} else {
+				if target != node.Name {
+					glog.V(6).Infof("Route Destination mismatch %s %s %s", target, node.Name, *r.CidrBlock)
+					destinationsMap[*r.CidrBlock] = ""
+				}
+			}
+
+			glog.V(6).Infof("Destination Map %s -> %s", *r.CidrBlock, destinationsMap[*r.CidrBlock])
+		}
+	}
+
+	var routes []*cloudprovider.Route
+
+	for destinationCidr, target := range destinationsMap {
+		found := true
+
+		if target == "" {
+			found = false
+		}
+
+		routes = append(routes, &cloudprovider.Route{
+			Name:            destinationCidr,
+			TargetNode:      types.NodeName(target),
+			Blackhole:       !found,
+			DestinationCIDR: destinationCidr,
+		})
+	}
+
+	glog.V(6).Infof("Listed Routes: %d", len(routes))
+	return routes, nil
+}

--- a/pkg/oci/routes.go
+++ b/pkg/oci/routes.go
@@ -156,10 +156,17 @@ var (
 )
 
 // SetSubnetIDs sets the subnetID map.
-func SetSubnetIDs(new map[string]string) {
+func SetSubnetIDs(new map[string]string, checkNil bool) {
 	subnetIDMutex.Lock()
 	defer subnetIDMutex.Unlock()
-	subnetIDs = new
+	if checkNil {
+		if subnetIDs == nil {
+			subnetIDs = new
+		}
+	} else {
+		subnetIDs = new
+	}
+
 }
 
 // GetSubnetIDs returns a map of subnet IDs.
@@ -180,11 +187,7 @@ var routeTableIds map[string]bool
 func (cp *CloudProvider) ListRoutes(ctx context.Context, clusterName string) ([]*cloudprovider.Route, error) {
 	glog.V(6).Info("Listing Routes: ", clusterName)
 
-	subnetIDMutex.Lock()
-	if subnetIDs == nil {
-		subnetIDs = make(map[string]string)
-	}
-	subnetIDMutex.Unlock()
+	SetSubnetIDs(make(map[string]string), true)
 
 	newRouteTableIds := make(map[string]bool)
 


### PR DESCRIPTION
Support managed routes. When `managedRoutes` in the configuration file is set to true, routeTables will be populated. This is useful when there is no overlay network to do this for us.