### PR TITLE
Enable e2e tests and add canary container builder to CI pipeline.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ manifests/bmcs-config.yaml
 manifests/bmcs-secret.yaml
 vendors.txt
 
+env-old.sh
+config.yaml
+**/*cloudconfig_var.enc
+**/*kubeconfig_var.enc
+
 # vim
 *.sw[op]
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ IMAGE := $(REGISTRY)/$(BIN)
 
 
 BUILD := $(shell git describe --always --dirty)
-# Allow overriding for release versions
+# allow overriding for release versions
 # Else just equal the build (git hash)
 VERSION ?= ${BUILD}
 GOOS ?= linux
@@ -79,6 +79,34 @@ manifests: build-dirs
 .PHONY: test
 test:
 	@./hack/test.sh $(SRC_DIRS)
+
+# Deploys the current version to a specified cluster.
+# Requires binary, manifests, images to be built and pushed. Requires $KUBECONFIG set.
+.PHONY: upgrade
+upgrade:
+	# Upgrade the current CCM to the specified version
+	@./hack/deploy.sh deploy-build-version-ccm
+
+# Deploys the current version to a specified cluster.
+# Requires a 'dist/oci-cloud-controller-manager-rollback.yaml' manifest. Requires $KUBECONFIG set.
+.PHONY: rollback
+rollback:
+	# Rollback the current CCM to the specified version
+	@./hack/deploy.sh rollback-original-ccm
+
+.PHONY: e2e
+e2e:
+	@./hack/test-e2e.sh
+
+# Run the canary tests.
+.PHONY: canary
+canary:
+	@./hack/test-canary.sh
+
+# Validate the generated canary test image.
+.PHONY: validate-canary
+validate-canary:
+	@./hack/validate-canary.sh
 
 .PHONY: clean
 clean:

--- a/ci-docker-images/Dockerfile
+++ b/ci-docker-images/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM oraclelinux:7.4
+
+RUN yum install -y ca-certificates make openssl git jq && yum clean all
+
+# Install golang environment
+RUN curl https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz -O && \
+    mkdir /tools && \
+    tar xzf go1.10.3.linux-amd64.tar.gz -C /tools && \
+    rm go1.10.3.linux-amd64.tar.gz && \
+    mkdir -p /go/bin
+
+ENV PATH=/tools/go/bin:/go/bin:/tools/linux-amd64:$PATH \
+    GOPATH=/go \
+    GOROOT=/tools/go
+
+# Install the kubectl client
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl
+
+# Install Ginkgo
+RUN go get -u github.com/onsi/ginkgo/ginkgo

--- a/ci-docker-images/Makefile
+++ b/ci-docker-images/Makefile
@@ -1,0 +1,34 @@
+# Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OCIRUSERNAME ?= spinnaker/everest-ocir-push 
+OCIREGISTRY ?= iad.ocir.io
+
+IMAGE ?= iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e
+VERSION ?= 1.0.1
+
+.PHONY: build
+build:
+	docker build \
+	  --build-arg=http_proxy \
+	  --build-arg=https_proxy \
+	  -f Dockerfile \
+	  -t ${IMAGE}:${VERSION} \
+	  .
+
+.PHONY: push
+push: build
+	@docker login -u '$(OCIRUSERNAME)' -p '$(OCIRPASSWORD)' $(OCIREGISTRY)
+	docker push $(IMAGE):$(VERSION)
+

--- a/hack/ci-util.sh
+++ b/hack/ci-util.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Utility functions for working with the CCM's Wercker CI.
+
+# Functions *******************************************************************
+#
+
+function _check_var() {
+    local name=$1
+    if [ -z ${!name} ]; then
+        echo "WARNING: '""$name""' is required."
+    fi
+}
+
+# Check the required environnment variables are set when generating a 
+# 'cloud-provider.yaml' file. 
+function _check_vars() {    
+    _check_var OCI_REGION
+    _check_var OCI_TENANCY
+    _check_var OCI_COMPARTMENT
+    _check_var OCI_USER
+    _check_var FINGERPRINT
+    _check_var PRIVATE_KEY
+    _check_var OCI_SUBNET_01 
+    _check_var OCI_SUBNET_02
+}
+
+# Generate a 'cloud-provider.yaml' file for use in CCM deployment and 
+# e2e testing. 
+function generate-cloud-provider-config() {
+    local file=${1:-"./cloud-provider.yaml"}
+    _check_vars 
+    cat > $file <<EOF
+auth:
+  region: $OCI_REGION
+  tenancy: $OCI_TENANCY
+  compartment: $OCI_COMPARTMENT
+  user: $OCI_USER
+  key: |
+    $PRIVATE_KEY
+  fingerprint: $FINGERPRINT
+loadBalancer:
+  disableSecurityListManagement: false
+  subnet1: $OCI_SUBNET_01
+  subnet2: $OCI_SUBNET_02
+EOF
+}
+
+# The Wercker CI platform requires configuration files are base64 encoded.
+function base64_encode() {
+    local input=$1
+    local output=${2:-encoded}
+    cat $input | openssl enc -base64 -A > $output
+}
+
+function base64_decode() {
+    local input=$1
+    local output=${2:-decoded}
+    cat $input | openssl enc -base64 -d -A > $output
+}
+
+# If provided, execute the specified function.
+if [ ! -z "$1" ]; then
+    $1
+else
+    generate-cloud-provider-config
+fi

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+
+# Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Utility functions for managing the version of the CCM running in a Kubernetes
+# cluster.
+# 
+# Functions for deploying the specified version of the CCM in a K8s cluster that 
+# that already has a DaemonSet deployed CCM. The version should be defined by the  
+# environment variable VERSION.
+# 
+# Functions for managing a soft (no-threadsafe) lock on the CCM daemonset to 
+# minimise it being upgraded/downgraded during integration tests.
+#
+# Kubectl configured to point to the required target cluster is required on the 
+# host machine.
+
+
+# The root name of the CCM daemon-set and pods.
+CCM_NAME="oci-cloud-controller-manager"
+# The name of an annotation that can be used to 'lock' the CCM from upgrade/
+# downgrade operations. 
+CCM_LOCK_LABEL="ccm-deployment-lock"
+
+
+# Kubernetes Cluster CCM Functions ********************************************
+#
+
+function get-k8s-api-server() {
+    local res=$(cat $KUBECONFIG | grep 'server:' | awk '{print $2}')
+    echo "${res}" 
+}
+
+function get-k8s-master() {
+    local res=$(kubectl get nodes | grep master | head -n 1 | awk '{print $1}')
+    echo "${res}" 
+}
+
+function get-ccm-ds-image-version() {
+    local res=$(kubectl -n kube-system get ds "${CCM_NAME}" -o=jsonpath="{.spec.template.spec.containers[0].image}")
+    echo "${res}"
+}
+
+function get-ccm-ds-image() {
+    local res=$(get-ccm-ds-image-version | cut -d':' -f 1)
+    echo "${res}"
+}
+
+function get-ccm-ds-version() {
+    local res=$(get-ccm-ds-image-version | cut -d':' -f 2)
+    echo "${res}"
+}
+
+function get-ccm-ds-json() {
+    local res=$(kubectl -n kube-system get ds "${CCM_NAME}" -ojson)
+    echo "${res}"
+}
+
+function get-ccm-pod-name() {
+    local name=$(kubectl -n kube-system get pods | grep oci-cloud-controller-manager | awk '{print $1}')
+    echo "${name}"
+}
+
+function get-ccm-pod-image-version() {
+    local name=$(get-ccm-pod-name)
+    local ready=$(kubectl -n kube-system get pod ${name} -o=jsonpath='{.status.containerStatuses[0].image}')
+    echo "${ready}"
+}
+
+function get-ccm-pod-version() {
+    local res=$(get-ccm-pod-image-version | cut -d':' -f 2)
+    echo "${res}"
+}
+
+function get-ccm-pod-ready() {
+    local name=$(get-ccm-pod-name)
+    local ready=$(kubectl -n kube-system get pod ${name} -o=jsonpath='{.status.containerStatuses[0].ready}')
+    echo "${ready}"
+}
+
+function is-ccm-pod-version-ready() {
+    local version=$1
+    local pod_vsn=$(get-ccm-pod-version)
+    if [ "${version}" = "${pod_vsn}" ]; then
+        echo $(get-ccm-pod-ready)
+    else
+        echo "false"
+    fi
+}
+
+# Wait for the specified ccm pod version to be ready.
+function wait-for-ccm-pod-version-ready() {
+    local version=$1
+    local duration=${2:-60}
+    local sleep=${3:-10}
+    local timeout=$(($(date +%s) + $duration))
+    while [ $(date +%s) -lt $timeout ]; do
+        if [ $(is-ccm-pod-version-ready ${version}) = 'true' ]; then
+            return 0
+        fi
+        sleep ${sleep}
+    done
+    echo "Failed to wait for pod version '${version}' to be ready."
+    exit 1 
+}
+
+# Kubernetes Manifest CCM Functions *******************************************
+#
+
+function get-ccm-manifest-image-version() {
+    local manifest=$1
+    local res=$(cat "${manifest}" | grep image | awk '{print $2}')
+    echo "${res}"
+}
+
+function get-ccm-manifest-image() {
+    local manifest=$1
+    local res=$(get-ccm-manifest-image-version ${manifest} | cut -d':' -f 1)
+    echo "${res}"
+}
+
+function get-ccm-manifest-version() {
+    local manifest=$1
+    local res=$(get-ccm-manifest-image-version ${manifest} | cut -d':' -f 2)
+    echo "${res}"
+}
+
+# Deployment Lock Functions ***************************************************
+#
+
+# NB: The date is used to help auto-release a lock that has been placed.
+function lock-ccm-deployment() {
+    kubectl -n kube-system annotate ds "${CCM_NAME}" "${CCM_LOCK_LABEL}"=$(date +%s)
+}
+
+function unlock-ccm-deployment() {
+    kubectl -n kube-system annotate ds "${CCM_NAME}" "${CCM_LOCK_LABEL}-"
+}
+
+function get-ccm-deployment-lock() {
+    local res=$(kubectl -n kube-system get ds ${CCM_NAME} -ojsonpath="{.metadata.annotations.${CCM_LOCK_LABEL}}")
+    echo "${res}"
+}
+
+function is-ccm-deployment-locked() {
+    local res=$(kubectl -n kube-system get ds ${CCM_NAME} -ojsonpath="{.metadata.annotations.${CCM_LOCK_LABEL}}")
+    if [ -z "${res}" ]; then
+        echo "false"
+    else
+        echo "true"
+    fi
+}
+
+# If the CCM has a lock older than hour; the automatically remove it.
+function auto-release-lock() {
+    local locked=$(get-ccm-deployment-lock)
+    if [ ! -z "${locked}" ]; then
+        local timeout=$((${locked} + 3600)) 
+        local now=$(date +%s)
+        if [ $now -gt $timeout ]; then
+           unlock-ccm-deployment 
+        fi
+    fi
+}
+
+# Wait for the CCM to have no lock present.
+function wait-for-ccm-deployment-permitted() {
+    local duration=${1:-3600}
+    local sleep=${2:-60}
+    local timeout=$(($(date +%s) + $duration))
+    while [ $(date +%s) -lt $timeout ]; do
+        auto-release-lock
+        if [ $(is-ccm-deployment-locked) = 'false' ]; then
+            return 0
+        fi
+        sleep ${sleep}
+    done
+    echo "Failed to wait for ccm to finish running existing ci pipeline tests."
+    exit 1 
+}
+
+# Obtain the deployment lock and ensure that all test namespaces have been cleaned up.
+function obtain-ccm-deployment-lock() {
+    wait-for-ccm-deployment-permitted
+    lock-ccm-deployment
+    ensure-clean-e2e-test-namespace
+}
+
+# Release the deployment lock and ensure that all test namespaces have been cleaned up.
+function release-ccm-deployment-lock() {
+    ensure-clean-e2e-test-namespace
+    unlock-ccm-deployment
+}
+
+# Test clean-up Functions *****************************************************
+#
+
+function ensure-clean-e2e-test-namespace() {
+    local res=$(kubectl get pods --all-namespaces | grep 'cm-e2e-tests-' | awk '{print $1}')
+    if [ ! -z ${res} ]; then
+        cat ${res} | xargs kubectl delete ns
+    fi
+}
+
+# Deploy CCM Functions ********************************************************
+#
+
+# Upgrade an already deployed CCM to the specified $VERSION.
+function deploy-build-version-ccm() {
+    local hack_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd)
+    local dist_dir=$(dirname "${hack_dir}")/dist
+    local build_version_manifest="${dist_dir}/oci-cloud-controller-manager.yaml"
+    local rollback_manifest="${dist_dir}/oci-cloud-controller-manager-rollback.yaml"
+
+    local version=$(cat ${dist_dir}/VERSION.txt)
+    local build_version_image=$(get-ccm-manifest-image ${build_version_manifest}) 
+    local build_version=$(get-ccm-manifest-version ${build_version_manifest})
+    local rollback_image=$(get-ccm-ds-image) 
+    local rollback_version=$(get-ccm-ds-version)
+
+    # Wait for there to be no lock on CCM deployment; then take the lock. 
+    # NB: Not threadsafe, but, better then nothing...
+    obtain-ccm-deployment-lock
+
+    # Generate a rollback CCM daemon-set manifest.
+    sed s#${rollback_image}:.*#${rollback_image}:${rollback_version}#g < ${build_version_manifest} > ${rollback_manifest}
+    
+    # Apply the build daemon-set manifest.
+    echo "deploying test '${version}' CCM '${build_version_image}:${build_version}' to cluster '$(get-k8s-master)'."
+    kubectl apply -f ${build_version_manifest}
+    
+    # Wait for CCM to be ready...
+    wait-for-ccm-pod-version-ready "${build_version}" 
+    
+    # Display Info
+    echo "currently deployed CCM daemon-set version: $(get-ccm-ds-image-version)"
+    echo "currently deployed CCM pod version       : $(get-ccm-pod-image-version)"
+    echo "currently deployed CCM pod ready state   : $(get-ccm-pod-ready)"
+}
+
+# Rollback to the CCM version the cluster originally used before it was upgraded.
+function rollback-original-ccm() {
+    local hack_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd)
+    local dist_dir=$(dirname "${hack_dir}")/dist
+    local build_version_manifest="${dist_dir}/oci-cloud-controller-manager.yaml"
+    local rollback_manifest="${dist_dir}/oci-cloud-controller-manager-rollback.yaml"
+    local rollback_image=$(get-ccm-manifest-image ${rollback_manifest}) 
+    local rollback_version=$(get-ccm-manifest-version ${rollback_manifest})
+
+    # Check the rollback manifest exists.
+    if [ ! -f ${rollback_manifest} ]; then
+        echo "the rollback manifest '${rollback_manifest}' did not exist."
+        exit 1
+    fi
+    
+    # Apply original CCM daemon-set manifest.
+    echo "rolling back CCM '${rollback_image}:${rollback_version}' to cluster '$(get-k8s-master)'."
+    kubectl apply -f ${rollback_manifest}
+    
+    # Wait for CCM to be ready after rollback...
+    wait-for-ccm-pod-version-ready "${rollback_version}" 
+    
+    # Display Info
+    echo "currently deployed CCM daemon-set version: $(get-ccm-ds-image-version)"
+    echo "currently deployed CCM pod version       : $(get-ccm-pod-image-version)"
+    echo "currently deployed CCM pod ready state   : $(get-ccm-pod-ready)"
+
+    # Release the lock on the CCM deployment mechanism.
+    release-ccm-deployment-lock
+}
+
+
+# Main ************************************************************************
+#
+
+if [ -z "${KUBECONFIG}" ]; then
+    if [ -z "${KUBECONFIG_VAR}" ]; then
+        echo "KUBECONFIG or KUBECONFIG_VAR must be set"
+        exit 1
+    else
+        # NB: Wercker environment variables are base64 encoded.
+        echo "$KUBECONFIG_VAR" | openssl enc -base64 -d -A > /tmp/kubeconfig
+        export KUBECONFIG=/tmp/kubeconfig
+    fi
+fi
+
+# If provided, execute the specified function.
+if [ ! -z "$1" ]; then
+    $1
+fi
+
+exit $?

--- a/hack/test-canary.sh
+++ b/hack/test-canary.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A small script to run the CCM ginkgo 'Canary' e2e tests, and, generate the 
+# defined canary test response file.
+#
+# https://confluence.oci.oraclecorp.com/display/BRISTOL/OKE+Canary+Test+Image+Contract
+
+# Functions *******************************************************************
+#
+
+function now() {
+    echo $(date +"%Y-%m-%d-%H%M%S") 
+}
+
+# Run the e2e [Canary] tests to produce a gingko result log.
+function run_canary_tests() {
+    echo "Running canary tests ..."
+    ginkgo -v -progress -noColor=true \
+        -focus "\[Canary\]" \
+        test/e2e \
+        -- --kubeconfig=${KUBECONFIG} --delete-namespace=false \
+        2>&1 | tee "${TEST_LOG}"
+}
+
+# Extract a {PASSED|FAILED|UNKNOWN} response from a Gingko test log based 
+# on the specified 'test_matcher'.
+function extract_result() {
+    local test_matcher=$1
+    local result=$(cat "${TEST_LOG}" | grep "${test_matcher}" | tail -n 1 | cut -d ' ' -f 1)
+    if [ "${result}" = [Fail] ]; then
+        echo "0"
+    else
+        local passed=$(tail -n 1 "${TEST_LOG}")
+        if [ "${passed}" = 'Test Suite Passed' ]; then 
+            echo "1"
+        else
+            echo "0"
+        fi
+    fi
+}
+
+# Initialise the result file.
+function init_results() {
+    local metrics_dir="$(dirname ${METRICS_FILE})"
+    mkdir -p "${metrics_dir}" 
+    echo "Initialising result file: ${METRICS_FILE}"
+    cat > "${METRICS_FILE}" <<EOF
+{
+    "start_time": "${START}"
+}
+EOF
+}
+
+# A set of test_matcher strings that must match the appropriate gingko test 
+# descriptions. These are used to extract the required test results.
+CREATE_LB_TEST="\[It\] \[Canary\] should be possible to create and mutate a Service type:LoadBalancer"
+# Creates a JSON result file for the specified [Canary] tests to be extracted.
+function create_results() {
+    local metrics_dir="$(dirname ${METRICS_FILE})"
+    mkdir -p "${metrics_dir}" 
+    echo "Creating result file: ${METRICS_FILE}"
+    cat > "${METRICS_FILE}" <<EOF
+{
+    "start_time": "${START}"
+    "create_lb": "$(_extract_result ${CREATE_LB_TEST})"
+    "end_time": "$(now)"
+}
+EOF
+}
+
+# Run the tests and extract the results
+function run() {
+    init_results
+    cat "${METRICS_FILE}" 
+    run_canary_tests
+    if [ ! -z "${METRICS_FILE}" ]; then
+        create_results
+        cat "${METRICS_FILE}" 
+    fi
+}
+
+# Helper function to clean up log and json files.
+function clean() {
+    kubectl get pods --all-namespaces | grep ccm | awk '{print $1}' | xargs kubectl delete ns
+    rm "${TEST_DIR}/${TEST_PREFIX}*"
+}
+
+# Main ************************************************************************
+#
+
+if [ -z "${KUBECONFIG}" ]; then
+    if [ -z "${KUBECONFIG_VAR}" ]; then
+        echo "KUBECONFIG or KUBECONFIG_VAR must be set"
+        exit 1
+    else
+        # NB: Wercker environment variables are base64 encoded.
+        echo "$KUBECONFIG_VAR" | openssl enc -base64 -d -A > /tmp/kubeconfig
+        export KUBECONFIG=/tmp/kubeconfig
+    fi
+fi
+
+START=$(now)
+
+TEST_ID=""
+if [ "${UNIQUE_TEST_ID}" = true ]; then
+    TEST_ID="-$(date +"%Y-%m-%d-%H%M%S")"
+fi
+
+if [ -z "${TEST_DIR}" ]; then
+    TEST_DIR="/tmp"
+fi
+mkdir -p "${TEST_DIR}" 
+
+TEST_PREFIX="oci-ccm-canary-test"
+TEST_LOG="${TEST_DIR}/${TEST_PREFIX}${TEST_ID}.log"
+
+# If provided, execute the specified function.
+if [ ! -z "$1" ]; then
+  $1
+else 
+    run
+fi
+
+exit $?

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# should be possible to create and mutate a Service type:LoadBalancer"
+
+# Functions *******************************************************************
+#
+
+function run_e2e_tests() {
+    echo "Running e2e tests..."
+    # Just run the canary for now... we are limite don loadbalancers.
+    ginkgo -v -progress \
+        -focus "\[Canary\]" \
+        test/e2e \
+        -- --kubeconfig=${KUBECONFIG} --cloud-config=${CLOUDCONFIG} --delete-namespace=false
+}
+
+# Main ************************************************************************
+#
+
+if [ -z "${KUBECONFIG}" ]; then
+    if [ -z "${KUBECONFIG_VAR}" ]; then
+        echo "KUBECONFIG or KUBECONFIG_VAR must be set"
+        exit 1
+    else
+        # NB: Wercker environment variables are base64 encoded.
+        echo "$KUBECONFIG_VAR" | openssl enc -base64 -d -A > /tmp/kubeconfig
+        export KUBECONFIG=/tmp/kubeconfig
+    fi
+fi
+
+if [ -z "${CLOUDCONFIG}" ]; then
+    if [ -z "${CLOUDCONFIG_VAR}" ]; then
+        echo "CLOUDCONFIG or CLOUDCONFIG_VAR must be set"
+        exit 1
+    else
+        # NB: Wercker environment variables are base64 encoded.
+        echo "$CLOUDCONFIG_VAR" | openssl enc -base64 -d -A > /tmp/cloudconfig
+        export CLOUDCONFIG=/tmp/cloudconfig
+    fi
+fi
+
+run_e2e_tests
+
+exit $?
+
+

--- a/hack/validate-canary.sh
+++ b/hack/validate-canary.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# Copyright 2017 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# A small script to validate the CCM 'Canary' test image works as expected. 
+#
+# https://confluence.oci.oraclecorp.com/display/BRISTOL/OKE+Canary+Test+Image+Contract
+
+
+# Helper Functions ************************************************************
+#
+
+function get-pod-status() {
+    local res=$(kubectl get pod oci-cloud-controller-manager-canary --show-all -ojsonpath="{.status.phase}" 2> /dev/null)
+    echo "${res}"
+}
+
+# Wait for the CCM canary test pod to reach the specified state within the timeout period. 
+function wait-for-canary-pod-state() {
+    local state=${1:-"Running"}
+    local duration=${2:-60}
+    local sleep=${3:-0.5}
+    local timeout=$(($(date +%s) + $duration))
+    while [ $(date +%s) -lt $timeout ]; do
+        local current=$(get-pod-status) 
+        echo "waiting for pod oci-cloud-controller-manager-canary state '${state}', currently '${current}'."
+        if [ "${current}" = "${state}" ]; then
+            return 0
+        fi
+        sleep ${sleep}
+    done
+    echo "Failed to wait for oci-cloud-controller-manager-canary state: '${state}'."
+    exit 1
+} 
+
+# Clean up the CCM canary test pods and associated manifest resources.
+function clean-canary() {
+    local hack_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd)
+    local dist_dir=$(dirname "${hack_dir}")/dist
+    local canary_manifest=${dist_dir}/validate-canary-pod.yaml
+    local status=$(get-pod-status) # 'Completed' if finished.
+    if [ ! -z "${status}" ]; then
+        kubectl delete pod oci-cloud-controller-manager-canary
+        rm -f ${canary_manifest} 
+    fi
+}
+
+function get-logs() {
+    local type=$1
+    kubectl logs oci-cloud-controller-manager-canary -c oci-cloud-controller-manager-canary-${type}
+}
+
+function get-test-runner-logs() {
+    get-logs test-runner
+}
+
+function get-test-reporter-logs() {
+    get-logs test-reporter
+}
+
+function ensure-cluster-docker-pull-secrets() {
+    kubectl create secret docker-registry ocir \
+        --docker-server="${OCIREGISTRY}" \
+        --docker-username="${OCIRUSERNAME}" \
+        --docker-password="${OCIRPASSWORD}" \
+        --docker-email="user@example.com"
+}
+
+# Shell into the specified canary image via Docker. Useful for debugging the container.
+# NB: May have proxy issues for some tests.
+function local-docker-mode() {
+    local image="iad.ocir.io/oracle/oci-cloud-controller-manager-canary"
+    local version="${VERSION}"
+    local cid=$(docker run -d -e KUBECONFIG_VAR=$(cat ${KUBECONFIG} | openssl enc -base64 -A) ${image}:${version})
+    docker exec -it ${cid} /bin/bash
+}
+
+
+# Test Functions **************************************************************
+#
+
+function generate-canary-manifest() {
+    local hack_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd)
+    local dist_dir=$(dirname "${hack_dir}")/dist
+    local canary_manifest=${dist_dir}/validate-canary-pod.yaml
+    local version=${VERSION}
+    rm -f "${canary_manifest}" 
+    cat > "${canary_manifest}" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oci-cloud-controller-manager-canary
+spec:
+  containers:
+  - name: oci-cloud-controller-manager-canary-test-runner
+    image: iad.ocir.io/oracle/oci-cloud-controller-manager-canary:${version}
+    command: ["/bin/bash"]
+    args: ["-ec", "make canary"]
+    env:
+      - name: METRICS_FILE
+        value: /metrics/output.json
+      - name: KUBECONFIG_VAR
+        value: $(cat ${KUBECONFIG} | openssl enc -base64 -A)
+    volumeMounts:
+    - mountPath: /metrics
+      name: metrics-volume
+ 
+  - name: oci-cloud-controller-manager-canary-test-reporter
+    image: iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e:1.0.1
+    command: ["/bin/bash"]
+    args: ["-ec", "touch \$METRICS_FILE; while [ -z \$(cat \$METRICS_FILE | grep 'end_time' | cut -d':' -f 1) ]; do sleep 1;  done; cat \$METRICS_FILE"]
+    env:
+      - name: METRICS_FILE
+        value: /metrics/output.json
+    volumeMounts:
+    - mountPath: /metrics
+      name: metrics-volume
+  
+  imagePullSecrets:
+  - name: ocir
+ 
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  restartPolicy: Never
+EOF
+}
+
+function deploy-canary() {
+    local hack_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd)
+    local dist_dir=$(dirname "${hack_dir}")/dist
+    local canary_manifest=${dist_dir}/validate-canary-pod.yaml
+    kubectl apply -f ${canary_manifest} > /dev/null
+    wait-for-canary-pod-state
+}
+
+function run() {
+    # Start a new canary.
+    clean-canary
+    generate-canary-manifest
+    deploy-canary
+    # Tail the logs of the reporter to block until it completes. The report only logs the result file.
+    res=$(kubectl logs -f oci-cloud-controller-manager-canary -c oci-cloud-controller-manager-canary-test-reporter)
+    # Display the results.
+    echo "${res}"
+    # Grep the log to return an error code.
+    error=$(echo "${res}" | grep 'end_time' | cut -d':' -f 1)
+    if [ -z ${error} ]; then
+        exit 1
+    else
+        exit 0
+    fi
+}
+
+# Main ************************************************************************
+#
+
+if [ -z "${KUBECONFIG}" ]; then
+    if [ -z "${KUBECONFIG_VAR}" ]; then
+        echo "KUBECONFIG or KUBECONFIG_VAR must be set"
+        exit 1
+    else
+        # NB: Wercker environment variables are base64 encoded.
+        echo "$KUBECONFIG_VAR" | openssl enc -base64 -d -A > /tmp/kubeconfig
+        export KUBECONFIG=/tmp/kubeconfig
+    fi
+fi
+if [ -z "${VERSION}" ]; then
+    echo "The VERSION must be set"
+    exit 1
+fi
+
+# If provided, execute the specified function.
+if [ ! -z "$1" ]; then
+    $1
+    exit "$?"
+else
+    run
+fi

--- a/test/e2e/load_balancer.go
+++ b/test/e2e/load_balancer.go
@@ -38,7 +38,7 @@ import (
 var _ = Describe("Service [Slow]", func() {
 	f := framework.NewDefaultFramework("service")
 
-	It("should be possible to create and mutate a Service type:LoadBalancer", func() {
+	It("should be possible to create and mutate a Service type:LoadBalancer [Canary]", func() {
 		serviceName := "basic-lb-test"
 		ns := f.Namespace.Name
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,7 +5,6 @@ dev:
 build:
   base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
   steps:
-
     - script:
       name: check boilerplate
       code: ./hack/verify-boilerplate.sh
@@ -42,12 +41,26 @@ build:
         make version > dist/VERSION.txt
         cat dist/VERSION.txt
 
+
 copy:
   steps:
     - script:
       name: copy output
       code: |
         cp -a dist/* ${WERCKER_OUTPUT_DIR}
+    
+    - script:
+      name: copy e2e test artifacts
+      code: |
+        cp -R .git ${WERCKER_OUTPUT_DIR}/
+        cp Makefile ${WERCKER_OUTPUT_DIR}/
+        cp -R cmd ${WERCKER_OUTPUT_DIR}/
+        cp -R dist ${WERCKER_OUTPUT_DIR}/
+        cp -R hack ${WERCKER_OUTPUT_DIR}/
+        cp -R pkg ${WERCKER_OUTPUT_DIR}/
+        cp -R test ${WERCKER_OUTPUT_DIR}/
+        cp -R vendor ${WERCKER_OUTPUT_DIR}/
+
 
 push:
   box:
@@ -109,10 +122,92 @@ push:
         username: $OCIRUSERNAME
         password: $OCIRPASSWORD
 
+
+e2e-test:
+  base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
+  box:
+    id: iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e:1.0.0
+    registry: https://iad.ocir.io/v2
+    username: $OCIRUSERNAME
+    password: $OCIRPASSWORD
+  steps:
+    - script:
+      name: set ENV vars
+      code: |
+        export VERSION=$(cat VERSION.txt)
+        echo "${VERSION}"
+
+    - script:
+      name: deploy latest CCM
+      code: make upgrade
+        
+    - script:
+      name: e2e default tests
+      code: make e2e
+
+  after-steps:
+    - script:
+      name: rollback original CCM
+      code: make rollback
+
+
+
+push-canary:
+  base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
+  box:
+    id: iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e:1.0.1
+    registry: https://iad.ocir.io/v2
+    username: $OCIRUSERNAME
+    password: $OCIRPASSWORD
+  steps:
+    - script:
+      name: set ENV vars
+      code: |
+        export VERSION=$(cat dist/VERSION.txt)
+        echo "Pushing test version ${VERSION}"
+
+    - internal/docker-push:
+      repository: iad.ocir.io/oracle/oci-cloud-controller-manager-canary
+      tag: $VERSION
+      working-dir: /go/src/github.com/oracle/oci-cloud-controller-manager/ 
+      entrypoint: make canary
+      registry: https://iad.ocir.io/v2
+      username: $OCIRUSERNAME
+      password: $OCIRPASSWORD
+
+
+validate-canary:
+  box:
+    id: iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e:1.0.1
+    registry: https://iad.ocir.io/v2
+    username: $OCIRUSERNAME
+    password: $OCIRPASSWORD
+  steps:
+    - script:
+      name: set ENV vars
+      code: |
+        export VERSION=$(cat VERSION.txt)
+        echo "Canary image version ${VERSION}"
+
+    - script:
+      name: deploy latest CCM
+      code: make upgrade
+        
+    - script:
+      name: validate canary tests
+      code: make validate-canary
+      
+  after-steps:
+    - script:
+      name: rollback original CCM
+      code: make rollback
+
+
 release:
   box:
     id: oraclelinux:7-slim
   steps:
+  
     - script:
         name: set ENV vars
         code: |


### PR DESCRIPTION
1. Enables e2e testing in the CI pipeline. Currently, the number of e2e tests have been restricted to one: 'should be possible to create and mutate a Service type:LoadBalancer'. It is assumed the others can be enabled at a later date.

2. Enables the creation and testing of a 'canary' container that tests the CCM creation of a load-balanced service. The canary image version is inter-linked with the CCM version. The validation test of the canary test is based on the canary container specification.

3. In order to execute in a timely manner both the e2e and canary test are configured to execute against a pre-existing kubernetes cluster. Soft primitives for upgrading/downgrading CCM versions and locking this functionality are present.