### PR TITLE
Improvements to deploy and rollback functions.

### DIFF
--- a/hack/test-canary.sh
+++ b/hack/test-canary.sh
@@ -67,7 +67,7 @@ EOF
 
 # A set of test_matcher strings that must match the appropriate gingko test 
 # descriptions. These are used to extract the required test results.
-CREATE_LB_TEST="\[It\] \[Canary\] should be possible to create and mutate a Service type:LoadBalancer"
+CREATE_LB_TEST="\[It\] should be possible to create and mutate a Service type:LoadBalancer \[Canary\]"
 # Creates a JSON result file for the specified [Canary] tests to be extracted.
 function create_results() {
     local metrics_dir="$(dirname ${METRICS_FILE})"
@@ -76,7 +76,7 @@ function create_results() {
     cat > "${METRICS_FILE}" <<EOF
 {
     "start_time": "${START}"
-    "create_lb": "$(_extract_result ${CREATE_LB_TEST})"
+    "create_lb": "$(extract_result ${CREATE_LB_TEST})"
     "end_time": "$(now)"
 }
 EOF

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,6 @@
 box: golang:1.9
+no-response-timeout: 30
+command-timeout: 30
 dev:
   steps:
     - internal/shell
@@ -8,7 +10,7 @@ build:
     - script:
       name: check boilerplate
       code: ./hack/verify-boilerplate.sh
-
+  
     - script:
       name: go fmt
       code: make gofmt
@@ -48,7 +50,7 @@ copy:
       name: copy output
       code: |
         cp -a dist/* ${WERCKER_OUTPUT_DIR}
-    
+
     - script:
       name: copy e2e test artifacts
       code: |
@@ -140,7 +142,7 @@ e2e-test:
     - script:
       name: deploy latest CCM
       code: make upgrade
-        
+
     - script:
       name: e2e default tests
       code: make e2e
@@ -169,7 +171,7 @@ push-canary:
     - internal/docker-push:
       repository: iad.ocir.io/oracle/oci-cloud-controller-manager-canary
       tag: $VERSION
-      working-dir: /go/src/github.com/oracle/oci-cloud-controller-manager/ 
+      working-dir: /go/src/github.com/oracle/oci-cloud-controller-manager/
       entrypoint: make canary
       registry: https://iad.ocir.io/v2
       username: $OCIRUSERNAME
@@ -192,11 +194,11 @@ validate-canary:
     - script:
       name: deploy latest CCM
       code: make upgrade
-        
+
     - script:
       name: validate canary tests
       code: make validate-canary
-      
+
   after-steps:
     - script:
       name: rollback original CCM


### PR DESCRIPTION
1. Changes rollback mechanism to always use the last release on github.
2. Always deletes all 'e2e-test-' test namespaces when rolling back.
3. Always remove the lock annotation when rolling back.
4. Improves output by logging status when waiting to upgrade/rollback CCM.
5. Minor bug fixes.