### PR TITLE
Support configuration of security list management modes as LB service annotation

### DIFF
--- a/hack/test-canary.sh
+++ b/hack/test-canary.sh
@@ -67,7 +67,7 @@ EOF
 
 # A set of test_matcher strings that must match the appropriate gingko test 
 # descriptions. These are used to extract the required test results.
-CREATE_LB_TEST="\[It\] \[Canary\] should be possible to create and mutate a Service type:LoadBalancer"
+CREATE_LB_TEST="\[It\] should be possible to create and mutate a Service type:LoadBalancer \[Canary\]"
 # Creates a JSON result file for the specified [Canary] tests to be extracted.
 function create_results() {
     local metrics_dir="$(dirname ${METRICS_FILE})"
@@ -76,7 +76,7 @@ function create_results() {
     cat > "${METRICS_FILE}" <<EOF
 {
     "start_time": "${START}"
-    "create_lb": "$(_extract_result ${CREATE_LB_TEST})"
+    "create_lb": "$(extract_result ${CREATE_LB_TEST})"
     "end_time": "$(now)"
 }
 EOF

--- a/pkg/oci/ccm.go
+++ b/pkg/oci/ccm.go
@@ -131,6 +131,7 @@ func (cp *CloudProvider) Initialize(clientBuilder controller.ControllerClientBui
 	go nodeInformer.Informer().Run(wait.NeverStop)
 	serviceInformer := factory.Core().V1().Services()
 	go serviceInformer.Informer().Run(wait.NeverStop)
+
 	glog.Info("Waiting for node informer cache to sync")
 	if !cache.WaitForCacheSync(wait.NeverStop, nodeInformer.Informer().HasSynced, serviceInformer.Informer().HasSynced) {
 		utilruntime.HandleError(fmt.Errorf("Timed out waiting for informers to sync"))

--- a/pkg/oci/load_balancer.go
+++ b/pkg/oci/load_balancer.go
@@ -67,8 +67,8 @@ const (
 	// on the service to specify the idle connection timeout.
 	ServiceAnnotationLoadBalancerConnectionIdleTimeout = "service.beta.kubernetes.io/oci-load-balancer-connection-idle-timeout"
 
-	//ServiceAnnotaionLoadBalancerSecurityListManagementMode is a Service annotation for
-	//specifying the security list managment mode ("All","Frontend","None") that configures how security lists are managed by the CCM
+	// ServiceAnnotaionLoadBalancerSecurityListManagementMode is a Service annotation for
+	// specifying the security list managment mode ("All", "Frontend", "None") that configures how security lists are managed by the CCM
 	ServiceAnnotaionLoadBalancerSecurityListManagementMode = "service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode"
 )
 
@@ -246,7 +246,7 @@ func (cp *CloudProvider) createLoadBalancer(ctx context.Context, spec *LBSpec) (
 	}
 
 	for _, ports := range spec.Ports {
-		if err = spec.SecurityListManager.Update(ctx, lbSubnets, nodeSubnets, spec.SourceCIDRs, nil, ports); err != nil {
+		if err = spec.securityListManager.Update(ctx, lbSubnets, nodeSubnets, spec.SourceCIDRs, nil, ports); err != nil {
 			return nil, err
 		}
 	}
@@ -368,7 +368,7 @@ func (cp *CloudProvider) updateLoadBalancer(ctx context.Context, lb *loadbalance
 	for _, action := range actions {
 		switch a := action.(type) {
 		case *BackendSetAction:
-			err := cp.updateBackendSet(ctx, lbID, a, lbSubnets, nodeSubnets, spec.SecurityListManager)
+			err := cp.updateBackendSet(ctx, lbID, a, lbSubnets, nodeSubnets, spec.securityListManager)
 			if err != nil {
 				return errors.Wrap(err, "updating BackendSet")
 			}
@@ -385,7 +385,7 @@ func (cp *CloudProvider) updateLoadBalancer(ctx context.Context, lb *loadbalance
 				ports = spec.Ports[backendSetName]
 			}
 
-			err := cp.updateListener(ctx, lbID, a, ports, lbSubnets, nodeSubnets, spec.SourceCIDRs, spec.SecurityListManager)
+			err := cp.updateListener(ctx, lbID, a, ports, lbSubnets, nodeSubnets, spec.SourceCIDRs, spec.securityListManager)
 			if err != nil {
 				return errors.Wrap(err, "updating listener")
 			}

--- a/pkg/oci/load_balancer.go
+++ b/pkg/oci/load_balancer.go
@@ -58,7 +58,7 @@ const (
 	ServiceAnnotationLoadBalancerSSLPorts = "service.beta.kubernetes.io/oci-load-balancer-ssl-ports"
 
 	// ServiceAnnotationLoadBalancerTLSSecret is a Service annotation for
-	// specifying the TLS secret ti install on the load balancer listeners which
+	// specifying the TLS secret to install on the load balancer listeners which
 	// have SSL enabled.
 	// See: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
 	ServiceAnnotationLoadBalancerTLSSecret = "service.beta.kubernetes.io/oci-load-balancer-tls-secret"
@@ -68,7 +68,7 @@ const (
 	ServiceAnnotationLoadBalancerConnectionIdleTimeout = "service.beta.kubernetes.io/oci-load-balancer-connection-idle-timeout"
 
 	//ServiceAnnotaionLoadBalancerSecurityListManagementMode is a Service annotation for
-	//specifying the security list managment mode ("All","Frontend",None) configures how security lists are managed by the CCM
+	//specifying the security list managment mode ("All","Frontend","None") that configures how security lists are managed by the CCM
 	ServiceAnnotaionLoadBalancerSecurityListManagementMode = "service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode"
 )
 

--- a/pkg/oci/load_balancer_security_lists.go
+++ b/pkg/oci/load_balancer_security_lists.go
@@ -82,6 +82,8 @@ type baseSecurityListManager struct {
 	securityLists map[string]string
 }
 
+type securityListManagerFactory func(mode string) securityListManager
+
 func newSecurityListManager(client client.Interface, serviceInformer informersv1.ServiceInformer, securityLists map[string]string, mode string) securityListManager {
 	if securityLists == nil {
 		securityLists = make(map[string]string)

--- a/pkg/oci/load_balancer_spec.go
+++ b/pkg/oci/load_balancer_spec.go
@@ -135,6 +135,8 @@ func NewLBSpec(svc *v1.Service, nodes []*v1.Node, defaultSubnets []string, sslCf
 		return nil, err
 	}
 
+	//A security list manager will be configured based on the annotation specified when creating the service,
+	//if an annotation is not specified, then the mode specified in cloud provider config file is used.
 	slManagerSpec := secListFactory(svc.Annotations[ServiceAnnotaionLoadBalancerSecurityListManagementMode])
 
 	return &LBSpec{

--- a/pkg/oci/load_balancer_spec.go
+++ b/pkg/oci/load_balancer_spec.go
@@ -77,7 +77,7 @@ type LBSpec struct {
 	Ports               map[string]portSpec
 	SourceCIDRs         []string
 	SSLConfig           *SSLConfig
-	SecurityListManager securityListManager
+	securityListManager securityListManager
 
 	service *v1.Service
 	nodes   []*v1.Node
@@ -135,10 +135,6 @@ func NewLBSpec(svc *v1.Service, nodes []*v1.Node, defaultSubnets []string, sslCf
 		return nil, err
 	}
 
-	//A security list manager will be configured based on the annotation specified when creating the service,
-	//if an annotation is not specified, then the mode specified in cloud provider config file is used.
-	slManagerSpec := secListFactory(svc.Annotations[ServiceAnnotaionLoadBalancerSecurityListManagementMode])
-
 	return &LBSpec{
 		Name:        GetLoadBalancerName(svc),
 		Shape:       shape,
@@ -151,9 +147,10 @@ func NewLBSpec(svc *v1.Service, nodes []*v1.Node, defaultSubnets []string, sslCf
 		SSLConfig:   sslCfg,
 		SourceCIDRs: sourceCIDRs,
 
-		service:             svc,
-		nodes:               nodes,
-		SecurityListManager: slManagerSpec,
+		service: svc,
+		nodes:   nodes,
+		securityListManager: secListFactory(
+			svc.Annotations[ServiceAnnotaionLoadBalancerSecurityListManagementMode]),
 	}, nil
 }
 

--- a/pkg/oci/load_balancer_spec_test.go
+++ b/pkg/oci/load_balancer_spec_test.go
@@ -83,7 +83,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				SecurityListManager: newSecurityListManagerNOOP(),
+				securityListManager: newSecurityListManagerNOOP(),
 			},
 		},
 		"internal": {
@@ -138,7 +138,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				SecurityListManager: newSecurityListManagerNOOP(),
+				securityListManager: newSecurityListManagerNOOP(),
 			},
 		},
 		"subnet annotations": {
@@ -194,10 +194,9 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				SecurityListManager: newSecurityListManagerNOOP(),
+				securityListManager: newSecurityListManagerNOOP(),
 			},
 		},
-		//"security list manager annotation":
 		"custom shape": {
 			defaultSubnetOne: "one",
 			defaultSubnetTwo: "two",
@@ -250,7 +249,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				SecurityListManager: newSecurityListManagerNOOP(),
+				securityListManager: newSecurityListManagerNOOP(),
 			},
 		},
 		"custom idle connection timeout": {
@@ -308,7 +307,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				SecurityListManager: newSecurityListManagerNOOP(),
+				securityListManager: newSecurityListManagerNOOP(),
 			},
 		},
 	}
@@ -318,7 +317,6 @@ func TestNewLBSpecSuccess(t *testing.T) {
 			// we expect the service to be unchanged
 			tc.expected.service = tc.service
 			subnets := []string{tc.defaultSubnetOne, tc.defaultSubnetTwo}
-			//reference default cp added
 			slManagerFactory := func(mode string) securityListManager {
 				return newSecurityListManagerNOOP()
 			}
@@ -340,8 +338,7 @@ func TestNewLBSpecFailure(t *testing.T) {
 		defaultSubnetTwo string
 		nodes            []*v1.Node
 		service          *v1.Service
-		//add cp or cp security list
-		expectedErrMsg string
+		expectedErrMsg   string
 	}{
 		"unsupported udp protocol": {
 			service: &v1.Service{
@@ -426,7 +423,6 @@ func TestNewLBSpecFailure(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					SessionAffinity: v1.ServiceAffinityNone,
 					Ports:           []v1.ServicePort{},
-					//add security list mananger in spec
 				},
 			},
 			expectedErrMsg: "a configuration for subnet1 must be specified for an internal load balancer",

--- a/pkg/oci/load_balancer_spec_test.go
+++ b/pkg/oci/load_balancer_spec_test.go
@@ -31,7 +31,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 		defaultSubnetTwo string
 		nodes            []*v1.Node
 		service          *v1.Service
-		expected         *LBSpec
+		//add cp or just cp security list manager
+		expected *LBSpec
 	}{
 		"defaults": {
 			defaultSubnetOne: "one",
@@ -83,6 +84,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
+				//Need to add security list manager to spec here
 			},
 		},
 		"internal": {
@@ -137,6 +139,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
+				//Need to add security list manager to spec here
 			},
 		},
 		"subnet annotations": {
@@ -192,6 +195,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
+				//Need to add security list manager to spec here
 			},
 		},
 		"custom shape": {
@@ -246,6 +250,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
+				//Need to add security list manager to spec here
 			},
 		},
 		"custom idle connection timeout": {
@@ -303,6 +308,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
+				//Need to add security list manager to spec here
 			},
 		},
 	}
@@ -312,6 +318,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 			// we expect the service to be unchanged
 			tc.expected.service = tc.service
 			subnets := []string{tc.defaultSubnetOne, tc.defaultSubnetTwo}
+			//reference default cp added
 			result, err := NewLBSpec(tc.service, tc.nodes, subnets, nil)
 			if err != nil {
 				t.Error(err)
@@ -330,7 +337,8 @@ func TestNewLBSpecFailure(t *testing.T) {
 		defaultSubnetTwo string
 		nodes            []*v1.Node
 		service          *v1.Service
-		expectedErrMsg   string
+		//add cp or cp security list
+		expectedErrMsg string
 	}{
 		"unsupported udp protocol": {
 			service: &v1.Service{
@@ -415,6 +423,7 @@ func TestNewLBSpecFailure(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					SessionAffinity: v1.ServiceAffinityNone,
 					Ports:           []v1.ServicePort{},
+					//add security list mananger in spec
 				},
 			},
 			expectedErrMsg: "a configuration for subnet1 must be specified for an internal load balancer",
@@ -424,6 +433,7 @@ func TestNewLBSpecFailure(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			subnets := []string{tc.defaultSubnetOne, tc.defaultSubnetTwo}
+			//cp or cp.security list to be passed in NewLBSpec
 			_, err := NewLBSpec(tc.service, tc.nodes, subnets, nil)
 			if err == nil || err.Error() != tc.expectedErrMsg {
 				t.Errorf("Expected error with message %q but got %q", tc.expectedErrMsg, err)

--- a/pkg/oci/load_balancer_spec_test.go
+++ b/pkg/oci/load_balancer_spec_test.go
@@ -31,8 +31,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 		defaultSubnetTwo string
 		nodes            []*v1.Node
 		service          *v1.Service
-		//add cp or just cp security list manager
-		expected *LBSpec
+		expected         *LBSpec
 	}{
 		"defaults": {
 			defaultSubnetOne: "one",
@@ -84,7 +83,6 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				//Need to add security list manager to spec here
 			},
 		},
 		"internal": {
@@ -319,7 +317,10 @@ func TestNewLBSpecSuccess(t *testing.T) {
 			tc.expected.service = tc.service
 			subnets := []string{tc.defaultSubnetOne, tc.defaultSubnetTwo}
 			//reference default cp added
-			result, err := NewLBSpec(tc.service, tc.nodes, subnets, nil)
+			slManagerFactory := func(mode string) securityListManager {
+				return newSecurityListManagerNOOP()
+			}
+			result, err := NewLBSpec(tc.service, tc.nodes, subnets, nil, slManagerFactory)
 			if err != nil {
 				t.Error(err)
 			}
@@ -433,8 +434,10 @@ func TestNewLBSpecFailure(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			subnets := []string{tc.defaultSubnetOne, tc.defaultSubnetTwo}
-			//cp or cp.security list to be passed in NewLBSpec
-			_, err := NewLBSpec(tc.service, tc.nodes, subnets, nil)
+			slManagerFactory := func(mode string) securityListManager {
+				return newSecurityListManagerNOOP()
+			}
+			_, err := NewLBSpec(tc.service, tc.nodes, subnets, nil, slManagerFactory)
 			if err == nil || err.Error() != tc.expectedErrMsg {
 				t.Errorf("Expected error with message %q but got %q", tc.expectedErrMsg, err)
 			}

--- a/pkg/oci/load_balancer_spec_test.go
+++ b/pkg/oci/load_balancer_spec_test.go
@@ -83,6 +83,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
+				SecurityListManager: newSecurityListManagerNOOP(),
 			},
 		},
 		"internal": {
@@ -137,7 +138,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				//Need to add security list manager to spec here
+				SecurityListManager: newSecurityListManagerNOOP(),
 			},
 		},
 		"subnet annotations": {
@@ -193,9 +194,10 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				//Need to add security list manager to spec here
+				SecurityListManager: newSecurityListManagerNOOP(),
 			},
 		},
+		//"security list manager annotation":
 		"custom shape": {
 			defaultSubnetOne: "one",
 			defaultSubnetTwo: "two",
@@ -248,7 +250,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				//Need to add security list manager to spec here
+				SecurityListManager: newSecurityListManagerNOOP(),
 			},
 		},
 		"custom idle connection timeout": {
@@ -306,7 +308,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						HealthCheckerPort: 10256,
 					},
 				},
-				//Need to add security list manager to spec here
+				SecurityListManager: newSecurityListManagerNOOP(),
 			},
 		},
 	}

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,6 @@
 box: golang:1.9
+no-response-timeout: 30
+command-timeout: 30
 dev:
   steps:
     - internal/shell
@@ -8,7 +10,7 @@ build:
     - script:
       name: check boilerplate
       code: ./hack/verify-boilerplate.sh
-
+  
     - script:
       name: go fmt
       code: make gofmt
@@ -48,7 +50,7 @@ copy:
       name: copy output
       code: |
         cp -a dist/* ${WERCKER_OUTPUT_DIR}
-    
+
     - script:
       name: copy e2e test artifacts
       code: |
@@ -140,7 +142,7 @@ e2e-test:
     - script:
       name: deploy latest CCM
       code: make upgrade
-        
+
     - script:
       name: e2e default tests
       code: make e2e
@@ -169,7 +171,7 @@ push-canary:
     - internal/docker-push:
       repository: iad.ocir.io/oracle/oci-cloud-controller-manager-canary
       tag: $VERSION
-      working-dir: /go/src/github.com/oracle/oci-cloud-controller-manager/ 
+      working-dir: /go/src/github.com/oracle/oci-cloud-controller-manager/
       entrypoint: make canary
       registry: https://iad.ocir.io/v2
       username: $OCIRUSERNAME
@@ -192,11 +194,11 @@ validate-canary:
     - script:
       name: deploy latest CCM
       code: make upgrade
-        
+
     - script:
       name: validate canary tests
       code: make validate-canary
-      
+
   after-steps:
     - script:
       name: rollback original CCM


### PR DESCRIPTION
For customers running in a management environment, they will not be able to modify the configuration of the CCM.This allows for dynamic configuration of security list management mode (All, Frontend, None) by adding an annotation when creating a LB service. 
This covers the following enhancement #217 as well as covering the seg fault issue #221 