### PR TITLE
Support load balancer listeners with http protocol via annotation

### DIFF
--- a/docs/load-balancer-annotations.md
+++ b/docs/load-balancer-annotations.md
@@ -28,6 +28,7 @@ spec:
 | `oci-load-balancer-subnet2`                 | The OCID of the second [subnet][2] of the two required subnets to attach the load balancer to. Must be in separate Availability Domains.                                                                                                           | Value provided in config file                    |
 | `oci-load-balancer-connection-idle-timeout` | The maximum idle time, in seconds, allowed between two successive receive or two successive send operations between the client and backend servers.                                                                                                | `300` for TCP listeners, `60` for HTTP listeners |
 | `oci-load-balancer-security-list-management-mode` | Specifies the [security list mode](##security-list-management-modes) (`"All"`, `"Frontend"`,`"None"`) to configure how security lists are managed by the CCM.                            | `"All"`            
+| `oci-load-balancer-backend-protocol` | Specify protocol on which the listener accepts connection requests. To get a list of valid protocols, use the [`ListProtocols`][5] operation.                          | `"TCP"`            
 
 ## TLS-related
 
@@ -51,3 +52,4 @@ Note:
 [2]: https://docs.us-phoenix-1.oraclecloud.com/Content/Network/Tasks/managingVCNs.htm
 [3]: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
 [4]: https://kubernetes.io/docs/concepts/services-networking/service/
+[5]: https://docs.cloud.oracle.com/iaas/api/#/en/loadbalancer/20170115/LoadBalancerProtocol/ListProtocols

--- a/pkg/oci/load_balancer.go
+++ b/pkg/oci/load_balancer.go
@@ -80,7 +80,7 @@ const (
 // balancers created by the CCM.
 const DefaultLoadBalancerPolicy = "ROUND_ROBIN"
 
-// DefaultLoadBalanceBEProtocol defines the default protocol for load
+// DefaultLoadBalancerBEProtocol defines the default protocol for load
 // balancer listeners created by the CCM.
 const DefaultLoadBalancerBEProtocol = "TCP"
 

--- a/pkg/oci/load_balancer.go
+++ b/pkg/oci/load_balancer.go
@@ -70,11 +70,19 @@ const (
 	// ServiceAnnotaionLoadBalancerSecurityListManagementMode is a Service annotation for
 	// specifying the security list managment mode ("All", "Frontend", "None") that configures how security lists are managed by the CCM
 	ServiceAnnotaionLoadBalancerSecurityListManagementMode = "service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode"
+
+	// ServiceAnnotationLoadBalancerBEProtocol is a Service annotation for specifying the
+	// load balancer listener backend protocol ("TCP", "HTTP").
+	ServiceAnnotationLoadBalancerBEProtocol = "service.beta.kubernetes.io/oci-load-balancer-backend-protocol"
 )
 
 // DefaultLoadBalancerPolicy defines the default traffic policy for load
 // balancers created by the CCM.
 const DefaultLoadBalancerPolicy = "ROUND_ROBIN"
+
+// DefaultLoadBalanceBEProtocol defines the default protocol for load
+// balancer listeners created by the CCM.
+const DefaultLoadBalancerBEProtocol = "TCP"
 
 const (
 	// Fallback value if annotation on service is not set

--- a/pkg/oci/load_balancer.go
+++ b/pkg/oci/load_balancer.go
@@ -73,6 +73,7 @@ const (
 
 	// ServiceAnnotationLoadBalancerBEProtocol is a Service annotation for specifying the
 	// load balancer listener backend protocol ("TCP", "HTTP").
+	// See: https://docs.cloud.oracle.com/iaas/Content/Balance/Concepts/balanceoverview.htm#concepts
 	ServiceAnnotationLoadBalancerBEProtocol = "service.beta.kubernetes.io/oci-load-balancer-backend-protocol"
 )
 


### PR DESCRIPTION
Addresses #208 

Currently only TCP listeners are supported when creating a service type load balancer. The oci console allows for either TCP or HTTP.

```
annotations:
    service.beta.kubernetes.io/oci-load-balancer-backend-protocol: "HTTP"
```

When the service is create with the `service.beta.kubernetes.io/oci-load-balancer-backend-protocol` annotation is set to `"HTTP"` the listener protocol will be overridden to use HTTP. The value `"TCP"` may also be used for TCP listeners, however, this is the default when the value is empty or when the annotation is not present.