### PR TITLE
Canary E2E - Optional NodePort test.

### DIFF
--- a/test/e2e/load_balancer.go
+++ b/test/e2e/load_balancer.go
@@ -83,9 +83,10 @@ var _ = Describe("Service [Slow]", func() {
 		tcpIngressIP := framework.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0])
 		framework.Logf("TCP load balancer: %s", tcpIngressIP)
 
-		// trjl - hide this?
-		By("hitting the TCP service's NodePort")
-		jig.TestReachableHTTP(nodeIP, tcpNodePort, framework.KubeProxyLagTimeout)
+		if f.NodePortTest {
+			By("hitting the TCP service's NodePort")
+			jig.TestReachableHTTP(nodeIP, tcpNodePort, framework.KubeProxyLagTimeout)
+		}
 
 		By("hitting the TCP service's LoadBalancer")
 		jig.TestReachableHTTP(tcpIngressIP, svcPort, loadBalancerLagTimeout)


### PR DESCRIPTION
What can I say. I missed a clause...

CI tested ok. I also tested by deploying on an OKE cluster with no additional seclists configured. It no only runs load-balancer tests (no nodePort test) as desired by canary team.