### PR TITLE
Update CI Docker image

### DIFF
--- a/ci-docker-images/Dockerfile
+++ b/ci-docker-images/Dockerfile
@@ -12,15 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM oraclelinux:7.4
+FROM oraclelinux:7.5
 
-RUN yum install -y ca-certificates make openssl git jq && yum clean all
+RUN yum install --enablerepo=ol7_developer_EPEL -y \
+    ca-certificates \
+    gcc \
+    git \
+    jq \
+    make \
+    openssl \
+    pwgen \
+    python \
+    python-pip \
+    python-yaml \
+    unzip && \
+    yum clean all
 
 # Install golang environment
-RUN curl https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz -O && \
+RUN curl https://storage.googleapis.com/golang/go1.11.1.linux-amd64.tar.gz -O && \
     mkdir /tools && \
-    tar xzf go1.10.3.linux-amd64.tar.gz -C /tools && \
-    rm go1.10.3.linux-amd64.tar.gz && \
+    tar xzf go1.11.1.linux-amd64.tar.gz -C /tools && \
+    rm go1.11.1.linux-amd64.tar.gz && \
     mkdir -p /go/bin
 
 ENV PATH=/tools/go/bin:/go/bin:/tools/linux-amd64:$PATH \
@@ -33,4 +45,22 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.0/b
     mv ./kubectl /usr/local/bin/kubectl
 
 # Install Ginkgo
-RUN go get -u github.com/onsi/ginkgo/ginkgo
+RUN go get -u github.com/onsi/ginkgo/ginkgo && \
+    go get -u github.com/onsi/gomega/...
+
+# Install Terraform
+RUN curl https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_linux_amd64.zip -LO && \
+    unzip terraform_0.10.7_linux_amd64.zip && \
+    mv terraform /usr/bin && \ 
+    rm -f terraform terraform_0.10.7_linux_amd64.zip
+
+# Installs the OCI terraform provider
+RUN curl -LO https://github.com/oracle/terraform-provider-oci/releases/download/2.0.2/linux.tar.gz && \
+    tar -xvf linux.tar.gz -C / && \
+    echo "providers { oci = \"/linux_amd64/terraform-provider-oci_v2.0.2\" }" > ~/.terraformrc && \
+    rm -f linux.tar.gz
+
+# Install OCI client
+RUN pip install \
+    oci \
+    requests[security]

--- a/ci-docker-images/Dockerfile
+++ b/ci-docker-images/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM oraclelinux:7.5
+FROM oraclelinux:7-slim
 
 RUN yum install --enablerepo=ol7_developer_EPEL -y \
     ca-certificates \
@@ -26,7 +26,7 @@ RUN yum install --enablerepo=ol7_developer_EPEL -y \
     python-pip \
     python-yaml \
     unzip && \
-    yum clean all
+    yum clean all && rm -rf /var/cache/yum
 
 # Install golang environment
 RUN curl https://storage.googleapis.com/golang/go1.11.1.linux-amd64.tar.gz -O && \
@@ -48,10 +48,13 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.11.0/b
 RUN go get -u github.com/onsi/ginkgo/ginkgo && \
     go get -u github.com/onsi/gomega/...
 
+# Install golint
+RUN go get -u golang.org/x/lint/golint
+
 # Install Terraform
 RUN curl https://releases.hashicorp.com/terraform/0.10.7/terraform_0.10.7_linux_amd64.zip -LO && \
     unzip terraform_0.10.7_linux_amd64.zip && \
-    mv terraform /usr/bin && \ 
+    mv terraform /usr/bin && \
     rm -f terraform terraform_0.10.7_linux_amd64.zip
 
 # Installs the OCI terraform provider

--- a/ci-docker-images/Makefile
+++ b/ci-docker-images/Makefile
@@ -32,6 +32,5 @@ build:
 
 .PHONY: push
 push: build
-	@docker login -u '$(OCIRUSERNAME)' -p '$(OCIRPASSWORD)' $(OCIREGISTRY)
 	docker push $(IMAGE):$(VERSION)
 

--- a/ci-docker-images/Makefile
+++ b/ci-docker-images/Makefile
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-OCIRUSERNAME ?= spinnaker/everest-ocir-push 
+OCIRUSERNAME ?= spinnaker/everest-ocir-push
 OCIREGISTRY ?= iad.ocir.io
 
-IMAGE ?= iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e
-VERSION ?= 1.0.1
+IMAGE ?= iad.ocir.io/spinnaker/oci-kube-ci
+
+ifndef VERSION
+  $(error VERSION is undefined)
+endif
 
 .PHONY: build
 build:

--- a/pkg/oci/client/load_balancer.go
+++ b/pkg/oci/client/load_balancer.go
@@ -199,10 +199,10 @@ func (c *client) CreateBackendSet(ctx context.Context, lbID, name string, detail
 	resp, err := c.loadbalancer.CreateBackendSet(ctx, loadbalancer.CreateBackendSetRequest{
 		LoadBalancerId: &lbID,
 		CreateBackendSetDetails: loadbalancer.CreateBackendSetDetails{
-			Name:          &name,
-			Backends:      details.Backends,
-			HealthChecker: details.HealthChecker,
-			Policy:        details.Policy,
+			Name:                            &name,
+			Backends:                        details.Backends,
+			HealthChecker:                   details.HealthChecker,
+			Policy:                          details.Policy,
 			SessionPersistenceConfiguration: details.SessionPersistenceConfiguration,
 			SslConfiguration:                details.SslConfiguration,
 		},
@@ -225,9 +225,9 @@ func (c *client) UpdateBackendSet(ctx context.Context, lbID, name string, detail
 		LoadBalancerId: &lbID,
 		BackendSetName: &name,
 		UpdateBackendSetDetails: loadbalancer.UpdateBackendSetDetails{
-			Backends:      details.Backends,
-			HealthChecker: details.HealthChecker,
-			Policy:        details.Policy,
+			Backends:                        details.Backends,
+			HealthChecker:                   details.HealthChecker,
+			Policy:                          details.Policy,
 			SessionPersistenceConfiguration: details.SessionPersistenceConfiguration,
 			SslConfiguration:                details.SslConfiguration,
 		},
@@ -267,11 +267,11 @@ func (c *client) CreateListener(ctx context.Context, lbID, name string, details 
 	resp, err := c.loadbalancer.CreateListener(ctx, loadbalancer.CreateListenerRequest{
 		LoadBalancerId: &lbID,
 		CreateListenerDetails: loadbalancer.CreateListenerDetails{
-			Name: &name,
+			Name:                  &name,
 			DefaultBackendSetName: details.DefaultBackendSetName,
-			Port:             details.Port,
-			Protocol:         details.Protocol,
-			SslConfiguration: details.SslConfiguration,
+			Port:                  details.Port,
+			Protocol:              details.Protocol,
+			SslConfiguration:      details.SslConfiguration,
 		},
 	})
 	incRequestCounter(err, createVerb, listenerResource)
@@ -293,9 +293,9 @@ func (c *client) UpdateListener(ctx context.Context, lbID, name string, details 
 		ListenerName:   &name,
 		UpdateListenerDetails: loadbalancer.UpdateListenerDetails{
 			DefaultBackendSetName: details.DefaultBackendSetName,
-			Port:             details.Port,
-			Protocol:         details.Protocol,
-			SslConfiguration: details.SslConfiguration,
+			Port:                  details.Port,
+			Protocol:              details.Protocol,
+			SslConfiguration:      details.SslConfiguration,
 		},
 	})
 	incRequestCounter(err, updateVerb, listenerResource)

--- a/pkg/oci/load_balancer.go
+++ b/pkg/oci/load_balancer.go
@@ -183,7 +183,7 @@ func getSubnetsForNodes(ctx context.Context, nodes []*v1.Node, client client.Int
 			!subnetOCIDs.Has(*vnic.SubnetId) {
 			subnet, err := client.Networking().GetSubnet(ctx, *vnic.SubnetId)
 			if err != nil {
-				return nil, errors.Wrapf(err, "get subnet %q for instance %q", *vnic.SubnetId, id, err)
+				return nil, errors.Wrapf(err, "get subnet %q for instance %q", *vnic.SubnetId, id)
 			}
 
 			subnets = append(subnets, subnet)

--- a/pkg/oci/load_balancer_spec.go
+++ b/pkg/oci/load_balancer_spec.go
@@ -70,7 +70,7 @@ func NewSSLConfig(listenerSecretName, backendSetSecretName string, ports []int, 
 		ssr = noopSSLSecretReader{}
 	}
 	return &SSLConfig{
-		Ports: sets.NewInt(ports...),
+		Ports:                   sets.NewInt(ports...),
 		ListenerSSLSecretName:   listenerSecretName,
 		BackendSetSSLSecretName: backendSetSecretName,
 		sslSecretReader:         ssr,

--- a/pkg/oci/load_balancer_spec_test.go
+++ b/pkg/oci/load_balancer_spec_test.go
@@ -60,8 +60,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:     common.Int(80),
-						Protocol: common.String("TCP"),
+						Port:                  common.Int(80),
+						Protocol:              common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -115,8 +115,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:     common.Int(80),
-						Protocol: common.String("TCP"),
+						Port:                  common.Int(80),
+						Protocol:              common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -171,8 +171,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:     common.Int(80),
-						Protocol: common.String("TCP"),
+						Port:                  common.Int(80),
+						Protocol:              common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -227,8 +227,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:     common.Int(80),
-						Protocol: common.String("TCP"),
+						Port:                  common.Int(80),
+						Protocol:              common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -282,8 +282,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:     common.Int(80),
-						Protocol: common.String("TCP"),
+						Port:                  common.Int(80),
+						Protocol:              common.String("TCP"),
 						ConnectionConfiguration: &loadbalancer.ConnectionConfiguration{
 							IdleTimeout: common.Int64(404),
 						},
@@ -342,8 +342,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"HTTP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:     common.Int(80),
-						Protocol: common.String("HTTP"),
+						Port:                  common.Int(80),
+						Protocol:              common.String("HTTP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -399,8 +399,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:     common.Int(80),
-						Protocol: common.String("TCP"),
+						Port:                  common.Int(80),
+						Protocol:              common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -456,8 +456,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:     common.Int(80),
-						Protocol: common.String("TCP"),
+						Port:                  common.Int(80),
+						Protocol:              common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{

--- a/pkg/oci/load_balancer_util.go
+++ b/pkg/oci/load_balancer_util.go
@@ -370,9 +370,9 @@ func getListenerChanges(actual map[string]loadbalancer.Listener, desired map[str
 			listenerActions = append(listenerActions, &ListenerAction{
 				Listener: loadbalancer.ListenerDetails{
 					DefaultBackendSetName: actualListener.DefaultBackendSetName,
-					Port:             actualListener.Port,
-					Protocol:         actualListener.Protocol,
-					SslConfiguration: sslConfigurationToDetails(actualListener.SslConfiguration),
+					Port:                  actualListener.Port,
+					Protocol:              actualListener.Protocol,
+					SslConfiguration:      sslConfigurationToDetails(actualListener.SslConfiguration),
 				},
 				name:       name,
 				actionType: Delete,

--- a/pkg/oci/load_balancer_util_test.go
+++ b/pkg/oci/load_balancer_util_test.go
@@ -411,7 +411,7 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 			actual: map[string]loadbalancer.Listener{
 				"TCP-80": loadbalancer.Listener{
-					Name: common.String("TCP-80"),
+					Name:                  common.String("TCP-80"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),
@@ -440,13 +440,13 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 			actual: map[string]loadbalancer.Listener{
 				"TCP-443": loadbalancer.Listener{
-					Name: common.String("TCP-443"),
+					Name:                  common.String("TCP-443"),
 					DefaultBackendSetName: common.String("TCP-443"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(443),
 				},
 				"TCP-80": loadbalancer.Listener{
-					Name: common.String("TCP-80"),
+					Name:                  common.String("TCP-80"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),
@@ -475,7 +475,7 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 			actual: map[string]loadbalancer.Listener{
 				"TCP-80": loadbalancer.Listener{
-					Name: common.String("TCP-80"),
+					Name:                  common.String("TCP-80"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),
@@ -497,7 +497,7 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 			actual: map[string]loadbalancer.Listener{
 				"TCP-80": loadbalancer.Listener{
-					Name: common.String("TCP-80"),
+					Name:                  common.String("TCP-80"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,9 +1,7 @@
-box: golang:1.9
+box: iad.ocir.io/spinnaker/oci-kube-ci:1.0.3
 no-response-timeout: 30
 command-timeout: 30
-dev:
-  steps:
-    - internal/shell
+
 build:
   base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
   steps:
@@ -43,7 +41,6 @@ build:
         make version > dist/VERSION.txt
         cat dist/VERSION.txt
 
-
 copy:
   steps:
     - script:
@@ -62,7 +59,6 @@ copy:
         cp -R pkg ${WERCKER_OUTPUT_DIR}/
         cp -R test ${WERCKER_OUTPUT_DIR}/
         cp -R vendor ${WERCKER_OUTPUT_DIR}/
-
 
 push:
   box:
@@ -124,11 +120,10 @@ push:
         username: $OCIRUSERNAME
         password: $OCIRPASSWORD
 
-
 e2e-test:
   base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
   box:
-    id: iad.ocir.io/spinnaker/oci-kube-ci:1.0.2
+    id: iad.ocir.io/spinnaker/oci-kube-ci:1.0.3
     registry: https://iad.ocir.io/v2
   steps:
     - script:
@@ -153,7 +148,6 @@ e2e-test:
       name: rollback original CCM
       code: make rollback
 
-
 push-canary:
   base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
   box:
@@ -177,10 +171,9 @@ push-canary:
       username: $OCIRUSERNAME
       password: $OCIRPASSWORD
 
-
 validate-canary:
   box:
-    id: iad.ocir.io/spinnaker/oci-kube-ci:1.0.2
+    id: iad.ocir.io/spinnaker/oci-kube-ci:1.0.3
     registry: https://iad.ocir.io/v2
   steps:
     - script:

--- a/wercker.yml
+++ b/wercker.yml
@@ -16,7 +16,6 @@ build:
     - script:
       name: golint
       code: |
-        go get -u github.com/golang/lint/golint
         make golint
 
     - script:

--- a/wercker.yml
+++ b/wercker.yml
@@ -128,10 +128,8 @@ push:
 e2e-test:
   base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
   box:
-    id: iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e:1.0.0
+    id: iad.ocir.io/spinnaker/oci-kube-ci:1.0.2
     registry: https://iad.ocir.io/v2
-    username: $OCIRUSERNAME
-    password: $OCIRPASSWORD
   steps:
     - script:
       name: set ENV vars
@@ -159,10 +157,8 @@ e2e-test:
 push-canary:
   base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
   box:
-    id: iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e:1.0.1
+    id: iad.ocir.io/spinnaker/oci-kube-ci:1.0.2
     registry: https://iad.ocir.io/v2
-    username: $OCIRUSERNAME
-    password: $OCIRPASSWORD
   steps:
     - script:
       name: set ENV vars
@@ -184,10 +180,8 @@ push-canary:
 
 validate-canary:
   box:
-    id: iad.ocir.io/oracle/oci-cloud-controller-manager-ci-e2e:1.0.1
+    id: iad.ocir.io/spinnaker/oci-kube-ci:1.0.2
     registry: https://iad.ocir.io/v2
-    username: $OCIRUSERNAME
-    password: $OCIRPASSWORD
   steps:
     - script:
       name: set ENV vars


### PR DESCRIPTION
Updates the Docker image to create a single base image for use across all projects (flexvolume driver, ccm and volume provisioner). Tenancy changed to spinnaker as the oracle tenancy should be used for customer images. Wercker pipeline updated to use this new image.