### PR TITLE
Run gofmt over source to prevent build errors

### DIFF
--- a/pkg/cloudprovider/providers/oci/load_balancer_spec.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec.go
@@ -67,7 +67,7 @@ func NewSSLConfig(listenerSecretName, backendSetSecretName string, ports []int, 
 		ssr = noopSSLSecretReader{}
 	}
 	return &SSLConfig{
-		Ports:                   sets.NewInt(ports...),
+		Ports: sets.NewInt(ports...),
 		ListenerSSLSecretName:   listenerSecretName,
 		BackendSetSSLSecretName: backendSetSecretName,
 		sslSecretReader:         ssr,

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
@@ -60,8 +60,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:                  common.Int(80),
-						Protocol:              common.String("TCP"),
+						Port:     common.Int(80),
+						Protocol: common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -115,8 +115,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:                  common.Int(80),
-						Protocol:              common.String("TCP"),
+						Port:     common.Int(80),
+						Protocol: common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -171,8 +171,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:                  common.Int(80),
-						Protocol:              common.String("TCP"),
+						Port:     common.Int(80),
+						Protocol: common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -227,8 +227,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:                  common.Int(80),
-						Protocol:              common.String("TCP"),
+						Port:     common.Int(80),
+						Protocol: common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -282,8 +282,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:                  common.Int(80),
-						Protocol:              common.String("TCP"),
+						Port:     common.Int(80),
+						Protocol: common.String("TCP"),
 						ConnectionConfiguration: &loadbalancer.ConnectionConfiguration{
 							IdleTimeout: common.Int64(404),
 						},
@@ -342,8 +342,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"HTTP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:                  common.Int(80),
-						Protocol:              common.String("HTTP"),
+						Port:     common.Int(80),
+						Protocol: common.String("HTTP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -399,8 +399,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:                  common.Int(80),
-						Protocol:              common.String("TCP"),
+						Port:     common.Int(80),
+						Protocol: common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{
@@ -456,8 +456,8 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Listeners: map[string]loadbalancer.ListenerDetails{
 					"TCP-80": loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
-						Port:                  common.Int(80),
-						Protocol:              common.String("TCP"),
+						Port:     common.Int(80),
+						Protocol: common.String("TCP"),
 					},
 				},
 				BackendSets: map[string]loadbalancer.BackendSetDetails{

--- a/pkg/cloudprovider/providers/oci/load_balancer_util.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_util.go
@@ -370,9 +370,9 @@ func getListenerChanges(actual map[string]loadbalancer.Listener, desired map[str
 			listenerActions = append(listenerActions, &ListenerAction{
 				Listener: loadbalancer.ListenerDetails{
 					DefaultBackendSetName: actualListener.DefaultBackendSetName,
-					Port:                  actualListener.Port,
-					Protocol:              actualListener.Protocol,
-					SslConfiguration:      sslConfigurationToDetails(actualListener.SslConfiguration),
+					Port:             actualListener.Port,
+					Protocol:         actualListener.Protocol,
+					SslConfiguration: sslConfigurationToDetails(actualListener.SslConfiguration),
 				},
 				name:       name,
 				actionType: Delete,

--- a/pkg/cloudprovider/providers/oci/load_balancer_util_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_util_test.go
@@ -411,7 +411,7 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 			actual: map[string]loadbalancer.Listener{
 				"TCP-80": loadbalancer.Listener{
-					Name:                  common.String("TCP-80"),
+					Name: common.String("TCP-80"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),
@@ -440,13 +440,13 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 			actual: map[string]loadbalancer.Listener{
 				"TCP-443": loadbalancer.Listener{
-					Name:                  common.String("TCP-443"),
+					Name: common.String("TCP-443"),
 					DefaultBackendSetName: common.String("TCP-443"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(443),
 				},
 				"TCP-80": loadbalancer.Listener{
-					Name:                  common.String("TCP-80"),
+					Name: common.String("TCP-80"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),
@@ -475,7 +475,7 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 			actual: map[string]loadbalancer.Listener{
 				"TCP-80": loadbalancer.Listener{
-					Name:                  common.String("TCP-80"),
+					Name: common.String("TCP-80"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),
@@ -497,7 +497,7 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 			actual: map[string]loadbalancer.Listener{
 				"TCP-80": loadbalancer.Listener{
-					Name:                  common.String("TCP-80"),
+					Name: common.String("TCP-80"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),

--- a/pkg/oci/client/load_balancer.go
+++ b/pkg/oci/client/load_balancer.go
@@ -199,10 +199,10 @@ func (c *client) CreateBackendSet(ctx context.Context, lbID, name string, detail
 	resp, err := c.loadbalancer.CreateBackendSet(ctx, loadbalancer.CreateBackendSetRequest{
 		LoadBalancerId: &lbID,
 		CreateBackendSetDetails: loadbalancer.CreateBackendSetDetails{
-			Name:                            &name,
-			Backends:                        details.Backends,
-			HealthChecker:                   details.HealthChecker,
-			Policy:                          details.Policy,
+			Name:          &name,
+			Backends:      details.Backends,
+			HealthChecker: details.HealthChecker,
+			Policy:        details.Policy,
 			SessionPersistenceConfiguration: details.SessionPersistenceConfiguration,
 			SslConfiguration:                details.SslConfiguration,
 		},
@@ -225,9 +225,9 @@ func (c *client) UpdateBackendSet(ctx context.Context, lbID, name string, detail
 		LoadBalancerId: &lbID,
 		BackendSetName: &name,
 		UpdateBackendSetDetails: loadbalancer.UpdateBackendSetDetails{
-			Backends:                        details.Backends,
-			HealthChecker:                   details.HealthChecker,
-			Policy:                          details.Policy,
+			Backends:      details.Backends,
+			HealthChecker: details.HealthChecker,
+			Policy:        details.Policy,
 			SessionPersistenceConfiguration: details.SessionPersistenceConfiguration,
 			SslConfiguration:                details.SslConfiguration,
 		},
@@ -267,11 +267,11 @@ func (c *client) CreateListener(ctx context.Context, lbID, name string, details 
 	resp, err := c.loadbalancer.CreateListener(ctx, loadbalancer.CreateListenerRequest{
 		LoadBalancerId: &lbID,
 		CreateListenerDetails: loadbalancer.CreateListenerDetails{
-			Name:                  &name,
+			Name: &name,
 			DefaultBackendSetName: details.DefaultBackendSetName,
-			Port:                  details.Port,
-			Protocol:              details.Protocol,
-			SslConfiguration:      details.SslConfiguration,
+			Port:             details.Port,
+			Protocol:         details.Protocol,
+			SslConfiguration: details.SslConfiguration,
 		},
 	})
 	incRequestCounter(err, createVerb, listenerResource)
@@ -293,9 +293,9 @@ func (c *client) UpdateListener(ctx context.Context, lbID, name string, details 
 		ListenerName:   &name,
 		UpdateListenerDetails: loadbalancer.UpdateListenerDetails{
 			DefaultBackendSetName: details.DefaultBackendSetName,
-			Port:                  details.Port,
-			Protocol:              details.Protocol,
-			SslConfiguration:      details.SslConfiguration,
+			Port:             details.Port,
+			Protocol:         details.Protocol,
+			SslConfiguration: details.SslConfiguration,
 		},
 	})
 	incRequestCounter(err, updateVerb, listenerResource)


### PR DESCRIPTION
Some of the source files had not been correctly formatted. This change fixes them so that the default make target does not cause errors.