### PR TITLE
Enable disabling component install in e2e

### DIFF
--- a/test/e2e/cloud-controller-manager/README.md
+++ b/test/e2e/cloud-controller-manager/README.md
@@ -5,8 +5,13 @@ E2E tests.
 
 ## Running
 
+By default the tests install the provided `$VERSION` of the CCM. To run against
+an existing deployment set `$INSTALL_DISABLED=1`
+
 ```bash
-$ ginkgo -v -progress test/e2e/cloud-controller-manager -- --kubeconfig=${HOME}/.kube/config --delete-namespace=false
+$ INSTALL_DISABLED=1 ginkgo -v -progress test/e2e/cloud-controller-manager -- \
+    --kubeconfig=${HOME}/.kube/config \
+    --delete-namespace=false
 ```
 
 NOTE: Test suite will fail if executed behind a `$HTTP_PROXY` that returns a

--- a/test/e2e/volume-provisioner/README.md
+++ b/test/e2e/volume-provisioner/README.md
@@ -5,20 +5,21 @@ E2E tests.
 
 ## Running
 
+By default the tests install the provided cloud-provider-oci `--image`. To run
+against an existing deployment set `$INSTALL_DISABLED=1`.
+
 ```bash
-export SUBNET_OCID=ocid1.subnet.oc1.phx.aaaaaaaanlsnbcixkkchz6n6eznusplxui3xwgb7bsaeucqy4zpehohcb3ra
+export INSTALL_DISABLED=1
 export MNT_TARGET_OCID=ocid1.mounttarget.oc1.phx.aaaaaa4np2snlxveobuhqllqojxwiotqnb4c2ylefuzaaaaa
-export IMAGE=iad.ocir.io/oracle/oci-volume-provisioner
+export IMAGE=iad.ocir.io/spinnaker/cloud-provider-oci
 export VERSION="<version under test>"
 export OCICONFIG=$(pwd)/oci-config.yaml
-export KUBECONFIG="${HOME}/Projects/kubernetes-test-terraform/oci-volume-provisioner-system-test/generated/kubeconfig"
 ginkgo \
   -v \
   -progress \
   test/e2e -- \
   --kubeconfig="${KUBECONFIG}" \
   --ociconfig="${OCICONFIG}" \
-  --subnet-id="${SUBNET_OCID}" \
   --mnt-target-id="${MNT_TARGET_OCID}" \
   --delete-namespace-on-failure=false \
   --image="${IMAGE}:${VERSION}"
@@ -31,7 +32,6 @@ ginkgo \
 | `--kubeconfig`                  | Path to Kubeconfig file with authorization and master location information.                                                        | string |
 | `--ociconfig`                   | Path to OCIconfig file with cloud provider config.                                                                                 | string |
 | `--mnt-target-id`               | Identifies the mount target id for a FSS.                                                                                          | string |
-| `--subnet-id`                   | Identifies a subnet to look for a mount target, such that a FSS can be mounted.                                                    | string |
 | `--ad`                          | Identifies the availability domain in which the PD resides                                                                         | string |
 | `--image`                       | Specifies the container image and version                                                                                          | string |
 | `--namespace`                   | Name of an existing Namespace to run tests in.                                                                                     | string |

--- a/test/e2e/volume-provisioner/framework/test_context.go
+++ b/test/e2e/volume-provisioner/framework/test_context.go
@@ -35,9 +35,6 @@ type TestContextType struct {
 	// MntTargetOCID used mount a volume to the specific mount id
 	MntTargetOCID string
 
-	// SubnetOCID used to mount a volume looking for a mount in the specified subnet
-	SubnetOCID string
-
 	// Image is the docker image to which we are building
 	Image string
 
@@ -61,7 +58,6 @@ func RegisterFlags() {
 	flag.StringVar(&TestContext.OCIConfig, "ociconfig", "", "Path to OCIconfig file with cloud provider config.")
 	flag.StringVar(&TestContext.AD, "ad", "AD-2", "The availability domain is specified to identify in which to create the volumes.")
 	flag.StringVar(&TestContext.MntTargetOCID, "mnt-target-id", "", "Mount Target ID is specified to identify the mount target to be attached to the volumes")
-	flag.StringVar(&TestContext.SubnetOCID, "subnet-id", "", "Subnet ID is specified to identify where to look for a mount target, such that a FSS can be mounted.")
 	flag.StringVar(&TestContext.Image, "image", "", "Image name and version to build images")
 	flag.StringVar(&TestContext.Namespace, "namespace", "", "Name of an existing Namespace to run tests in.")
 	flag.BoolVar(&TestContext.DeleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")


### PR DESCRIPTION
Enable disabling component install in e2e via setting `$INSTALL_DISABLED`.

Additionally remove the now redundant `--subnet-id` flag from VP E2E tests.