### PR TITLE
Remove support for key_passphrase as an auth configuration field.

### DIFF
--- a/pkg/cloudprovider/providers/oci/config/config.go
+++ b/pkg/cloudprovider/providers/oci/config/config.go
@@ -40,8 +40,6 @@ type AuthConfig struct {
 	// CompartmentID is DEPRECIATED and should be set on the top level Config
 	// struct.
 	CompartmentID string `yaml:"compartment"`
-	// PrivateKeyPassphrase is DEPRECIATED in favour of Passphrase.
-	PrivateKeyPassphrase string `yaml:"key_passphrase"`
 }
 
 const (
@@ -116,13 +114,10 @@ func (c *Config) Complete() {
 			c.LoadBalancer.SecurityListManagementMode = ManagementModeNone
 		}
 	}
+
 	if c.CompartmentID == "" && c.Auth.CompartmentID != "" {
 		zap.S().Warn("cloud-provider config: \"auth.compartment\" is DEPRECIATED and will be removed in a later release. Please set \"compartment\".")
 		c.CompartmentID = c.Auth.CompartmentID
-	}
-	if c.Auth.Passphrase == "" && c.Auth.PrivateKeyPassphrase != "" {
-		zap.S().Warn("cloud-provider config: \"auth.key_passphrase\" is DEPRECIATED and will be removed in a later release. Please set \"auth.passphrase\".")
-		c.Auth.Passphrase = c.Auth.PrivateKeyPassphrase
 	}
 }
 

--- a/pkg/flexvolume/block/config.go
+++ b/pkg/flexvolume/block/config.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"strings"
 
@@ -106,11 +105,6 @@ func (c *Config) setDefaults() error {
 	err := c.setRegionFields(c.Auth.Region)
 	if err != nil {
 		return fmt.Errorf("setting config region fields: %v", err)
-	}
-
-	if c.Auth.Passphrase == "" && c.Auth.PrivateKeyPassphrase != "" {
-		log.Print("config: auth.key_passphrase is DEPRECIATED and will be removed in a later release. Please set auth.passphrase instead.")
-		c.Auth.Passphrase = c.Auth.PrivateKeyPassphrase
 	}
 
 	return nil

--- a/pkg/volume/provisioner/core/config.go
+++ b/pkg/volume/provisioner/core/config.go
@@ -88,7 +88,7 @@ func newConfigurationProvider(logger *zap.SugaredLogger, cfg *Config) (common.Co
 			cfg.Auth.Region,
 			cfg.Auth.Fingerprint,
 			cfg.Auth.PrivateKey,
-			common.String(cfg.Auth.PrivateKeyPassphrase))
+			common.String(cfg.Auth.Passphrase))
 	} else {
 		conf = common.DefaultConfigProvider()
 	}

--- a/pkg/volume/provisioner/core/config_test.go
+++ b/pkg/volume/provisioner/core/config_test.go
@@ -35,6 +35,7 @@ auth:
   key: |
     -----BEGIN RSA PRIVATE KEY-----
     -----END RSA PRIVATE KEY-----
+  passphrase: secret passphrase
   fingerprint: 97:84:f7:26:a3:7b:74:d0:bd:4e:08:a7:79:c9:d0:1d
 `
 const validConfigNoRegion = `


### PR DESCRIPTION
key_passphrase is no longer supported. Use passphrase instead.

Fixes #275 