### PR TITLE
Fix incorrect error check in provisioner.go.

### DIFF
--- a/pkg/volume/provisioner/core/provisioner.go
+++ b/pkg/volume/provisioner/core/provisioner.go
@@ -98,7 +98,7 @@ func NewOCIProvisioner(
 	}
 
 	metadata, mdErr := metadata.New().Get()
-	if err != nil {
+	if mdErr != nil {
 		logger.With(zap.Error(mdErr)).Warnf("Unable to retrieve instance metadata.")
 	}
 


### PR DESCRIPTION
Incorrect error being checked when performing a metadata lookup.