### PR TITLE
Replaced logging to stdout with logging to file using zap

### DIFF
--- a/cmd/oci-flexvolume-driver/main.go
+++ b/cmd/oci-flexvolume-driver/main.go
@@ -16,11 +16,12 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/oracle/oci-cloud-controller-manager/pkg/flexvolume"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/flexvolume/block"
+	"github.com/oracle/oci-cloud-controller-manager/pkg/logging"
+	"go.uber.org/zap"
 )
 
 // version/build is set at build time to the version of the driver being built.
@@ -37,24 +38,22 @@ func GetLogPath() string {
 }
 
 func main() {
-	// TODO: Maybe use sirupsen/logrus?
-	f, err := os.OpenFile(GetLogPath(), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error opening log file: %v", err)
-		os.Exit(1)
-	}
-	defer f.Close()
+	l := logging.FileLogger(GetLogPath())
+	defer l.Sync()
+	zap.ReplaceGlobals(l)
+	logger := l.Sugar()
+	logger = logger.With(
+		"pid", os.Getpid(),
+		"version", version,
+		"build", build,
+	)
+	logger.Debug("OCI Flexvolume driver")
+	d, err := block.NewOCIFlexvolumeDriver(logger)
 
-	log.SetPrefix(fmt.Sprintf("%d ", os.Getpid()))
-
-	log.SetOutput(f)
-
-	log.Printf("OCI FlexVolume Driver version: %s (%s)", version, build)
-	d, err := block.NewOCIFlexvolumeDriver()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating new driver: %v", err)
-		log.Printf("error creating new driver: %v", err)
+		logger.With(zap.Error(err)).Error("Error creating new driver")
 		os.Exit(1)
 	}
-	flexvolume.ExecDriver(d, os.Args)
+	flexvolume.ExecDriver(logger, d, os.Args)
 }

--- a/cmd/oci-flexvolume-driver/main.go
+++ b/cmd/oci-flexvolume-driver/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/oracle/oci-cloud-controller-manager/pkg/flexvolume"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/flexvolume/block"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/logging"
+
 	"go.uber.org/zap"
 )
 

--- a/pkg/flexvolume/block/driver.go
+++ b/pkg/flexvolume/block/driver.go
@@ -151,10 +151,10 @@ func (d OCIFlexvolumeDriver) Init(logger *zap.SugaredLogger) flexvolume.DriverSt
 			return flexvolume.Fail(logger, err)
 		}
 	} else {
-		logger.Info("Assuming worker node.")
+		logger.Debug("Assuming worker node.")
 	}
 
-	return flexvolume.Succeed(logger)
+	return flexvolume.Succeed(zap.New(nil).Sugar())
 }
 
 // deriveVolumeOCID will expand a partial OCID to a full OCID

--- a/pkg/flexvolume/block/driver.go
+++ b/pkg/flexvolume/block/driver.go
@@ -261,8 +261,8 @@ func (d OCIFlexvolumeDriver) Attach(logger *zap.SugaredLogger, opts flexvolume.O
 
 // Detach detaches the volume from the worker node.
 func (d OCIFlexvolumeDriver) Detach(logger *zap.SugaredLogger, pvOrVolumeName, nodeName string) flexvolume.DriverStatus {
-	logger = logger.With("node", nodeName, "pvOrVolumeName", pvOrVolumeName)
-	logger.Info("Detaching.")
+	logger = logger.With("node", nodeName, "volume", pvOrVolumeName)
+	logger.Info("Looking for volume to detach.")
 	config, err := ConfigFromFile(GetConfigPath())
 	if err != nil {
 		return flexvolume.Fail(logger, err)
@@ -278,7 +278,7 @@ func (d OCIFlexvolumeDriver) Detach(logger *zap.SugaredLogger, pvOrVolumeName, n
 	if err != nil {
 		return flexvolume.Fail(logger, "Failed to find volume attachment: ", err)
 	}
-	logger.With("attachmentOCID", *attachment.GetId()).Info("Found attachment to detatch.")
+	logger.Info("Found volume to detatch.")
 	err = c.Compute().DetachVolume(ctx, *attachment.GetId())
 	if err != nil {
 		return flexvolume.Fail(logger, err)
@@ -288,7 +288,7 @@ func (d OCIFlexvolumeDriver) Detach(logger *zap.SugaredLogger, pvOrVolumeName, n
 	if err != nil {
 		return flexvolume.Fail(logger, err)
 	}
-	return flexvolume.Succeed(logger, "Detatchment completed.")
+	return flexvolume.Succeed(logger, "Volume detatchment completed.")
 }
 
 // WaitForAttach searches for the the volume attachment created by Attach() and

--- a/pkg/flexvolume/block/driver.go
+++ b/pkg/flexvolume/block/driver.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +48,7 @@ type OCIFlexvolumeDriver struct {
 }
 
 // NewOCIFlexvolumeDriver creates a new driver
-func NewOCIFlexvolumeDriver() (fvd *OCIFlexvolumeDriver, err error) {
+func NewOCIFlexvolumeDriver(logger *zap.SugaredLogger) (fvd *OCIFlexvolumeDriver, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			fvd = nil
@@ -65,7 +64,7 @@ func NewOCIFlexvolumeDriver() (fvd *OCIFlexvolumeDriver, err error) {
 		}
 		return &OCIFlexvolumeDriver{K: k, master: true}, nil
 	} else if os.IsNotExist(err) {
-		log.Printf("Config file %q does not exist. Assuming worker node.", path)
+		logger.With(zap.Error(err), "path", path).Error("Config file does not exist. Assuming worker node.")
 		return &OCIFlexvolumeDriver{}, nil
 	}
 	return nil, err
@@ -135,27 +134,27 @@ func newClient(config *Config) (client.Interface, error) {
 
 // Init checks that we have the appropriate credentials and metadata API access
 // on driver initialisation.
-func (d OCIFlexvolumeDriver) Init() flexvolume.DriverStatus {
+func (d OCIFlexvolumeDriver) Init(logger *zap.SugaredLogger) flexvolume.DriverStatus {
 	path := GetConfigPath()
 	if d.master {
 		config, err := ConfigFromFile(path)
 		if err != nil {
-			return flexvolume.Fail(err)
+			return flexvolume.Fail(logger, err)
 		}
 		_, err = newClient(config)
 		if err != nil {
-			return flexvolume.Fail(err)
+			return flexvolume.Fail(logger, err)
 		}
 
 		_, err = constructKubeClient()
 		if err != nil {
-			return flexvolume.Fail(err)
+			return flexvolume.Fail(logger, err)
 		}
 	} else {
-		log.Printf("Assuming worker node.")
+		logger.Info("Assuming worker node.")
 	}
 
-	return flexvolume.Succeed()
+	return flexvolume.Succeed(logger)
 }
 
 // deriveVolumeOCID will expand a partial OCID to a full OCID
@@ -193,66 +192,65 @@ func lookupNodeID(k kubernetes.Interface, nodeName string) (string, error) {
 
 // Attach initiates the attachment of the given OCI volume to the k8s worker
 // node.
-func (d OCIFlexvolumeDriver) Attach(opts flexvolume.Options, nodeName string) flexvolume.DriverStatus {
+func (d OCIFlexvolumeDriver) Attach(logger *zap.SugaredLogger, opts flexvolume.Options, nodeName string) flexvolume.DriverStatus {
 	config, err := ConfigFromFile(GetConfigPath())
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	c, err := newClient(config)
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	id, err := lookupNodeID(d.K, nodeName)
 	if err != nil {
-		return flexvolume.Fail("failed to look up node id: ", err)
+		return flexvolume.Fail(logger, "Failed to look up node id: ", err)
 	}
 
 	// Handle possible oci:// prefix.
 	id, err = ociprovider.MapProviderIDToInstanceID(id)
 	if err != nil {
-		return flexvolume.Fail("failed to map nodes provider id to instance id: ", err)
+		return flexvolume.Fail(logger, "Failed to map nodes provider id to instance id: ", err)
 	}
 
 	ctx := context.Background()
 
 	instance, err := c.Compute().GetInstance(ctx, id)
 	if err != nil {
-		return flexvolume.Fail("failed to get instance: ", err)
+		return flexvolume.Fail(logger, "Failed to get instance: ", err)
 	}
 
 	volumeOCID := deriveVolumeOCID(config.Auth.RegionKey, opts["kubernetes.io/pvOrVolumeName"])
 
-	log.Printf("Attaching volume %s -> instance %s", volumeOCID, *instance.Id)
+	logger.With("volumeID", volumeOCID, "instanceID", *instance.Id).Info("Attaching volume to instance")
 
 	attachment, err := c.Compute().AttachVolume(ctx, *instance.Id, volumeOCID)
 	if err != nil {
 		if !client.IsConflict(err) {
-			log.Printf("AttachVolume: %+v", err)
-			return flexvolume.Fail("failed to attach volume: ", err)
+			return flexvolume.Fail(logger, "failed to attach volume: ", err)
 		}
 		// If we get a 409 conflict response when attaching we
 		// presume that the device is already attached.
-		log.Printf("Attach(): Volume %q already attached.", volumeOCID)
+		logger.With("volumeID", volumeOCID).Info("Volume already attached.")
 		attachment, err = c.Compute().FindVolumeAttachment(ctx, config.Auth.CompartmentID, volumeOCID)
 		if err != nil {
-			return flexvolume.Fail("failed to find volume attachment: ", err)
+			return flexvolume.Fail(logger, "Failed to find volume attachment: ", err)
 		}
 		if *attachment.GetInstanceId() != *instance.Id {
-			return flexvolume.Fail("Already attached to anoter instance: ", *instance.Id)
+			return flexvolume.Fail(logger, "Already attached to anoter instance: ", *instance.Id)
 		}
 	}
 
 	attachment, err = c.Compute().WaitForVolumeAttached(ctx, *attachment.GetId())
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
-	log.Printf("attach: %s attached", *attachment.GetId())
+	logger.With("attachmentID", *attachment.GetId()).Info("Volume attached")
 	iscsiAttachment, ok := attachment.(core.IScsiVolumeAttachment)
 	if !ok {
-		return flexvolume.Fail("Only ISCSI volume attachments are currently supported")
+		return flexvolume.Fail(logger, "Only ISCSI volume attachments are currently supported")
 	}
 
 	return flexvolume.DriverStatus{
@@ -262,33 +260,33 @@ func (d OCIFlexvolumeDriver) Attach(opts flexvolume.Options, nodeName string) fl
 }
 
 // Detach detaches the volume from the worker node.
-func (d OCIFlexvolumeDriver) Detach(pvOrVolumeName, nodeName string) flexvolume.DriverStatus {
+func (d OCIFlexvolumeDriver) Detach(logger *zap.SugaredLogger, pvOrVolumeName, nodeName string) flexvolume.DriverStatus {
 	config, err := ConfigFromFile(GetConfigPath())
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 	c, err := newClient(config)
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	volumeOCID := deriveVolumeOCID(config.Auth.RegionKey, pvOrVolumeName)
 	ctx := context.Background()
 	attachment, err := c.Compute().FindVolumeAttachment(ctx, config.Auth.CompartmentID, volumeOCID)
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	err = c.Compute().DetachVolume(ctx, *attachment.GetId())
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	err = c.Compute().WaitForVolumeDetached(ctx, *attachment.GetId())
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
-	return flexvolume.Succeed()
+	return flexvolume.Succeed(logger)
 }
 
 // WaitForAttach searches for the the volume attachment created by Attach() and
@@ -304,14 +302,14 @@ func (d OCIFlexvolumeDriver) WaitForAttach(mountDevice string, _ flexvolume.Opti
 // TODO(apryde): The documentation states that this is called from the Kubelet
 // and KCM. Implementation requries credentials which won't be present on nodes
 // but I've only ever seen it called by the KCM.
-func (d OCIFlexvolumeDriver) IsAttached(opts flexvolume.Options, nodeName string) flexvolume.DriverStatus {
+func (d OCIFlexvolumeDriver) IsAttached(logger *zap.SugaredLogger, opts flexvolume.Options, nodeName string) flexvolume.DriverStatus {
 	config, err := ConfigFromFile(GetConfigPath())
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 	c, err := newClient(config)
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	ctx := context.Background()
@@ -325,7 +323,7 @@ func (d OCIFlexvolumeDriver) IsAttached(opts flexvolume.Options, nodeName string
 		}
 	}
 
-	log.Printf("attach: found volume attachment %s", *attachment.GetId())
+	logger.With("attachmentID", *attachment.GetId()).Info("Found volume attachment")
 
 	return flexvolume.DriverStatus{
 		Status:   flexvolume.StatusSuccess,
@@ -335,30 +333,30 @@ func (d OCIFlexvolumeDriver) IsAttached(opts flexvolume.Options, nodeName string
 
 // MountDevice connects the iSCSI target on the k8s worker node before mounting
 // and (if necessary) formatting the disk.
-func (d OCIFlexvolumeDriver) MountDevice(mountDir, mountDevice string, opts flexvolume.Options) flexvolume.DriverStatus {
-	iSCSIMounter, err := iscsi.NewFromDevicePath(mountDevice)
+func (d OCIFlexvolumeDriver) MountDevice(logger *zap.SugaredLogger, mountDir, mountDevice string, opts flexvolume.Options) flexvolume.DriverStatus {
+	iSCSIMounter, err := iscsi.NewFromDevicePath(logger, mountDevice)
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	if isMounted, oErr := iSCSIMounter.DeviceOpened(mountDevice); oErr != nil {
-		return flexvolume.Fail(oErr)
+		return flexvolume.Fail(logger, oErr)
 	} else if isMounted {
-		return flexvolume.Succeed("Device already mounted. Nothing to do.")
+		return flexvolume.Succeed(logger, "Device already mounted. Nothing to do.")
 	}
 
 	if err = iSCSIMounter.AddToDB(); err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 	if err = iSCSIMounter.SetAutomaticLogin(); err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 	if err = iSCSIMounter.Login(); err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	if !waitForPathToExist(mountDevice, 20) {
-		return flexvolume.Fail("Failed waiting for device to exist: ", mountDevice)
+		return flexvolume.Fail(logger, "Failed waiting for device to exist: ", mountDevice)
 	}
 
 	options := []string{}
@@ -367,44 +365,44 @@ func (d OCIFlexvolumeDriver) MountDevice(mountDir, mountDevice string, opts flex
 	}
 	err = iSCSIMounter.FormatAndMount(mountDevice, mountDir, opts[flexvolume.OptionFSType], options)
 	if err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
-	return flexvolume.Succeed()
+	return flexvolume.Succeed(logger)
 }
 
 // UnmountDevice unmounts the disk, logs out the iscsi target, and deletes the
 // iscsi node record.
-func (d OCIFlexvolumeDriver) UnmountDevice(mountPath string) flexvolume.DriverStatus {
-	iSCSIMounter, err := iscsi.NewFromMountPointPath(mountPath)
+func (d OCIFlexvolumeDriver) UnmountDevice(logger *zap.SugaredLogger, mountPath string) flexvolume.DriverStatus {
+	iSCSIMounter, err := iscsi.NewFromMountPointPath(logger, mountPath)
 	if err != nil {
 		if err == iscsi.ErrMountPointNotFound {
-			return flexvolume.Succeed("Mount point not found. Nothing to do.")
+			return flexvolume.Succeed(logger, "Mount point not found. Nothing to do.")
 		}
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
 	if err = iSCSIMounter.UnmountPath(mountPath); err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 	if err = iSCSIMounter.Logout(); err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 	if err = iSCSIMounter.RemoveFromDB(); err != nil {
-		return flexvolume.Fail(err)
+		return flexvolume.Fail(logger, err)
 	}
 
-	return flexvolume.Succeed()
+	return flexvolume.Succeed(logger)
 }
 
 // Mount is unimplemented as we use the --enable-controller-attach-detach flow
 // and as such mount the drive in MountDevice().
-func (d OCIFlexvolumeDriver) Mount(mountDir string, opts flexvolume.Options) flexvolume.DriverStatus {
-	return flexvolume.NotSupported()
+func (d OCIFlexvolumeDriver) Mount(logger *zap.SugaredLogger, mountDir string, opts flexvolume.Options) flexvolume.DriverStatus {
+	return flexvolume.NotSupported(logger)
 }
 
 // Unmount is unimplemented as we use the --enable-controller-attach-detach flow
 // and as such unmount the drive in UnmountDevice().
-func (d OCIFlexvolumeDriver) Unmount(mountDir string) flexvolume.DriverStatus {
-	return flexvolume.NotSupported()
+func (d OCIFlexvolumeDriver) Unmount(logger *zap.SugaredLogger, mountDir string) flexvolume.DriverStatus {
+	return flexvolume.NotSupported(logger)
 }

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -160,7 +160,7 @@ func ExecDriver(logger *zap.SugaredLogger, driver Driver, args []string) {
 	switch args[1] {
 	// <driver executable> init
 	case "init":
-		ExitWithResult(logger, driver.Init(zap.New(nil).Sugar()))
+		ExitWithResult(logger, driver.Init(logger))
 
 	// <driver executable> getvolumename <json options>
 	// Currently broken as of lates kube release (1.6.4). Work around hardcodes

--- a/pkg/flexvolume/flexvolume.go
+++ b/pkg/flexvolume/flexvolume.go
@@ -18,8 +18,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
+
+	"go.uber.org/zap"
 )
 
 // Defined to enable overriding in tests.
@@ -71,20 +72,20 @@ const (
 
 // Driver is the main Flexvolume interface.
 type Driver interface {
-	Init() DriverStatus
-	Attach(opts Options, nodeName string) DriverStatus
-	Detach(mountDevice, nodeName string) DriverStatus
+	Init(logger *zap.SugaredLogger) DriverStatus
+	Attach(logger *zap.SugaredLogger, opts Options, nodeName string) DriverStatus
+	Detach(logger *zap.SugaredLogger, mountDevice, nodeName string) DriverStatus
 	WaitForAttach(mountDevice string, opts Options) DriverStatus
-	IsAttached(opts Options, nodeName string) DriverStatus
-	MountDevice(mountDir, mountDevice string, opts Options) DriverStatus
-	UnmountDevice(mountDevice string) DriverStatus
-	Mount(mountDir string, opts Options) DriverStatus
-	Unmount(mountDir string) DriverStatus
+	IsAttached(logger *zap.SugaredLogger, opts Options, nodeName string) DriverStatus
+	MountDevice(logger *zap.SugaredLogger, mountDir, mountDevice string, opts Options) DriverStatus
+	UnmountDevice(logger *zap.SugaredLogger, mountDevice string) DriverStatus
+	Mount(logger *zap.SugaredLogger, mountDir string, opts Options) DriverStatus
+	Unmount(logger *zap.SugaredLogger, mountDir string) DriverStatus
 }
 
 // ExitWithResult outputs the given Result and exits with the appropriate exit
 // code.
-func ExitWithResult(result DriverStatus) {
+func ExitWithResult(logger *zap.SugaredLogger, result DriverStatus) {
 	code := 1
 	if result.Status == StatusSuccess || result.Status == StatusNotSupported {
 		code = 0
@@ -92,19 +93,20 @@ func ExitWithResult(result DriverStatus) {
 
 	res, err := json.Marshal(result)
 	if err != nil {
-		log.Printf("Error marshaling result: %v", err)
+		logger.With("result", result, zap.Error(err)).Error("Error marshaling result to JSON.")
 		fmt.Fprintln(out, `{"status":"Failure","message":"Error marshaling result to JSON"}`)
 	} else {
 		s := string(res)
-		log.Printf("Command result: %s", s)
+		logger.With("result", res).Debug("Command finished.")
 		fmt.Fprintln(out, s)
 	}
 	exit(code)
 }
 
 // Fail creates a StatusFailure Result with a given message.
-func Fail(a ...interface{}) DriverStatus {
+func Fail(logger *zap.SugaredLogger, a ...interface{}) DriverStatus {
 	msg := fmt.Sprint(a...)
+	logger.With("status", StatusFailure).Error(msg)
 	return DriverStatus{
 		Status:  StatusFailure,
 		Message: msg,
@@ -112,18 +114,22 @@ func Fail(a ...interface{}) DriverStatus {
 }
 
 // Succeed creates a StatusSuccess Result with a given message.
-func Succeed(a ...interface{}) DriverStatus {
+func Succeed(logger *zap.SugaredLogger, a ...interface{}) DriverStatus {
+	msg := fmt.Sprint(a...)
+	logger.With("status", StatusSuccess).Info(msg)
 	return DriverStatus{
 		Status:  StatusSuccess,
-		Message: fmt.Sprint(a...),
+		Message: msg,
 	}
 }
 
 // NotSupported creates a StatusNotSupported Result with a given message.
-func NotSupported(a ...interface{}) DriverStatus {
+func NotSupported(logger *zap.SugaredLogger, a ...interface{}) DriverStatus {
+	msg := fmt.Sprint(a...)
+	logger.With("status", StatusNotSupported).Warn(msg)
 	return DriverStatus{
 		Status:  StatusNotSupported,
-		Message: fmt.Sprint(a...),
+		Message: msg,
 	}
 }
 
@@ -143,17 +149,18 @@ func processOpts(optsStr string) (Options, error) {
 
 // ExecDriver executes the appropriate FlexvolumeDriver command based on
 // recieved call-out.
-func ExecDriver(driver Driver, args []string) {
+func ExecDriver(logger *zap.SugaredLogger, driver Driver, args []string) {
 	if len(args) < 2 {
-		ExitWithResult(Fail("Expected at least one argument"))
+		ExitWithResult(logger, Fail(logger, "Expected at least one argument."))
 	}
 
-	log.Printf("'%s %s' called with %s", args[0], args[1], args[2:])
+	logger = logger.With("command", args[1])
+	logger.With("binary", args[0], "arguments", args[2:]).Debug("Exec called")
 
 	switch args[1] {
 	// <driver executable> init
 	case "init":
-		ExitWithResult(driver.Init())
+		ExitWithResult(logger, driver.Init(zap.New(nil).Sugar()))
 
 	// <driver executable> getvolumename <json options>
 	// Currently broken as of lates kube release (1.6.4). Work around hardcodes
@@ -161,63 +168,63 @@ func ExecDriver(driver Driver, args []string) {
 	// TODO(apryde): Investigate current situation and version support
 	// requirements.
 	case "getvolumename":
-		ExitWithResult(NotSupported("getvolumename is broken as of kube 1.6.4"))
+		ExitWithResult(logger, NotSupported(logger, "getvolumename is broken as of kube 1.6.4"))
 
 	// <driver executable> attach <json options> <node name>
 	case "attach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("attach expected exactly 4 arguments; got ", args))
+			ExitWithResult(logger, Fail(logger, "attach expected exactly 4 arguments; got ", args))
 		}
 
 		opts, err := processOpts(args[2])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			ExitWithResult(logger, Fail(logger, err))
 		}
 
 		nodeName := args[3]
-		ExitWithResult(driver.Attach(opts, nodeName))
+		ExitWithResult(logger, driver.Attach(logger, opts, nodeName))
 
 	// <driver executable> detach <mount device> <node name>
 	case "detach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("detach expected exactly 4 arguments; got ", args))
+			ExitWithResult(logger, Fail(logger, "detach expected exactly 4 arguments; got ", args))
 		}
 
 		mountDevice := args[2]
 		nodeName := args[3]
-		ExitWithResult(driver.Detach(mountDevice, nodeName))
+		ExitWithResult(logger, driver.Detach(logger, mountDevice, nodeName))
 
 	// <driver executable> waitforattach <mount device> <json options>
 	case "waitforattach":
 		if len(args) != 4 {
-			ExitWithResult(Fail("waitforattach expected exactly 4 arguments; got ", args))
+			ExitWithResult(logger, Fail(logger, "waitforattach expected exactly 4 arguments; got ", args))
 		}
 
 		mountDevice := args[2]
 		opts, err := processOpts(args[3])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			ExitWithResult(logger, Fail(logger, err))
 		}
 
-		ExitWithResult(driver.WaitForAttach(mountDevice, opts))
+		ExitWithResult(logger, driver.WaitForAttach(mountDevice, opts))
 
 	// <driver executable> isattached <json options> <node name>
 	case "isattached":
 		if len(args) != 4 {
-			ExitWithResult(Fail("isattached expected exactly 4 arguments; got ", args))
+			ExitWithResult(logger, Fail(logger, "isattached expected exactly 4 arguments; got ", args))
 		}
 
 		opts, err := processOpts(args[2])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			ExitWithResult(logger, Fail(logger, err))
 		}
 		nodeName := args[3]
-		ExitWithResult(driver.IsAttached(opts, nodeName))
+		ExitWithResult(logger, driver.IsAttached(logger, opts, nodeName))
 
 	// <driver executable> mountdevice <mount dir> <mount device> <json options>
 	case "mountdevice":
 		if len(args) != 5 {
-			ExitWithResult(Fail("mountdevice expected exactly 5 arguments; got ", args))
+			ExitWithResult(logger, Fail(logger, "mountdevice expected exactly 5 arguments; got ", args))
 		}
 
 		mountDir := args[2]
@@ -225,45 +232,45 @@ func ExecDriver(driver Driver, args []string) {
 
 		opts, err := processOpts(args[4])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			ExitWithResult(logger, Fail(logger, err))
 		}
 
-		ExitWithResult(driver.MountDevice(mountDir, mountDevice, opts))
+		ExitWithResult(logger, driver.MountDevice(logger, mountDir, mountDevice, opts))
 
 	// <driver executable> unmountdevice <mount dir>
 	case "unmountdevice":
 		if len(args) != 3 {
-			ExitWithResult(Fail("unmountdevice expected exactly 3 arguments; got ", args))
+			ExitWithResult(logger, Fail(logger, "unmountdevice expected exactly 3 arguments; got ", args))
 		}
 
 		mountDir := args[2]
-		ExitWithResult(driver.UnmountDevice(mountDir))
+		ExitWithResult(logger, driver.UnmountDevice(logger, mountDir))
 
 	// <driver executable> mount <mount dir> <json options>
 	case "mount":
 		if len(args) != 4 {
-			ExitWithResult(Fail("mount expected exactly 4 arguments; got ", args))
+			ExitWithResult(logger, Fail(logger, "mount expected exactly 4 arguments; got ", args))
 		}
 
 		mountDir := args[2]
 
 		opts, err := processOpts(args[3])
 		if err != nil {
-			ExitWithResult(Fail(err))
+			ExitWithResult(logger, Fail(logger, err))
 		}
 
-		ExitWithResult(driver.Mount(mountDir, opts))
+		ExitWithResult(logger, driver.Mount(logger, mountDir, opts))
 
 	// <driver executable> unmount <mount dir>
 	case "unmount":
 		if len(args) != 3 {
-			ExitWithResult(Fail("mount expected exactly 3 arguments; got ", args))
+			ExitWithResult(logger, Fail(logger, "mount expected exactly 3 arguments; got ", args))
 		}
 
 		mountDir := args[2]
-		ExitWithResult(driver.Unmount(mountDir))
+		ExitWithResult(logger, driver.Unmount(logger, mountDir))
 
 	default:
-		ExitWithResult(Fail("Invalid command; got ", args))
+		ExitWithResult(logger, Fail(logger, "Invalid command; got ", args))
 	}
 }

--- a/pkg/flexvolume/flexvolume_mock.go
+++ b/pkg/flexvolume/flexvolume_mock.go
@@ -14,40 +14,47 @@
 
 package flexvolume
 
+import (
+	"go.uber.org/zap"
+)
+
 type mockFlexvolumeDriver struct{}
 
-func (driver mockFlexvolumeDriver) Init() DriverStatus {
-	return Succeed()
+func (driver mockFlexvolumeDriver) Init(logger *zap.SugaredLogger) DriverStatus {
+	return Succeed(logger)
 }
 
-func (driver mockFlexvolumeDriver) Attach(opts Options, nodeName string) DriverStatus {
-	return NotSupported()
+func (driver mockFlexvolumeDriver) Attach(logger *zap.SugaredLogger, opts Options, nodeName string) DriverStatus {
+	return NotSupported(logger)
 }
 
-func (driver mockFlexvolumeDriver) Detach(mountDevice, nodeName string) DriverStatus {
-	return Succeed()
+func (driver mockFlexvolumeDriver) Detach(logger *zap.SugaredLogger, mountDevice, nodeName string) DriverStatus {
+	return Succeed(logger)
 }
 
 func (driver mockFlexvolumeDriver) WaitForAttach(mountDevice string, opts Options) DriverStatus {
-	return Succeed()
+	return DriverStatus{
+		Status: StatusSuccess,
+		Device: mountDevice,
+	}
 }
 
-func (driver mockFlexvolumeDriver) IsAttached(opts Options, nodeName string) DriverStatus {
-	return Succeed()
+func (driver mockFlexvolumeDriver) IsAttached(logger *zap.SugaredLogger, opts Options, nodeName string) DriverStatus {
+	return Succeed(logger)
 }
 
-func (driver mockFlexvolumeDriver) MountDevice(mountDir, mountDevice string, opts Options) DriverStatus {
-	return Succeed()
+func (driver mockFlexvolumeDriver) MountDevice(logger *zap.SugaredLogger, mountDir, mountDevice string, opts Options) DriverStatus {
+	return Succeed(logger)
 }
 
-func (driver mockFlexvolumeDriver) UnmountDevice(mountDevice string) DriverStatus {
-	return Succeed()
+func (driver mockFlexvolumeDriver) UnmountDevice(logger *zap.SugaredLogger, mountDevice string) DriverStatus {
+	return Succeed(logger)
 }
 
-func (driver mockFlexvolumeDriver) Mount(mountDir string, opts Options) DriverStatus {
-	return Succeed()
+func (driver mockFlexvolumeDriver) Mount(logger *zap.SugaredLogger, mountDir string, opts Options) DriverStatus {
+	return Succeed(logger)
 }
 
-func (driver mockFlexvolumeDriver) Unmount(mountDir string) DriverStatus {
-	return Succeed()
+func (driver mockFlexvolumeDriver) Unmount(logger *zap.SugaredLogger, mountDir string) DriverStatus {
+	return Succeed(logger)
 }

--- a/pkg/flexvolume/flexvolume_test.go
+++ b/pkg/flexvolume/flexvolume_test.go
@@ -17,11 +17,14 @@ package flexvolume
 import (
 	"bytes"
 	"testing"
+
+	"go.uber.org/zap/zaptest"
 )
 
 const defaultTestOps = `{"kubernetes.io/fsType":"ext4","kubernetes.io/readwrite":"rw"}`
 
 func TestInit(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
 	bak := out
 	out = new(bytes.Buffer)
 	defer func() { out = bak }()
@@ -31,10 +34,10 @@ func TestInit(t *testing.T) {
 	exit = func(c int) { code = c }
 	defer func() { exit = osexit }()
 
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "init"})
+	ExecDriver(logger, mockFlexvolumeDriver{}, []string{"oci", "init"})
 
 	if out.(*bytes.Buffer).String() != `{"status":"Success"}`+"\n" {
-		t.Fatalf(`Expected '{"status":"Success"}'; got %s`, out.(*bytes.Buffer).String())
+		t.Fatalf(`Expected '{"status":"Success"}'; got %q`, out.(*bytes.Buffer).String())
 	}
 
 	if code != 0 {
@@ -46,6 +49,7 @@ func TestInit(t *testing.T) {
 // StatusNotSupported as the call-out is broken as of the latest stable Kube
 // release (1.6.4).
 func TestGetVolumeName(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
 	bak := out
 	out = new(bytes.Buffer)
 	defer func() { out = bak }()
@@ -55,7 +59,7 @@ func TestGetVolumeName(t *testing.T) {
 	exit = func(c int) { code = c }
 	defer func() { exit = osexit }()
 
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "getvolumename", defaultTestOps})
+	ExecDriver(logger, mockFlexvolumeDriver{}, []string{"oci", "getvolumename", defaultTestOps})
 
 	if out.(*bytes.Buffer).String() != `{"status":"Not supported","message":"getvolumename is broken as of kube 1.6.4"}`+"\n" {
 		t.Fatalf(`Expected '{"status":"Not supported","message":"getvolumename is broken as of kube 1.6.4"}}'; got %s`, out.(*bytes.Buffer).String())
@@ -67,6 +71,7 @@ func TestGetVolumeName(t *testing.T) {
 }
 
 func TestAttachUnsuported(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
 	bak := out
 	out = new(bytes.Buffer)
 	defer func() { out = bak }()
@@ -76,7 +81,7 @@ func TestAttachUnsuported(t *testing.T) {
 	exit = func(c int) { code = c }
 	defer func() { exit = osexit }()
 
-	ExecDriver(mockFlexvolumeDriver{}, []string{"oci", "attach", defaultTestOps, "nodeName"})
+	ExecDriver(logger, mockFlexvolumeDriver{}, []string{"oci", "attach", defaultTestOps, "nodeName"})
 
 	if out.(*bytes.Buffer).String() != `{"status":"Not supported"}`+"\n" {
 		t.Fatalf(`Expected '{"status":"Not supported""}'; got %s`, out.(*bytes.Buffer).String())

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -52,6 +52,15 @@ func Level() *zap.AtomicLevel {
 
 // Logger builds a new logger based on the given flags.
 func Logger() *zap.Logger {
+	return logger(logfilePath)
+}
+
+// FileLogger builds a new logger which logs to the given path.
+func FileLogger(path string) *zap.Logger {
+	return logger(path)
+}
+
+func logger(path string) *zap.Logger {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -73,9 +82,9 @@ func Logger() *zap.Logger {
 		}),
 	}
 
-	if len(logfilePath) > 0 {
+	if len(path) > 0 {
 		w := zapcore.AddSync(&lumberjack.Logger{
-			Filename:   logfilePath,
+			Filename:   path,
 			MaxSize:    10, // megabytes
 			MaxBackups: 3,
 			MaxAge:     28, // days

--- a/pkg/util/iscsi/iscsi.go
+++ b/pkg/util/iscsi/iscsi.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 
 	"github.com/oracle/oci-cloud-controller-manager/pkg/util/mount"
+
 	"go.uber.org/zap"
 	"k8s.io/utils/exec"
 )

--- a/pkg/util/iscsi/iscsi.go
+++ b/pkg/util/iscsi/iscsi.go
@@ -114,7 +114,7 @@ func newWithMounter(logger *zap.SugaredLogger, mounter mount.Interface, iqn, ipv
 
 // New creates a new iSCSI handler.
 func New(logger *zap.SugaredLogger, iqn, ipv4 string, port int) Interface {
-	return newWithMounter(logger, mount.New(mountCommand), iqn, ipv4, port)
+	return newWithMounter(logger, mount.New(logger, mountCommand), iqn, ipv4, port)
 }
 
 // NewFromDevicePath extracts the IQN, IPv4 address, and port from a
@@ -137,7 +137,7 @@ func NewFromDevicePath(logger *zap.SugaredLogger, mountDevice string) (Interface
 // NewFromMountPointPath gets /dev/disk/by-path/ip-<ip>:<port>-iscsi-<IQN>-lun-1
 // from the given mount point path.
 func NewFromMountPointPath(logger *zap.SugaredLogger, mountPath string) (Interface, error) {
-	mounter := mount.New(mountCommand)
+	mounter := mount.New(logger, mountCommand)
 	mountPoint, err := getMountPointForPath(mounter, mountPath)
 	if err != nil {
 		return nil, err
@@ -273,11 +273,12 @@ func (c *iSCSIMounter) FormatAndMount(source string, target string, fstype strin
 	return (&mount.SafeFormatAndMount{
 		Interface: c.mounter,
 		Runner:    c.runner,
+		Logger:    c.logger,
 	}).FormatAndMount(source, target, fstype, options)
 }
 
 func (c *iSCSIMounter) UnmountPath(path string) error {
-	return mount.UnmountPath(path, c.mounter)
+	return mount.UnmountPath(c.logger, path, c.mounter)
 }
 
 // mountLister is a minimal subset of mount.Interface (used to enable testing).

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -19,12 +19,6 @@ limitations under the License.
 package mount
 
 import (
-	"fmt"
-	"log"
-	"path"
-	"path/filepath"
-	"strings"
-
 	"k8s.io/utils/exec"
 )
 
@@ -61,7 +55,7 @@ type Interface interface {
 // the mount interface
 var _ Interface = &Mounter{}
 
-// This represents a single line in /proc/mounts or /etc/fstab.
+// MountPoint represents a single line in /proc/mounts or /etc/fstab.
 type MountPoint struct {
 	Device string
 	Path   string
@@ -101,101 +95,4 @@ func New(mounterPath string) Interface {
 	return &Mounter{
 		mounterPath: mounterPath,
 	}
-}
-
-// GetMountRefs finds all other references to the device referenced
-// by mountPath; returns a list of paths.
-func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
-	mps, err := mounter.List()
-	if err != nil {
-		return nil, err
-	}
-
-	// Find the device name.
-	deviceName := ""
-	// If mountPath is symlink, need get its target path.
-	slTarget, err := filepath.EvalSymlinks(mountPath)
-	if err != nil {
-		slTarget = mountPath
-	}
-	for i := range mps {
-		if mps[i].Path == slTarget {
-			deviceName = mps[i].Device
-			break
-		}
-	}
-
-	// Find all references to the device.
-	var refs []string
-	if deviceName == "" {
-		log.Printf("could not determine device for path: %q", mountPath)
-	} else {
-		for i := range mps {
-			if mps[i].Device == deviceName && mps[i].Path != slTarget {
-				refs = append(refs, mps[i].Path)
-			}
-		}
-	}
-	return refs, nil
-}
-
-// GetDeviceNameFromMount: given a mnt point, find the device from /proc/mounts
-// returns the device name, reference count, and error code
-func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, error) {
-	mps, err := mounter.List()
-	if err != nil {
-		return "", 0, err
-	}
-
-	// Find the device name.
-	// FIXME if multiple devices mounted on the same mount path, only the first one is returned
-	device := ""
-	// If mountPath is symlink, need get its target path.
-	slTarget, err := filepath.EvalSymlinks(mountPath)
-	if err != nil {
-		slTarget = mountPath
-	}
-	for i := range mps {
-		if mps[i].Path == slTarget {
-			device = mps[i].Device
-			break
-		}
-	}
-
-	// Find all references to the device.
-	refCount := 0
-	for i := range mps {
-		if mps[i].Device == device {
-			refCount++
-		}
-	}
-	return device, refCount, nil
-}
-
-// getDeviceNameFromMount find the device name from /proc/mounts in which
-// the mount path reference should match the given plugin directory. In case no mount path reference
-// matches, returns the volume name taken from its given mountPath
-func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (string, error) {
-	refs, err := GetMountRefs(mounter, mountPath)
-	if err != nil {
-		log.Printf("GetMountRefs failed for mount path %q: %v", mountPath, err)
-		return "", err
-	}
-	if len(refs) == 0 {
-		log.Printf("Directory %s is not mounted", mountPath)
-		return "", fmt.Errorf("directory %s is not mounted", mountPath)
-	}
-	basemountPath := path.Join(pluginDir, MountsInGlobalPDPath)
-	for _, ref := range refs {
-		if strings.HasPrefix(ref, basemountPath) {
-			volumeID, err := filepath.Rel(basemountPath, ref)
-			if err != nil {
-				log.Printf("Failed to get volume id from mount %s - %v", mountPath, err)
-				return "", err
-			}
-			return volumeID, nil
-		}
-	}
-
-	return path.Base(mountPath), nil
 }

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -176,12 +176,13 @@ func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, e
 // matches, returns the volume name taken from its given mountPath
 func getDeviceNameFromMount(logger *zap.SugaredLogger, mounter Interface, mountPath, pluginDir string) (string, error) {
 	refs, err := GetMountRefs(logger, mounter, mountPath)
+	logger = logger.With("mountpath", mountPath)
 	if err != nil {
-		logger.With(zap.Error(err), "mount path", mountPath).Error("GetMountRefs failed.")
+		logger.With(zap.Error(err)).Error("GetMountRefs failed.")
 		return "", err
 	}
 	if len(refs) == 0 {
-		logger.With("mount path", mountPath).Info("Directory is not mounted.")
+		logger.Info("Directory is not mounted.")
 		return "", fmt.Errorf("directory %s is not mounted", mountPath)
 	}
 	basemountPath := path.Join(pluginDir, MountsInGlobalPDPath)
@@ -189,7 +190,7 @@ func getDeviceNameFromMount(logger *zap.SugaredLogger, mounter Interface, mountP
 		if strings.HasPrefix(ref, basemountPath) {
 			volumeID, err := filepath.Rel(basemountPath, ref)
 			if err != nil {
-				logger.With(zap.Error(err), "mount path", mountPath).Error("Failed to get volume id from mount.")
+				logger.With(zap.Error(err)).Error("Failed to get volume id from mount.")
 				return "", err
 			}
 			return volumeID, nil

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -129,7 +129,7 @@ func GetMountRefs(logger *zap.SugaredLogger, mounter Interface, mountPath string
 	// Find all references to the device.
 	var refs []string
 	if deviceName == "" {
-		logger.With("mount path", mountPath).Info("Could not deterimne device at mount path.")
+		logger.With("mountPath", mountPath).Info("Could not determine device at mount path.")
 	} else {
 		for i := range mps {
 			if mps[i].Device == deviceName && mps[i].Path != slTarget {

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -19,6 +19,12 @@ limitations under the License.
 package mount
 
 import (
+	"fmt"
+	"log"
+	"path"
+	"path/filepath"
+	"strings"
+
 	"k8s.io/utils/exec"
 )
 
@@ -95,4 +101,96 @@ func New(mounterPath string) Interface {
 	return &Mounter{
 		mounterPath: mounterPath,
 	}
+}
+
+// GetMountRefs finds all other references to the device referenced
+// by mountPath; returns a list of paths.
+func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
+	mps, err := mounter.List()
+	if err != nil {
+		return nil, err
+	}
+	// Find the device name.
+	deviceName := ""
+	// If mountPath is symlink, need get its target path.
+	slTarget, err := filepath.EvalSymlinks(mountPath)
+	if err != nil {
+		slTarget = mountPath
+	}
+	for i := range mps {
+		if mps[i].Path == slTarget {
+			deviceName = mps[i].Device
+			break
+		}
+	}
+	// Find all references to the device.
+	var refs []string
+	if deviceName == "" {
+		log.Printf("could not determine device for path: %q", mountPath)
+	} else {
+		for i := range mps {
+			if mps[i].Device == deviceName && mps[i].Path != slTarget {
+				refs = append(refs, mps[i].Path)
+			}
+		}
+	}
+	return refs, nil
+}
+
+// GetDeviceNameFromMount: given a mnt point, find the device from /proc/mounts
+// returns the device name, reference count, and error code
+func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, error) {
+	mps, err := mounter.List()
+	if err != nil {
+		return "", 0, err
+	}
+	// Find the device name.
+	// FIXME if multiple devices mounted on the same mount path, only the first one is returned
+	device := ""
+	// If mountPath is symlink, need get its target path.
+	slTarget, err := filepath.EvalSymlinks(mountPath)
+	if err != nil {
+		slTarget = mountPath
+	}
+	for i := range mps {
+		if mps[i].Path == slTarget {
+			device = mps[i].Device
+			break
+		}
+	}
+	// Find all references to the device.
+	refCount := 0
+	for i := range mps {
+		if mps[i].Device == device {
+			refCount++
+		}
+	}
+	return device, refCount, nil
+}
+
+// getDeviceNameFromMount find the device name from /proc/mounts in which
+// the mount path reference should match the given plugin directory. In case no mount path reference
+// matches, returns the volume name taken from its given mountPath
+func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (string, error) {
+	refs, err := GetMountRefs(mounter, mountPath)
+	if err != nil {
+		log.Printf("GetMountRefs failed for mount path %q: %v", mountPath, err)
+		return "", err
+	}
+	if len(refs) == 0 {
+		log.Printf("Directory %s is not mounted", mountPath)
+		return "", fmt.Errorf("directory %s is not mounted", mountPath)
+	}
+	basemountPath := path.Join(pluginDir, MountsInGlobalPDPath)
+	for _, ref := range refs {
+		if strings.HasPrefix(ref, basemountPath) {
+			volumeID, err := filepath.Rel(basemountPath, ref)
+			if err != nil {
+				log.Printf("Failed to get volume id from mount %s - %v", mountPath, err)
+				return "", err
+			}
+			return volumeID, nil
+		}
+	}
+	return path.Base(mountPath), nil
 }

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -20,10 +20,11 @@ package mount
 
 import (
 	"fmt"
-	"log"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"go.uber.org/zap"
 
 	"k8s.io/utils/exec"
 )
@@ -77,6 +78,7 @@ type MountPoint struct {
 type SafeFormatAndMount struct {
 	Interface
 	Runner exec.Interface
+	Logger *zap.SugaredLogger
 }
 
 // FormatAndMount formats the given disk, if needed, and mounts it.
@@ -97,15 +99,16 @@ func (mounter *SafeFormatAndMount) FormatAndMount(source string, target string, 
 // New returns a mount.Interface for the current system.
 // It provides options to override the default mounter behavior.
 // mounterPath allows using an alternative to `/bin/mount` for mounting.
-func New(mounterPath string) Interface {
+func New(logger *zap.SugaredLogger, mounterPath string) Interface {
 	return &Mounter{
 		mounterPath: mounterPath,
+		logger:      logger,
 	}
 }
 
 // GetMountRefs finds all other references to the device referenced
 // by mountPath; returns a list of paths.
-func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
+func GetMountRefs(logger *zap.SugaredLogger, mounter Interface, mountPath string) ([]string, error) {
 	mps, err := mounter.List()
 	if err != nil {
 		return nil, err
@@ -126,7 +129,7 @@ func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
 	// Find all references to the device.
 	var refs []string
 	if deviceName == "" {
-		log.Printf("could not determine device for path: %q", mountPath)
+		logger.With("mount path", mountPath).Info("Could not deterimne device at mount path.")
 	} else {
 		for i := range mps {
 			if mps[i].Device == deviceName && mps[i].Path != slTarget {
@@ -137,8 +140,8 @@ func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
 	return refs, nil
 }
 
-// GetDeviceNameFromMount: given a mnt point, find the device from /proc/mounts
-// returns the device name, reference count, and error code
+// GetDeviceNameFromMount finds the device name and reference count
+// of given a mount point from /proc/mounts
 func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, error) {
 	mps, err := mounter.List()
 	if err != nil {
@@ -171,14 +174,14 @@ func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, e
 // getDeviceNameFromMount find the device name from /proc/mounts in which
 // the mount path reference should match the given plugin directory. In case no mount path reference
 // matches, returns the volume name taken from its given mountPath
-func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (string, error) {
-	refs, err := GetMountRefs(mounter, mountPath)
+func getDeviceNameFromMount(logger *zap.SugaredLogger, mounter Interface, mountPath, pluginDir string) (string, error) {
+	refs, err := GetMountRefs(logger, mounter, mountPath)
 	if err != nil {
-		log.Printf("GetMountRefs failed for mount path %q: %v", mountPath, err)
+		logger.With(zap.Error(err), "mount path", mountPath).Error("GetMountRefs failed.")
 		return "", err
 	}
 	if len(refs) == 0 {
-		log.Printf("Directory %s is not mounted", mountPath)
+		logger.With("mount path", mountPath).Info("Directory is not mounted.")
 		return "", fmt.Errorf("directory %s is not mounted", mountPath)
 	}
 	basemountPath := path.Join(pluginDir, MountsInGlobalPDPath)
@@ -186,7 +189,7 @@ func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (str
 		if strings.HasPrefix(ref, basemountPath) {
 			volumeID, err := filepath.Rel(basemountPath, ref)
 			if err != nil {
-				log.Printf("Failed to get volume id from mount %s - %v", mountPath, err)
+				logger.With(zap.Error(err), "mount path", mountPath).Error("Failed to get volume id from mount.")
 				return "", err
 			}
 			return volumeID, nil

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -342,12 +342,18 @@ func readProcMountsFrom(file io.Reader, out *[]MountPoint) (uint32, error) {
 // formatAndMount uses unix utils to format and mount the given disk
 func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, fstype string, options []string) error {
 	options = append(options, "defaults")
-	mounter.Logger = mounter.Logger.With("source", source)
+	mounter.Logger = mounter.Logger.With(
+		"source", source,
+		"target", target,
+		"fstype", fstype,
+		"options", options,
+	)
 	// Run fsck on the disk to fix repairable issues
 	mounter.Logger.Info("Checking disk for issues using 'fsck'.")
 	args := []string{"-a", source}
 	cmd := mounter.Runner.Command("fsck", args...)
 	out, err := cmd.CombinedOutput()
+	mounter.Logger = mounter.Logger.With("output", out)
 	if err != nil {
 		ee, isExitError := err.(utilexec.ExitError)
 		switch {
@@ -356,15 +362,15 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 		case isExitError && ee.ExitStatus() == fsckErrorsCorrected:
 			mounter.Logger.Info("Device has errors that were corrected with 'fsck'.")
 		case isExitError && ee.ExitStatus() == fsckErrorsUncorrected:
-			mounter.Logger.With("output", out).Info("'fsck' found errors on device but was unable to correct them.")
+			mounter.Logger.Info("'fsck' found errors on device but was unable to correct them.")
 			return fmt.Errorf("'fsck' found errors on device %s but could not correct them: %s.", source, string(out))
 		case isExitError && ee.ExitStatus() > fsckErrorsUncorrected:
-			mounter.Logger.With("output", out).Error("'fsck' error.")
+			mounter.Logger.Error("'fsck' error.")
 		}
 	}
 
 	// Try to mount the disk
-	mounter.Logger.With("fsType", fstype, "source", source, "target", target).Info("Attempting to mount disk.")
+	mounter.Logger.Info("Attempting to mount disk.")
 	mountErr := mounter.Interface.Mount(source, target, fstype, options)
 	if mountErr != nil {
 		// Mount failed. This indicates either that the disk is unformatted or
@@ -384,26 +390,15 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 			if fstype == "ext4" || fstype == "ext3" {
 				args = []string{"-F", source}
 			}
-			mounter.Logger.With(
-				"fsType", fstype,
-				"argruments", args,
-			).Info("Disk appears to be unformatted, attempting to format.")
+			mounter.Logger.With("argruments", args).Info("Disk appears to be unformatted, attempting to format.")
 			cmd := mounter.Runner.Command("mkfs."+fstype, args...)
 			_, err := cmd.CombinedOutput()
 			if err == nil {
 				// the disk has been formatted successfully try to mount it again.
-				mounter.Logger.With(
-					"fs type", fstype,
-					"target", target,
-				).Info("Disk successfully formatted.")
+				mounter.Logger.Info("Disk successfully formatted.")
 				return mounter.Interface.Mount(source, target, fstype, options)
 			}
-			mounter.Logger.With(
-				zap.Error(err),
-				"fsType", fstype,
-				"target", target,
-				"options", options,
-			).Error("Format of disk failed.")
+			mounter.Logger.With(zap.Error(err)).Error("Format of disk failed.")
 			return err
 		} else {
 			// Disk is already formatted and failed to mount

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -122,7 +122,7 @@ func doMount(logger *zap.SugaredLogger, mounterPath string, mountCmd string, sou
 	if err != nil {
 		logger.With(
 			zap.Error(err),
-			"mount command", mountCmd,
+			"command", mountCmd,
 			"source", source,
 			"target", target,
 			"fs type", fstype,

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -23,13 +23,13 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
 
+	"go.uber.org/zap"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -54,6 +54,7 @@ const (
 // kubelet is running in the host's root mount namespace.
 type Mounter struct {
 	mounterPath string
+	logger      *zap.SugaredLogger
 }
 
 // Mount mounts source to target as fstype with given options. 'source' and 'fstype' must
@@ -67,11 +68,11 @@ func (mounter *Mounter) Mount(source string, target string, fstype string, optio
 	mounterPath := ""
 	bind, bindRemountOpts := isBind(options)
 	if bind {
-		err := doMount(mounterPath, defaultMountCommand, source, target, fstype, []string{"bind"})
+		err := doMount(mounter.logger, mounterPath, defaultMountCommand, source, target, fstype, []string{"bind"})
 		if err != nil {
 			return err
 		}
-		return doMount(mounterPath, defaultMountCommand, source, target, fstype, bindRemountOpts)
+		return doMount(mounter.logger, mounterPath, defaultMountCommand, source, target, fstype, bindRemountOpts)
 	}
 	// The list of filesystems that require containerized mounter on GCI image cluster
 	fsTypesNeedMounter := []string{"nfs", "glusterfs", "ceph", "cifs"}
@@ -80,7 +81,7 @@ func (mounter *Mounter) Mount(source string, target string, fstype string, optio
 			mounterPath = mounter.mounterPath
 		}
 	}
-	return doMount(mounterPath, defaultMountCommand, source, target, fstype, options)
+	return doMount(mounter.logger, mounterPath, defaultMountCommand, source, target, fstype, options)
 }
 
 // isBind detects whether a bind mount is being requested and makes the remount options to
@@ -109,18 +110,25 @@ func isBind(options []string) (bool, []string) {
 }
 
 // doMount runs the mount command. mounterPath is the path to mounter binary if containerized mounter is used.
-func doMount(mounterPath string, mountCmd string, source string, target string, fstype string, options []string) error {
+func doMount(logger *zap.SugaredLogger, mounterPath string, mountCmd string, source string, target string, fstype string, options []string) error {
 	mountArgs := makeMountArgs(source, target, fstype, options)
 	if len(mounterPath) > 0 {
 		mountArgs = append([]string{mountCmd}, mountArgs...)
 		mountCmd = mounterPath
 	}
-
-	log.Printf("Mounting cmd (%s) with arguments (%s)", mountCmd, mountArgs)
+	logger.With("mount command", mountCmd, "mount arguments", mountArgs).Info("Mounting.")
 	command := exec.Command(mountCmd, mountArgs...)
 	output, err := command.CombinedOutput()
 	if err != nil {
-		log.Printf("Mount failed: %v\nMounting command: %s\nMounting arguments: %s %s %s %v\nOutput: %s\n", err, mountCmd, source, target, fstype, options, string(output))
+		logger.With(
+			zap.Error(err),
+			"mount command", mountCmd,
+			"source", source,
+			"target", target,
+			"fs type", fstype,
+			"options", options,
+			"output", output,
+		).Error("Mount failed.")
 		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s %s %s %v\nOutput: %s\n",
 			err, mountCmd, source, target, fstype, options, string(output))
 	}
@@ -148,10 +156,15 @@ func makeMountArgs(source, target, fstype string, options []string) []string {
 
 // Unmount unmounts the target.
 func (mounter *Mounter) Unmount(target string) error {
-	log.Printf("Unmounting %s", target)
+	mounter.logger.With("target", target).Info("Unmounting.")
 	command := exec.Command("umount", target)
 	output, err := command.CombinedOutput()
 	if err != nil {
+		mounter.logger.With(
+			zap.Error(err),
+			"target", target,
+			"output", output,
+		).Error("Unmount failed.")
 		return fmt.Errorf("Unmount failed: %v\nUnmounting arguments: %s\nOutput: %s\n", err, target, string(output))
 	}
 	return nil
@@ -195,7 +208,7 @@ func IsNotMountPoint(file string) (bool, error) {
 // If open returns nil, return false with nil error.
 // Otherwise, return false with error
 func (mounter *Mounter) DeviceOpened(pathname string) (bool, error) {
-	return exclusiveOpenFailsOnDevice(pathname)
+	return exclusiveOpenFailsOnDevice(mounter.logger, pathname)
 }
 
 // PathIsDevice uses FileInfo returned from os.Stat to check if path refers
@@ -204,7 +217,7 @@ func (mounter *Mounter) PathIsDevice(pathname string) (bool, error) {
 	return pathIsDevice(pathname)
 }
 
-func exclusiveOpenFailsOnDevice(pathname string) (bool, error) {
+func exclusiveOpenFailsOnDevice(logger *zap.SugaredLogger, pathname string) (bool, error) {
 	isDevice, err := pathIsDevice(pathname)
 	if err != nil {
 		return false, fmt.Errorf(
@@ -213,7 +226,7 @@ func exclusiveOpenFailsOnDevice(pathname string) (bool, error) {
 			err)
 	}
 	if !isDevice {
-		log.Printf("Path %q is not refering to a device.", pathname)
+		logger.With("path", pathname).Warn("Path does not refer to a device.")
 		return false, nil
 	}
 	fd, errno := syscall.Open(pathname, syscall.O_RDONLY|syscall.O_EXCL, 0)
@@ -250,7 +263,7 @@ func pathIsDevice(pathname string) (bool, error) {
 
 //GetDeviceNameFromMount: given a mount point, find the device name from its global mount point
 func (mounter *Mounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
-	return getDeviceNameFromMount(mounter, mountPath, pluginDir)
+	return getDeviceNameFromMount(mounter.logger, mounter, mountPath, pluginDir)
 }
 
 func listProcMounts(mountFilePath string) ([]MountPoint, error) {
@@ -331,7 +344,7 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 	options = append(options, "defaults")
 
 	// Run fsck on the disk to fix repairable issues
-	log.Printf("Checking for issues with fsck on disk: %s", source)
+	mounter.Logger.With("source", source).Info("Checking disk for issues using 'fsck'.")
 	args := []string{"-a", source}
 	cmd := mounter.Runner.Command("fsck", args...)
 	out, err := cmd.CombinedOutput()
@@ -339,18 +352,18 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 		ee, isExitError := err.(utilexec.ExitError)
 		switch {
 		case err == utilexec.ErrExecutableNotFound:
-			log.Printf("'fsck' not found on system; continuing mount without running 'fsck'.")
+			mounter.Logger.Info("'fsck' not found on system; continuing mount without running 'fsck'.")
 		case isExitError && ee.ExitStatus() == fsckErrorsCorrected:
-			log.Printf("Device %s has errors which were corrected by fsck.", source)
+			mounter.Logger.With("source", source).Info("Device has errors that were corrected with 'fsck'.")
 		case isExitError && ee.ExitStatus() == fsckErrorsUncorrected:
-			return fmt.Errorf("'fsck' found errors on device %s but could not correct them: %s.", source, string(out))
+			mounter.Logger.With("source", source, "output", out).Info("'fsck' found errors on device but was unable to correct them.")
 		case isExitError && ee.ExitStatus() > fsckErrorsUncorrected:
-			log.Printf("`fsck` error %s", string(out))
+			mounter.Logger.With("output", out).Error("'fsck' error.")
 		}
 	}
 
 	// Try to mount the disk
-	log.Printf("Attempting to mount disk: %s %s %s", fstype, source, target)
+	mounter.Logger.With("fs type", fstype, "source", source, "target", target).Info("Attempting to mount disk.")
 	mountErr := mounter.Interface.Mount(source, target, fstype, options)
 	if mountErr != nil {
 		// Mount failed. This indicates either that the disk is unformatted or
@@ -370,15 +383,29 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 			if fstype == "ext4" || fstype == "ext3" {
 				args = []string{"-F", source}
 			}
-			log.Printf("Disk %q appears to be unformatted, attempting to format as type: %q with options: %v", source, fstype, args)
+			mounter.Logger.With(
+				"fs type", fstype,
+				"source", source,
+				"argruments", args,
+			).Info("Disk appears to be unformatted, attempting to format.")
 			cmd := mounter.Runner.Command("mkfs."+fstype, args...)
 			_, err := cmd.CombinedOutput()
 			if err == nil {
 				// the disk has been formatted successfully try to mount it again.
-				log.Printf("Disk successfully formatted (mkfs): %s - %s %s", fstype, source, target)
+				mounter.Logger.With(
+					"fs type", fstype,
+					"source", source,
+					"target", target,
+				).Info("Disk successfully formatted.")
 				return mounter.Interface.Mount(source, target, fstype, options)
 			}
-			log.Printf("format of disk %q failed: type:(%q) target:(%q) options:(%q)error:(%v)", source, fstype, target, options, err)
+			mounter.Logger.With(
+				zap.Error(err),
+				"fs type", fstype,
+				"source", source,
+				"target", target,
+				"options", options,
+			).Error("Format of disk failed.")
 			return err
 		} else {
 			// Disk is already formatted and failed to mount
@@ -394,19 +421,19 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 	return mountErr
 }
 
-// diskLooksUnformatted uses 'lsblk' to see if the given disk is unformated
+// getDiskFormat uses 'lsblk' to determine a given disk's format
 func (mounter *SafeFormatAndMount) getDiskFormat(disk string) (string, error) {
 	args := []string{"-n", "-o", "FSTYPE", disk}
 	cmd := mounter.Runner.Command("lsblk", args...)
-	log.Printf("Attempting to determine if disk %q is formatted using lsblk with args: (%v)", disk, args)
+	mounter.Logger.With("disk", disk, "arguments", args).Info("Attempting to determine if disk is formatted using lsblk.")
 	dataOut, err := cmd.CombinedOutput()
 	output := string(dataOut)
-	log.Printf("Output: %q", output)
 
 	if err != nil {
-		log.Printf("Could not determine if disk %q is formatted (%v)", disk, err)
+		mounter.Logger.With(zap.Error(err), "disk", disk).Error("Could not determine if disk is formatted.")
 		return "", err
 	}
+	mounter.Logger.With("output", output).Info("Disk format determined.")
 
 	// Split lsblk output into lines. Unformatted devices should contain only
 	// "\n". Beware of "\n\n", that's a device with one empty partition.

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -125,7 +125,7 @@ func doMount(logger *zap.SugaredLogger, mounterPath string, mountCmd string, sou
 			"command", mountCmd,
 			"source", source,
 			"target", target,
-			"fs type", fstype,
+			"fsType", fstype,
 			"options", options,
 			"output", output,
 		).Error("Mount failed.")

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -116,7 +116,7 @@ func doMount(logger *zap.SugaredLogger, mounterPath string, mountCmd string, sou
 		mountArgs = append([]string{mountCmd}, mountArgs...)
 		mountCmd = mounterPath
 	}
-	logger.With("mount command", mountCmd, "mount arguments", mountArgs).Info("Mounting.")
+	logger.With("command", mountCmd, "args", mountArgs).Info("Mounting")
 	command := exec.Command(mountCmd, mountArgs...)
 	output, err := command.CombinedOutput()
 	if err != nil {

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -384,7 +384,7 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 				args = []string{"-F", source}
 			}
 			mounter.Logger.With(
-				"fs type", fstype,
+				"fsType", fstype,
 				"source", source,
 				"argruments", args,
 			).Info("Disk appears to be unformatted, attempting to format.")

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -363,7 +363,7 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 	}
 
 	// Try to mount the disk
-	mounter.Logger.With("fs type", fstype, "source", source, "target", target).Info("Attempting to mount disk.")
+	mounter.Logger.With("fsType", fstype, "source", source, "target", target).Info("Attempting to mount disk.")
 	mountErr := mounter.Interface.Mount(source, target, fstype, options)
 	if mountErr != nil {
 		// Mount failed. This indicates either that the disk is unformatted or

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -401,7 +401,7 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 			}
 			mounter.Logger.With(
 				zap.Error(err),
-				"fs type", fstype,
+				"fsType", fstype,
 				"source", source,
 				"target", target,
 				"options", options,

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -18,8 +18,13 @@ limitations under the License.
 
 package mount
 
+import (
+	"go.uber.org/zap"
+)
+
 type Mounter struct {
 	mounterPath string
+	logger      *zap.SugaredLogger
 }
 
 func (mounter *Mounter) Mount(source string, target string, fstype string, options []string) error {

--- a/pkg/util/mount/unmount.go
+++ b/pkg/util/mount/unmount.go
@@ -18,17 +18,18 @@ package mount
 
 import (
 	"fmt"
-	"log"
 	"os"
+
+	"go.uber.org/zap"
 )
 
 // UnmountPath is a common unmount routine that unmounts the given path and
 // deletes the remaining directory if successful.
-func UnmountPath(mountPath string, mounter Interface) error {
+func UnmountPath(logger *zap.SugaredLogger, mountPath string, mounter Interface) error {
 	if pathExists, pathErr := PathExists(mountPath); pathErr != nil {
 		return fmt.Errorf("Error checking if path exists: %v", pathErr)
 	} else if !pathExists {
-		log.Printf("Warning: Unmount skipped because path does not exist: %v", mountPath)
+		logger.With("mount path", mountPath).Warn("Unmount skipped because path does not exist.")
 		return nil
 	}
 
@@ -37,7 +38,7 @@ func UnmountPath(mountPath string, mounter Interface) error {
 		return err
 	}
 	if notMnt {
-		log.Printf("Warning: %q is not a mountpoint, deleting", mountPath)
+		logger.With("mount path", mountPath).Warn("Mount path is not a mount point. Removing directory.")
 		return os.Remove(mountPath)
 	}
 
@@ -50,7 +51,7 @@ func UnmountPath(mountPath string, mounter Interface) error {
 		return err
 	}
 	if notMnt {
-		log.Printf("%q is unmounted, deleting the directory", mountPath)
+		logger.With("mount path", mountPath).Info("Mount path is unmounted. Removing directory.")
 		return os.Remove(mountPath)
 	}
 	return fmt.Errorf("Failed to unmount path %v", mountPath)


### PR DESCRIPTION
Replaced existing log calls with structured zap logs that write to file making them accessible

Example of new logs running from worker:
`kubectl -n kube-system logs oci-flexvolume-driver-worker-khsww -f`

```
2018-11-14T10:13:22.061Z        ERROR   block/driver.go:67      Config file does not exist. Assuming worker node.       {"pid": 19200, "version": "ce515365", "build": "ce515365", "error": "stat /usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/config.yaml: no such file or directory", "path": "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/config.yaml"}
2018-11-14T10:13:22.075Z        ERROR   block/driver.go:67      Config file does not exist. Assuming worker node.       {"pid": 19204, "version": "ce515365", "build": "ce515365", "error": "stat /usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/config.yaml: no such file or directory", "path": "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/config.yaml"}
2018-11-14T10:13:22.175Z        ERROR   block/driver.go:67      Config file does not exist. Assuming worker node.       {"pid": 19208, "version": "ce515365", "build": "ce515365", "error": "stat /usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/config.yaml: no such file or directory", "path": "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/config.yaml"}
2018-11-14T10:13:22.189Z        ERROR   block/driver.go:67      Config file does not exist. Assuming worker node.       {"pid": 19213, "version": "ce515365", "build": "ce515365", "error": "stat /usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/config.yaml: no such file or directory", "path": "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/oracle~oci/config.yaml"}
2018-11-14T10:13:22.290Z        ERROR   block/driver.go:67      Config file does not exist. Assuming worker node.       {"pid": 19220, "version": "ce515365", "build": "ce515365", "error": "stat /usr/libexec
```

Example of new logs running from master:
`kubectl -n kube-system logs oci-flexvolume-driver-master-ghcbs`

```
2018-11-14T10:18:30.611Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17226, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:18:30.793Z        INFO    block/driver.go:226     Attaching volume to instance    {"pid": 17235, "version": "07e562f6", "build": "07e562f6", "command": "attach", "volumeID": "ocid1.volume.oc1.iad.abuwcljtiogsbwqzaz3nzufprvp6ans3znyrpdgoj242xnnylrqtkyqikfsq", "instanceID": "ocid1.instance.oc1.iad.abuwcljtgfsssg6a7wepbdhjfnslqdtmsfxcreojvqv27jjys7dxwedb3jda"}
2018-11-14T10:18:31.604Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17246, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:18:46.326Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17260, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:11.459Z        INFO    block/driver.go:250     Volume attached {"pid": 17235, "version": "07e562f6", "build": "07e562f6", "command": "attach", "attachmentID": "ocid1.volumeattachment.oc1.iad.abuwcljt6faujbbavw7vz2jdahmo6vnrkq3unjngxs6i5ignshmshqdb2ruq"}
2018-11-14T10:19:11.515Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17276, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:29.338Z        INFO    block/driver.go:326     Found volume attachment {"pid": 17286, "version": "07e562f6", "build": "07e562f6", "command": "isattached", "attachmentID": "ocid1.volumeattachment.oc1.iad.abuwcljt6faujbbavw7vz2jdahmo6vnrkq3unjngxs6i5ignshmshqdb2ruq"}
2018-11-14T10:19:40.694Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17299, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:41.688Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17310, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:42.593Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17319, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:42.636Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17330, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:42.706Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17338, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:44.735Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17349, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:45.760Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17360, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:46.770Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17369, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:51.777Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17379, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:51.864Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17388, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:51.949Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17397, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:52.015Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17408, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:52.063Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17418, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:52.103Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17427, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:57.832Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17436, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:19:58.864Z        WARN    flexvolume/flexvolume.go:129    getvolumename is broken as of kube 1.6.4        {"pid": 17445, "version": "07e562f6", "build": "07e562f6", "command": "getvolumename", "status": "Not supported"}
2018-11-14T10:20:24.546Z        INFO    flexvolume/flexvolume.go:119            {"pid": 17449, "version": "07e562f6", "build": "07e562f6", "command": "detach", "status": "Success"}
```