### PR TITLE
Update Development Docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ The CCM has a simple build system based on `make`. Dependencies are managed
 using [`dep`][2].
 
 ## Running locally
- 1. Ensure you have the aforementioned development tools installed as well as
+ 1. Ensure you have the aforementioned development tools installed
     as well as the latest release of [Go][3].
 
  2. Create a `cloud-provider.yaml` file in the root of the repository containing
@@ -53,7 +53,11 @@ using [`dep`][2].
  3. Ensure you have [`$KUBECONFIG`][4] to the Kubernetes configuration file for
     your cluster.
 
- 4. Execute `GOOS=darwin make run-dev`
+ 4. For CCM execute:
+    `GOOS=darwin make run-ccm-dev`
+    For Volume Provisioner execute:
+    `GOOS=darwin make run-volume-provisioner-dev`
+ 
 
 ## DaemonSet manifests
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,11 +78,20 @@ $ kubectl apply -f dist/oci-cloud-controller-manager-rbac.yaml
 
 ## Running the e2e tests
 
-The e2e test suite requires the version of the CCM under test to be installed in
-the cluster referenced via the `--kubeconfig` flag.
+The e2e test suite makes use of environement variables explained below:
 
+| Environment variable | Required | Description | Value example |
+|----------------------|----------|---------------------------------------------------------------------------------------------------------------------------------|---------------|
+| VERSION | ✓ | The version of the ccm to test against. Can be any value if testing locally running ccm | e4f42f6c |
+| INSTALL_DISABLED | ✗ | Setting this variable to true will run tests against your locally running ccm, rather than installing a ccm pod on your cluster | true |
+
+To test locally running ccm:
 ```console
-$ ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
+$ VERSION=x INSTALL_DISABLED=true ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
+```
+To test a specific version of the ccm in your cluster (change VERSION to the specific version you wish to test):
+```console
+$ VERSION=e4f42f6c ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
 ```
 
 [1]: https://www.docker.com/

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,9 +54,9 @@ using [`dep`][2].
     your cluster.
 
  4. For CCM execute:
-    `GOOS=darwin make run-ccm-dev`
+    ```GOOS=darwin make run-ccm-dev```
     For Volume Provisioner execute:
-    `GOOS=darwin make run-volume-provisioner-dev`
+    ```GOOS=darwin make run-volume-provisioner-dev```
  
 
 ## DaemonSet manifests

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,9 +54,13 @@ using [`dep`][2].
     your cluster.
 
  4. For CCM execute:
-    ```GOOS=darwin make run-ccm-dev```
+    ```
+    GOOS=darwin make run-ccm-dev
+    ```
     For Volume Provisioner execute:
-    ```GOOS=darwin make run-volume-provisioner-dev```
+    ```
+    GOOS=darwin make run-volume-provisioner-dev
+    ```
  
 
 ## DaemonSet manifests

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,7 +81,7 @@ The e2e test suite makes use of environment variables explained below:
 
 | Environment variable | Required | Description | Expected Value |
 |-|-|-|-|
-| `CCM_VERSION` | Required if `INSTALL_DISABLED` is unset | The version of the ccm to test against. | CCM version, e.g. `e4f42f6c` |
+| `VERSION` | Required if `INSTALL_DISABLED` is unset | The version of the ccm to test against. | CCM version, e.g. `e4f42f6c` |
 | `INSTALL_DISABLED` | No | Setting this variable will prevent a CCM pod being installed on your cluster, allowing tests to run against a locally running CCM. | Any value e.g. `x` |
 |`IGNORE_E2E_LOCK` | No | Setting this variable will disable the e2e lock that prevents 2 tests running simaltaneously | Any value e.g. `y`|
 
@@ -90,9 +90,9 @@ To test locally running CCM:
 $ INSTALL_DISABLED=foobar ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
 ```
 To test a specific version of the CCM in your cluster:
-> **NOTE:** change the value of `CCM_VERSION` to the specific version you wish to test
+> **NOTE:** change the value of `VERSION` to the specific version you wish to test
 ```console
-$ CCM_VERSION=e4f42f6c ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
+$ VERSION=e4f42f6c ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
 ```
 
 [1]: https://www.docker.com/

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,6 +94,7 @@ To test a specific version of the ccm in your cluster (change VERSION to the spe
 $ VERSION=e4f42f6c ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
 ```
 
+
 [1]: https://www.docker.com/
 [2]: https://github.com/golang/dep
 [3]: https://golang.org/

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,8 +50,7 @@ using [`dep`][2].
       subnet1: ocid1.subnet.oc1.phx.aaaaaaaasa53hlkzk6nzksqfccegk2qnkxmphkblst3riclzs4rhwg7rg57q
       subnet2: ocid1.subnet.oc1.phx.aaaaaaaahuxrgvs65iwdz7ekwgg3l5gyah7ww5klkwjcso74u3e4i64hvtvq
     ```
- 3. Ensure you have [`$KUBECONFIG`][4] to the Kubernetes configuration file for
-    your cluster.
+ 3. Ensure you have the environment variable [`$KUBECONFIG`][4] set to the path to your Kubernetes configuration file for your cluster.
 
  4. For CCM execute:
     ```
@@ -78,22 +77,23 @@ $ kubectl apply -f dist/oci-cloud-controller-manager-rbac.yaml
 
 ## Running the e2e tests
 
-The e2e test suite makes use of environement variables explained below:
+The e2e test suite makes use of environment variables explained below:
 
-| Environment variable | Required | Description | Value example |
-|----------------------|----------|---------------------------------------------------------------------------------------------------------------------------------|---------------|
-| VERSION | ✓ | The version of the ccm to test against. Can be any value if testing locally running ccm | e4f42f6c |
-| INSTALL_DISABLED | ✗ | Setting this variable to true will run tests against your locally running ccm, rather than installing a ccm pod on your cluster | true |
+| Environment variable | Required | Description | Expected Value |
+|-|-|-|-|
+| `CCM_VERSION` | Required if `INSTALL_DISABLED` is unset | The version of the ccm to test against. | CCM version, e.g. `e4f42f6c` |
+| `INSTALL_DISABLED` | No | Setting this variable will prevent a CCM pod being installed on your cluster, allowing tests to run against a locally running CCM. | Any value e.g. `x` |
+|`IGNORE_E2E_LOCK` | No | Setting this variable will disable the e2e lock that prevents 2 tests running simaltaneously | Any value e.g. `y`|
 
-To test locally running ccm:
+To test locally running CCM:
 ```console
-$ VERSION=x INSTALL_DISABLED=true ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
+$ INSTALL_DISABLED=foobar ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
 ```
-To test a specific version of the ccm in your cluster (change VERSION to the specific version you wish to test):
+To test a specific version of the CCM in your cluster:
+> **NOTE:** change the value of `CCM_VERSION` to the specific version you wish to test
 ```console
-$ VERSION=e4f42f6c ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
+$ CCM_VERSION=e4f42f6c ginkgo -v -progress test/e2e/cloud-controller-manager  -- --kubeconfig=$HOME/.kube/config --cloud-config="$(pwd)/cloud-provider.yaml"
 ```
-
 
 [1]: https://www.docker.com/
 [2]: https://github.com/golang/dep

--- a/test/e2e/cloud-controller-manager/e2e_test.go
+++ b/test/e2e/cloud-controller-manager/e2e_test.go
@@ -35,15 +35,15 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 	cs, err := framework.NewClientSetFromFlags()
 	Ω(err).ShouldNot(HaveOccurred())
-	_, installDisabled = os.LookupEnv(sharedfw.VarInstallDisabled)
+	_, installDisabled = os.LookupEnv(sharedfw.EnvInstallDisabled)
 	if !installDisabled {
-		version := os.Getenv(sharedfw.VarVersion)
-		Ω(version).ShouldNot(BeEmpty(), "Environment variable '"+sharedfw.VarVersion+"' is empty, either set it or set "+sharedfw.VarInstallDisabled)
+		version := os.Getenv(sharedfw.EnvVersion)
+		Ω(version).ShouldNot(BeEmpty(), "Environment variable '"+sharedfw.EnvVersion+"' is empty, either set it or set "+sharedfw.EnvInstallDisabled)
 		err = framework.InstallCCM(cs, version)
 		Ω(err).ShouldNot(HaveOccurred())
 	}
 
-	_, ignoreLock := os.LookupEnv(sharedfw.VarIgnoreLock)
+	_, ignoreLock := os.LookupEnv(sharedfw.EnvIgnoreLock)
 	if !ignoreLock {
 		err = sharedfw.AquireRunLock(cs, "oci-cloud-controller-manager-e2e-tests")
 		Ω(err).ShouldNot(HaveOccurred())

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -36,7 +36,7 @@ import (
 const (
 	// VarVersion is the environment variable used to defined the
 	// version of the CCM to run tests against
-	EnvVersion = "CCM_VERSION"
+	EnvVersion = "VERSION"
 	// VarInstallDisabled is the environment variable used to prevent
 	// installation of the CCM in the cluster, allowing tests to run
 	// against a locally running version of the CCM

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -33,6 +33,19 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+const (
+	// VarVersion is the environment variable used to defined the
+	// version of the CCM to run tests against
+	VarVersion = "CCM_VERSION"
+	// VarInstallDisabled is the environment variable used to prevent
+	// installation of the CCM in the cluster, allowing tests to run
+	// against a locally running version of the CCM
+	VarInstallDisabled = "INSTALL_DISABLED"
+	// VarIgnoreLock is the environment variable used to ignore a test
+	// run lock. Use with caution.
+	VarIgnoreLock = "IGNORE_E2E_LOCK"
+)
+
 // AquireRunLock blocks until the test run lock is required or a timeout
 // elapses. A lock is required as only one test run can safely be executed on
 // the same cluster at any given time.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -36,14 +36,14 @@ import (
 const (
 	// VarVersion is the environment variable used to defined the
 	// version of the CCM to run tests against
-	VarVersion = "CCM_VERSION"
+	EnvVersion = "CCM_VERSION"
 	// VarInstallDisabled is the environment variable used to prevent
 	// installation of the CCM in the cluster, allowing tests to run
 	// against a locally running version of the CCM
-	VarInstallDisabled = "INSTALL_DISABLED"
+	EnvInstallDisabled = "INSTALL_DISABLED"
 	// VarIgnoreLock is the environment variable used to ignore a test
 	// run lock. Use with caution.
-	VarIgnoreLock = "IGNORE_E2E_LOCK"
+	EnvIgnoreLock = "IGNORE_E2E_LOCK"
 )
 
 // AquireRunLock blocks until the test run lock is required or a timeout

--- a/test/e2e/volume-provisioner/e2e_test.go
+++ b/test/e2e/volume-provisioner/e2e_test.go
@@ -30,15 +30,18 @@ var lockAquired bool
 var installDisabled bool
 
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
+
 	cs, err := framework.NewClientSetFromFlags()
 	Ω(err).ShouldNot(HaveOccurred())
 
-	err = sharedfw.AquireRunLock(cs, "oci-volume-provisioner-e2e-tests")
-	Ω(err).ShouldNot(HaveOccurred())
-
+	_, ignoreLock := os.LookupEnv(sharedfw.VarIgnoreLock)
+	if !ignoreLock {
+		err = sharedfw.AquireRunLock(cs, "oci-volume-provisioner-e2e-tests")
+		Ω(err).ShouldNot(HaveOccurred())
+	}
 	lockAquired = true
 
-	_, installDisabled = os.LookupEnv("INSTALL_DISABLED")
+	_, installDisabled = os.LookupEnv(sharedfw.VarInstallDisabled)
 	if !installDisabled {
 		err = framework.InstallFlexvolumeDriver(cs)
 		Ω(err).ShouldNot(HaveOccurred())

--- a/test/e2e/volume-provisioner/e2e_test.go
+++ b/test/e2e/volume-provisioner/e2e_test.go
@@ -34,14 +34,14 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	cs, err := framework.NewClientSetFromFlags()
 	Ω(err).ShouldNot(HaveOccurred())
 
-	_, ignoreLock := os.LookupEnv(sharedfw.VarIgnoreLock)
+	_, ignoreLock := os.LookupEnv(sharedfw.EnvIgnoreLock)
 	if !ignoreLock {
 		err = sharedfw.AquireRunLock(cs, "oci-volume-provisioner-e2e-tests")
 		Ω(err).ShouldNot(HaveOccurred())
 	}
 	lockAquired = true
 
-	_, installDisabled = os.LookupEnv(sharedfw.VarInstallDisabled)
+	_, installDisabled = os.LookupEnv(sharedfw.EnvInstallDisabled)
 	if !installDisabled {
 		err = framework.InstallFlexvolumeDriver(cs)
 		Ω(err).ShouldNot(HaveOccurred())

--- a/wercker.yml
+++ b/wercker.yml
@@ -51,7 +51,7 @@ publish-docker-image:
         name: Set ENV vars
         code: |
           export IMAGE="iad.ocir.io/oracle/cloud-provider-oci"
-          export CCM_VERSION=$(cat dist/VERSION.txt)
+          export VERSION=$(cat dist/VERSION.txt)
           echo "${VERSION}"
 
     - script:
@@ -81,7 +81,7 @@ ccm-e2e-test:
     - script:
       name: Run CCM E2E tests
       code: |
-        export CCM_VERSION=$(make version)
+        export VERSION=$(make version)
         echo "Running CCM tests version: ${VERSION}"
         export NODEPORT_TEST="true"
         export CCM_SECLIST_ID="ocid1.securitylist.oc1.iad.aaaaaaaagekgnvc75yxb66xj2qgocejhyk5xuhojm6wimmteqa5fj43kk5lq"
@@ -123,7 +123,7 @@ volume-provisioner-e2e-test:
     - script:
       name: Run volume provisioner E2E tests
       code: |
-        export CCM_VERSION=$(cat dist/VERSION.txt)
+        export VERSION=$(cat dist/VERSION.txt)
 
         export OCI_CONFIG="/tmp/ociconfig"
         echo -n "${OCI_CONFIG_VAR}" | openssl enc -base64 -d -A > "${OCI_CONFIG}"
@@ -150,7 +150,7 @@ release:
     - script:
         name: set ENV vars
         code: |
-          export CCM_VERSION=$(cat dist/VERSION.txt)
+          export VERSION=$(cat dist/VERSION.txt)
           echo "${VERSION}"
 
     - script:

--- a/wercker.yml
+++ b/wercker.yml
@@ -51,7 +51,7 @@ publish-docker-image:
         name: Set ENV vars
         code: |
           export IMAGE="iad.ocir.io/oracle/cloud-provider-oci"
-          export VERSION=$(cat dist/VERSION.txt)
+          export CCM_VERSION=$(cat dist/VERSION.txt)
           echo "${VERSION}"
 
     - script:
@@ -81,7 +81,7 @@ ccm-e2e-test:
     - script:
       name: Run CCM E2E tests
       code: |
-        export VERSION=$(make version)
+        export CCM_VERSION=$(make version)
         echo "Running CCM tests version: ${VERSION}"
         export NODEPORT_TEST="true"
         export CCM_SECLIST_ID="ocid1.securitylist.oc1.iad.aaaaaaaagekgnvc75yxb66xj2qgocejhyk5xuhojm6wimmteqa5fj43kk5lq"
@@ -123,7 +123,7 @@ volume-provisioner-e2e-test:
     - script:
       name: Run volume provisioner E2E tests
       code: |
-        export VERSION=$(cat dist/VERSION.txt)
+        export CCM_VERSION=$(cat dist/VERSION.txt)
 
         export OCI_CONFIG="/tmp/ociconfig"
         echo -n "${OCI_CONFIG_VAR}" | openssl enc -base64 -d -A > "${OCI_CONFIG}"
@@ -150,7 +150,7 @@ release:
     - script:
         name: set ENV vars
         code: |
-          export VERSION=$(cat dist/VERSION.txt)
+          export CCM_VERSION=$(cat dist/VERSION.txt)
           echo "${VERSION}"
 
     - script:


### PR DESCRIPTION
This PR updates the Documentation of the development.md to reflect the new makefile commands for running the CCM / VolumeProvisioner locally.

Some minor quality of life improvements are also made to improve the use of environment variables such that setting `INSTALL_DISABLED` now means you will not have to define a `VERSION`. The ability to `IGNORE_E2E_LOCK` is also added to make running e2e tests locally more convenient. 

Additionally, the definitions of the Environment variables that pertain to e2e tests are now all stored in the shared e2e framework package and documented in `docs/development.md`
