### PR TITLE
Fix bad pointer dereference in backup_util.go 

### DIFF
--- a/test/e2e/volume-provisioner/framework/backup_util.go
+++ b/test/e2e/volume-provisioner/framework/backup_util.go
@@ -49,7 +49,7 @@ func (j *PVCTestJig) CreateBackupVolume(storageClient ocicore.BlockstorageClient
 		},
 	})
 	if err != nil {
-		return *backupVolume.Id, fmt.Errorf("failed to backup volume with ocid %q: %v", volumeID, err)
+		return "", fmt.Errorf("failed to backup volume: %v", err)
 	}
 
 	err = j.waitForVolumeAvailable(ctx, storageClient, *backupVolume.Id, DefaultTimeout)


### PR DESCRIPTION
The logic in backup_util.go was causing a panic on entering the error clause. This change fixes the tests so that errors are propagated back correctly.