### PR TITLE
allow retrieval of instance fqdn using instanceID

### DIFF
--- a/pkg/cloudprovider/providers/oci/instances_test.go
+++ b/pkg/cloudprovider/providers/oci/instances_test.go
@@ -15,81 +15,397 @@
 package oci
 
 import (
+	"context"
 	"errors"
-	"reflect"
-	"testing"
-
+	providercfg "github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
+	"github.com/oracle/oci-cloud-controller-manager/pkg/oci/client"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/core"
-
+	"github.com/oracle/oci-go-sdk/filestorage"
+	"github.com/oracle/oci-go-sdk/identity"
+	"github.com/oracle/oci-go-sdk/loadbalancer"
+	"go.uber.org/zap"
 	"k8s.io/api/core/v1"
+	"reflect"
+	"testing"
 )
 
-func TestExtractNodeAddressesFromVNIC(t *testing.T) {
+var (
+	instances = map[string]*core.Vnic{
+		"basic-complete": &core.Vnic{
+			PrivateIp:     common.String("10.0.0.1"),
+			PublicIp:      common.String("0.0.0.1"),
+			HostnameLabel: common.String("basic-complete"),
+			SubnetId:      common.String("subnetwithdnslabel"),
+		},
+		"no-external-ip": &core.Vnic{
+			PrivateIp:     common.String("10.0.0.1"),
+			HostnameLabel: common.String("no-external-ip"),
+			SubnetId:      common.String("subnetwithdnslabel"),
+		},
+		"no-internal-ip": &core.Vnic{
+			PublicIp:      common.String("0.0.0.1"),
+			HostnameLabel: common.String("no-internal-ip"),
+			SubnetId:      common.String("subnetwithdnslabel"),
+		},
+		"invalid-internal-ip": &core.Vnic{
+			PrivateIp:     common.String("10.0.0."),
+			HostnameLabel: common.String("no-internal-ip"),
+			SubnetId:      common.String("subnetwithdnslabel"),
+		},
+		"invalid-external-ip": &core.Vnic{
+			PublicIp:      common.String("0.0.0."),
+			HostnameLabel: common.String("invalid-external-ip"),
+			SubnetId:      common.String("subnetwithdnslabel"),
+		},
+		"no-hostname-label": &core.Vnic{
+			PrivateIp: common.String("10.0.0.1"),
+			PublicIp:  common.String("0.0.0.1"),
+			SubnetId:  common.String("subnetwithdnslabel"),
+		},
+		"no-subnet-dns-label": &core.Vnic{
+			PrivateIp:     common.String("10.0.0.1"),
+			PublicIp:      common.String("0.0.0.1"),
+			HostnameLabel: common.String("no-subnet-dns-label"),
+			SubnetId:      common.String("subnetwithoutdnslabel"),
+		},
+		"no-vcn-dns-label": &core.Vnic{
+			PrivateIp:     common.String("10.0.0.1"),
+			PublicIp:      common.String("0.0.0.1"),
+			HostnameLabel: common.String("no-vcn-dns-label"),
+			SubnetId:      common.String("subnetwithnovcndnslabel"),
+		},
+	}
+
+	subnets = map[string]*core.Subnet{
+		"subnetwithdnslabel": &core.Subnet{
+			Id:       common.String("subnetwithdnslabel"),
+			DnsLabel: common.String("subnetwithdnslabel"),
+			VcnId:    common.String("vcnwithdnslabel"),
+		},
+		"subnetwithoutdnslabel": &core.Subnet{
+			Id:    common.String("subnetwithoutdnslabel"),
+			VcnId: common.String("vcnwithdnslabel"),
+		},
+		"subnetwithnovcndnslabel": &core.Subnet{
+			Id:       common.String("subnetwithnovcndnslabel"),
+			DnsLabel: common.String("subnetwithnovcndnslabel"),
+			VcnId:    common.String("vcnwithoutdnslabel"),
+		},
+	}
+
+	vcns = map[string]*core.Vcn{
+		"vcnwithdnslabel": &core.Vcn{
+			Id:       common.String("vcnwithdnslabel"),
+			DnsLabel: common.String("vcnwithdnslabel"),
+		},
+		"vcnwithoutdnslabel": &core.Vcn{
+			Id: common.String("vcnwithoutdnslabel"),
+		},
+	}
+)
+
+type MockOCIClient struct{}
+
+func (MockOCIClient) Compute() client.ComputeInterface {
+	return &MockComputeClient{}
+}
+
+func (MockOCIClient) LoadBalancer() client.LoadBalancerInterface {
+	return &MockLoadBalancerClient{}
+}
+
+func (MockOCIClient) Networking() client.NetworkingInterface {
+	return &MockVirtualNetworkClient{}
+}
+
+func (MockOCIClient) BlockStorage() client.BlockStorageInterface {
+	return &MockBlockStorageClient{}
+}
+
+func (MockOCIClient) FSS() client.FileStorageInterface {
+	return &MockFileStorageClient{}
+}
+
+func (MockOCIClient) Identity() client.IdentityInterface {
+	return &MockIdentityClient{}
+}
+
+// MockComputeClient mocks Compute client implementation
+type MockComputeClient struct{}
+
+func (MockComputeClient) GetInstance(ctx context.Context, id string) (*core.Instance, error) {
+	return nil, nil
+}
+
+func (MockComputeClient) GetInstanceByNodeName(ctx context.Context, compartmentID, vcnID, nodeName string) (*core.Instance, error) {
+	return nil, nil
+}
+
+func (MockComputeClient) GetPrimaryVNICForInstance(ctx context.Context, compartmentID, instanceID string) (*core.Vnic, error) {
+	return instances[instanceID], nil
+}
+
+func (MockComputeClient) FindVolumeAttachment(ctx context.Context, compartmentID, volumeID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (MockComputeClient) AttachVolume(ctx context.Context, instanceID, volumeID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (MockComputeClient) WaitForVolumeAttached(ctx context.Context, attachmentID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (MockComputeClient) DetachVolume(ctx context.Context, id string) error {
+	return nil
+}
+
+func (MockComputeClient) WaitForVolumeDetached(ctx context.Context, attachmentID string) error {
+	return nil
+}
+
+// MockVirtualNetworkClient mocks VirtualNetwork client implementation
+type MockVirtualNetworkClient struct {
+}
+
+func (c *MockVirtualNetworkClient) GetPrivateIP(ctx context.Context, id string) (*core.PrivateIp, error) {
+	return nil, nil
+}
+
+func (c *MockVirtualNetworkClient) GetSubnet(ctx context.Context, id string) (*core.Subnet, error) {
+	return subnets[id], nil
+}
+
+func (c *MockVirtualNetworkClient) GetVcn(ctx context.Context, id string) (*core.Vcn, error) {
+	return vcns[id], nil
+}
+
+func (c *MockVirtualNetworkClient) GetSubnetFromCacheByIP(ip string) (*core.Subnet, error) {
+	return nil, nil
+}
+
+func (c *MockVirtualNetworkClient) GetSecurityList(ctx context.Context, id string) (core.GetSecurityListResponse, error) {
+	return core.GetSecurityListResponse{}, nil
+}
+
+func (c *MockVirtualNetworkClient) UpdateSecurityList(ctx context.Context, request core.UpdateSecurityListRequest) (core.UpdateSecurityListResponse, error) {
+	return core.UpdateSecurityListResponse{}, nil
+}
+
+//// MockFileStorageClient mocks FileStorage client implementation.
+type MockLoadBalancerClient struct{}
+
+func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details loadbalancer.CreateLoadBalancerDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, id string) (*loadbalancer.LoadBalancer, error) {
+	return nil, nil
+}
+
+func (c *MockLoadBalancerClient) GetLoadBalancerByName(ctx context.Context, compartmentID, name string) (*loadbalancer.LoadBalancer, error) {
+	return nil, nil
+}
+
+func (c *MockLoadBalancerClient) DeleteLoadBalancer(ctx context.Context, id string) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) GetCertificateByName(ctx context.Context, lbID, name string) (*loadbalancer.Certificate, error) {
+	return nil, nil
+}
+
+func (c *MockLoadBalancerClient) CreateCertificate(ctx context.Context, lbID string, cert loadbalancer.CertificateDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) CreateBackendSet(ctx context.Context, lbID, name string, details loadbalancer.BackendSetDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) UpdateBackendSet(ctx context.Context, lbID, name string, details loadbalancer.BackendSetDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) DeleteBackendSet(ctx context.Context, lbID, name string) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) UpdateListener(ctx context.Context, lbID, name string, details loadbalancer.ListenerDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) CreateListener(ctx context.Context, lbID, name string, details loadbalancer.ListenerDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) DeleteListener(ctx context.Context, lbID, name string) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) AwaitWorkRequest(ctx context.Context, id string) (*loadbalancer.WorkRequest, error) {
+	return nil, nil
+}
+
+// MockBlockStorageClient mocks BlockStoargae client implementation
+type MockBlockStorageClient struct{}
+
+func (MockBlockStorageClient) AwaitVolumeAvailable(ctx context.Context, id string) (*core.Volume, error) {
+	return nil, nil
+}
+
+func (MockBlockStorageClient) CreateVolume(ctx context.Context, details core.CreateVolumeDetails) (*core.Volume, error) {
+	return nil, nil
+}
+
+func (MockBlockStorageClient) DeleteVolume(ctx context.Context, id string) error {
+	return nil
+}
+
+// MockFileStorageClient mocks FileStorage client implementation.
+type MockFileStorageClient struct{}
+
+func (MockFileStorageClient) AwaitMountTargetActive(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.MountTarget, error) {
+	return nil, nil
+}
+
+func (MockFileStorageClient) GetFileSystem(ctx context.Context, id string) (*filestorage.FileSystem, error) {
+	return nil, nil
+}
+
+func (MockFileStorageClient) GetFileSystemSummaryByDisplayName(ctx context.Context, compartmentID, ad, displayName string) (*filestorage.FileSystemSummary, error) {
+	return nil, nil
+}
+
+func (MockFileStorageClient) AwaitFileSystemActive(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.FileSystem, error) {
+	return nil, nil
+}
+
+func (MockFileStorageClient) CreateFileSystem(ctx context.Context, details filestorage.CreateFileSystemDetails) (*filestorage.FileSystem, error) {
+	return nil, nil
+}
+
+func (MockFileStorageClient) DeleteFileSystem(ctx context.Context, id string) error {
+	return nil
+}
+
+func (MockFileStorageClient) CreateExport(ctx context.Context, details filestorage.CreateExportDetails) (*filestorage.Export, error) {
+	return nil, nil
+}
+
+func (MockFileStorageClient) FindExport(ctx context.Context, compartmentID, fsID, exportSetID string) (*filestorage.ExportSummary, error) {
+	return nil, nil
+}
+
+func (MockFileStorageClient) AwaitExportActive(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.Export, error) {
+	return nil, nil
+}
+
+func (MockFileStorageClient) DeleteExport(ctx context.Context, id string) error {
+	return nil
+}
+
+// MockIdentityClient mocks Identity client implementaion
+type MockIdentityClient struct{}
+
+func (MockIdentityClient) GetAvailabilityDomainByName(ctx context.Context, compartmentID, name string) (*identity.AvailabilityDomain, error) {
+	return nil, nil
+}
+
+func TestExtractNodeAddresses(t *testing.T) {
 	testCases := []struct {
 		name string
-		in   *core.Vnic
+		in   string
 		out  []v1.NodeAddress
 		err  error
 	}{
 		{
 			name: "basic-complete",
-			in: &core.Vnic{
-				PrivateIp: common.String("10.0.0.1"),
-				PublicIp:  common.String("0.0.0.1"),
-			},
+			in:   "basic-complete",
 			out: []v1.NodeAddress{
 				v1.NodeAddress{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
 				v1.NodeAddress{Type: v1.NodeExternalIP, Address: "0.0.0.1"},
+				v1.NodeAddress{Type: v1.NodeHostName, Address: "basic-complete.subnetwithdnslabel.vcnwithdnslabel.oraclevcn.com"},
+				v1.NodeAddress{Type: v1.NodeInternalDNS, Address: "basic-complete.subnetwithdnslabel.vcnwithdnslabel.oraclevcn.com"},
 			},
 			err: nil,
 		},
 		{
 			name: "no-external-ip",
-			in: &core.Vnic{
-				PrivateIp: common.String("10.0.0.1"),
-			},
+			in:   "no-external-ip",
 			out: []v1.NodeAddress{
 				v1.NodeAddress{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
+				v1.NodeAddress{Type: v1.NodeHostName, Address: "no-external-ip.subnetwithdnslabel.vcnwithdnslabel.oraclevcn.com"},
+				v1.NodeAddress{Type: v1.NodeInternalDNS, Address: "no-external-ip.subnetwithdnslabel.vcnwithdnslabel.oraclevcn.com"},
 			},
 			err: nil,
 		},
 		{
 			name: "no-internal-ip",
-			in: &core.Vnic{
-				PublicIp: common.String("0.0.0.1"),
-			},
+			in:   "no-internal-ip",
 			out: []v1.NodeAddress{
 				v1.NodeAddress{Type: v1.NodeExternalIP, Address: "0.0.0.1"},
+				v1.NodeAddress{Type: v1.NodeHostName, Address: "no-internal-ip.subnetwithdnslabel.vcnwithdnslabel.oraclevcn.com"},
+				v1.NodeAddress{Type: v1.NodeInternalDNS, Address: "no-internal-ip.subnetwithdnslabel.vcnwithdnslabel.oraclevcn.com"},
 			},
 			err: nil,
 		},
 		{
 			name: "invalid-external-ip",
-			in: &core.Vnic{
-				PublicIp: common.String("0.0.0."),
-			},
-			out: nil,
-			err: errors.New(`instance has invalid public address: "0.0.0."`),
+			in:   "invalid-external-ip",
+			out:  nil,
+			err:  errors.New(`instance has invalid public address: "0.0.0."`),
 		},
 		{
-			name: "invalid-external-ip",
-			in: &core.Vnic{
-				PrivateIp: common.String("10.0.0."),
-			},
-			out: nil,
-			err: errors.New(`instance has invalid private address: "10.0.0."`),
+			name: "invalid-internal-ip",
+			in:   "invalid-internal-ip",
+			out:  nil,
+			err:  errors.New(`instance has invalid private address: "10.0.0."`),
 		},
+		{
+			name: "no-hostname-label",
+			in:   "no-hostname-label",
+			out: []v1.NodeAddress{
+				v1.NodeAddress{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
+				v1.NodeAddress{Type: v1.NodeExternalIP, Address: "0.0.0.1"},
+			},
+			err: nil,
+		},
+		{
+			name: "no-subnet-dns-label",
+			in:   "no-subnet-dns-label",
+			out: []v1.NodeAddress{
+				v1.NodeAddress{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
+				v1.NodeAddress{Type: v1.NodeExternalIP, Address: "0.0.0.1"},
+			},
+			err: nil,
+		},
+		{
+			name: "no-vcn-dns-label",
+			in:   "no-vcn-dns-label",
+			out: []v1.NodeAddress{
+				v1.NodeAddress{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
+				v1.NodeAddress{Type: v1.NodeExternalIP, Address: "0.0.0.1"},
+			},
+			err: nil,
+		},
+	}
+
+	cp := &CloudProvider{
+		client: MockOCIClient{},
+		config: &providercfg.Config{CompartmentID: "testCompartment"},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := extractNodeAddressesFromVNIC(tt.in)
+			result, err := cp.extractNodeAddresses(context.Background(), tt.in)
 			if err != nil && err.Error() != tt.err.Error() {
-				t.Errorf("extractNodeAddressesFromVNIC(%+v) got error %v, expected %v", tt.in, err, tt.err)
+				t.Errorf("extractNodeAddresses(context, %+v) got error %v, expected %v", tt.in, err, tt.err)
 			}
 			if !reflect.DeepEqual(result, tt.out) {
-				t.Errorf("extractNodeAddressesFromVNIC(%+v) => %+v, want %+v", tt.in, result, tt.out)
+				t.Errorf("extractNodeAddresses(context, %+v) => %+v, want %+v", tt.in, result, tt.out)
 			}
 		})
 	}

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -66,6 +66,7 @@ type computeClient interface {
 type virtualNetworkClient interface {
 	GetVnic(ctx context.Context, request core.GetVnicRequest) (response core.GetVnicResponse, err error)
 	GetSubnet(ctx context.Context, request core.GetSubnetRequest) (response core.GetSubnetResponse, err error)
+	GetVcn(ctx context.Context, request core.GetVcnRequest) (response core.GetVcnResponse, err error)
 	GetSecurityList(ctx context.Context, request core.GetSecurityListRequest) (response core.GetSecurityListResponse, err error)
 	UpdateSecurityList(ctx context.Context, request core.UpdateSecurityListRequest) (response core.UpdateSecurityListResponse, err error)
 

--- a/pkg/oci/client/client_test.go
+++ b/pkg/oci/client/client_test.go
@@ -187,6 +187,10 @@ func (c *mockVirtualNetworkClient) GetSubnet(ctx context.Context, request core.G
 	return core.GetSubnetResponse{}, nil
 }
 
+func (c *mockVirtualNetworkClient) GetVcn(ctx context.Context, request core.GetVcnRequest) (response core.GetVcnResponse, err error)  {
+	return core.GetVcnResponse{} , nil
+}
+
 func (c *mockVirtualNetworkClient) GetSecurityList(ctx context.Context, request core.GetSecurityListRequest) (response core.GetSecurityListResponse, err error) {
 	return core.GetSecurityListResponse{}, nil
 }

--- a/pkg/oci/client/metrics.go
+++ b/pkg/oci/client/metrics.go
@@ -38,6 +38,7 @@ const (
 	vnicAttachmentResource     resource = "vnic_attachment"
 	vnicResource               resource = "vnic"
 	subnetResource             resource = "subnet"
+	vcnResource                resource = "vcn"
 	loadBalancerResource       resource = "load_balancer"
 	backendSetResource         resource = "load_balancer_backend_set"
 	listenerResource           resource = "load_balancer_listener"

--- a/pkg/volume/provisioner/block/block_test.go
+++ b/pkg/volume/provisioner/block/block_test.go
@@ -206,6 +206,10 @@ func (c *MockVirtualNetworkClient) GetSubnet(ctx context.Context, id string) (*c
 	return nil, nil
 }
 
+func (c *MockVirtualNetworkClient) GetVcn(ctx context.Context, id string) (*core.Vcn, error) {
+	return &core.Vcn{}, nil
+}
+
 func (c *MockVirtualNetworkClient) GetSubnetFromCacheByIP(ip string) (*core.Subnet, error) {
 	return nil, nil
 }

--- a/pkg/volume/provisioner/fss/fss_test.go
+++ b/pkg/volume/provisioner/fss/fss_test.go
@@ -209,6 +209,10 @@ func (c *MockVirtualNetworkClient) GetSubnetFromCacheByIP(ip string) (*core.Subn
 	return nil, nil
 }
 
+func (c *MockVirtualNetworkClient) GetVcn(ctx context.Context, id string) (*core.Vcn, error) {
+	return &core.Vcn{}, nil
+}
+
 func (c *MockVirtualNetworkClient) GetSecurityList(ctx context.Context, id string) (core.GetSecurityListResponse, error) {
 	return core.GetSecurityListResponse{}, nil
 }


### PR DESCRIPTION
K8s supports Hostname, ExternalIP, InternalIP, ExternalDNS, InternalDNS as valid address type of node. 
We should return all possible addresses that a node is configured with. Certain k8s operation  like fetching logs, exec into pods, port forwading etc works only when a address of   `kubelet-preferred-address-types`  is supplied. 
One such problem scenario is (https://gitlab.cncf.ci/cncf/cross-project/-/jobs/156739). Here apiserver is configured with  `-kubelet-preferred-address-types=Hostname`. And since we currently return only externalIP and internalIP, helm command fails (it internally uses port forwarding) with the follwoing error 
`no preferred addresses found; known addresses: [{InternalIP 10.0.15.2} {ExternalIP 129.146.173.78}]`.