### PR TITLE
Handle multiple /dev/disk/by-path symlinks

### DIFF
--- a/pkg/util/iscsi/iscsi.go
+++ b/pkg/util/iscsi/iscsi.go
@@ -143,11 +143,17 @@ func NewFromMountPointPath(logger *zap.SugaredLogger, mountPath string) (Interfa
 	if err != nil {
 		return nil, err
 	}
-	diskByPath, err := diskByPathForMountPoint(mountPoint)
+	diskByPaths, err := diskByPathsForMountPoint(mountPoint)
 	if err != nil {
 		return nil, err
 	}
-	return NewFromDevicePath(logger, diskByPath)
+	for _, diskByPath := range(diskByPaths) {
+		iface, err := NewFromDevicePath(logger, diskByPath)
+		if err == nil {
+			return iface, nil
+		}
+	}
+	return nil, errors.New("iSCSI information not found for mount point")
 }
 
 // getISCSIAdmPath gets the absolute path to the iscsiadm executable on the
@@ -306,22 +312,23 @@ func getMountPointForPath(ml mountLister, path string) (mount.MountPoint, error)
 
 // TODO(apryde): Need to think about how best to test this/make it more
 // testable.
-func diskByPathForMountPoint(mountPoint mount.MountPoint) (string, error) {
-	foundErr := errors.New("found")
-	diskByPath := ""
+func diskByPathsForMountPoint(mountPoint mount.MountPoint) ([]string, error) {
+	diskByPaths := []string{}
 	err := filepath.Walk("/dev/disk/by-path/", func(path string, info os.FileInfo, err error) error {
 		target, err := filepath.EvalSymlinks(path)
 		if err != nil {
 			return err
 		}
 		if target == mountPoint.Device {
-			diskByPath = path
-			return foundErr
+			diskByPaths = append(diskByPaths, path)
 		}
 		return nil
 	})
-	if err != foundErr {
-		return "", err
+	if err != nil {
+		return nil, err
 	}
-	return diskByPath, nil
+	if len(diskByPaths) == 0 {
+		return nil, errors.New("disk by path link not found")
+	}
+	return diskByPaths, nil
 }


### PR DESCRIPTION
Some systems have udev rules which create additional symlinks under
/dev/disk/by-path which don't follow the expected format. In these cases
we want to proceed if any symlink matches the expected pattern.