### PR TITLE
Cherry pick commits from internal repo, add back commit from PR #307

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,5 @@
 
 FROM oraclelinux:7-slim
 
-COPY dist/oci-cloud-controller-manager /usr/local/bin/
-COPY dist/oci-flexvolume-driver /usr/local/bin/
-COPY dist/oci-volume-provisioner /usr/local/bin/
+COPY dist/* /usr/local/bin/
 COPY image/* /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 PKG := github.com/oracle/oci-cloud-controller-manager
 IMAGE ?= iad.ocir.io/oracle/cloud-provider-oci
+COMPONENT ?= oci-cloud-controller-manager oci-volume-provisioner oci-flexvolume-driver cloud-provider-oci
 
 BUILD := $(shell git describe --exact-match 2> /dev/null || git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 # Allow overriding for release versions else just equal the build (git hash)
@@ -57,30 +58,11 @@ check: gofmt govet golint
 build-dirs:
 	@mkdir -p dist/
 
-.PHONY: oci-cloud-controller-manager
-oci-cloud-controller-manager: build-dirs
-	@GOOS=$(GOOS) GOARCH=$(ARCH) go build                          \
-	  -o dist/oci-cloud-controller-manager                         \
-	  -installsuffix "static"                                      \
-	  -ldflags "-X main.version=$(VERSION) -X main.build=$(BUILD)" \
-	  ./cmd/oci-cloud-controller-manager
-
-.PHONY: oci-volume-provisioner
-oci-volume-provisioner: build-dirs
-	@GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=0 go build                                      \
-	  -o dist/oci-volume-provisioner                                                         \
-	  -ldflags="-s -w -X main.version=${VERSION} -X main.build=${BUILD} -extldflags -static" \
-	  ./cmd/oci-volume-provisioner
-
-.PHONY: oci-flexvolume-driver
-oci-flexvolume-driver: build-dirs
-	@GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=0 go build                  \
-	  -o dist/oci-flexvolume-driver                                      \
-	  -ldflags="-s -w -X main.version=$(VERSION) -X main.build=$(BUILD)" \
-	  ./cmd/oci-flexvolume-driver/
-
 .PHONY: build
-build: oci-cloud-controller-manager oci-volume-provisioner oci-flexvolume-driver
+build: build-dirs
+	@for component in $(COMPONENT); do \
+		GOOS=$(GOOS) GOARCH=$(ARCH) CGO_ENABLED=0 go build -o dist/$$component -ldflags "-X main.version=$(VERSION) -X main.build=$(BUILD)" ./cmd/$$component ; \
+    done
 
 .PHONY: manifests
 manifests: build-dirs
@@ -130,6 +112,15 @@ run-volume-provisioner-dev:
 	go run cmd/oci-volume-provisioner/main.go         \
 	    --kubeconfig=$(KUBECONFIG)                    \
 	    -v=4
+
+.PHONY: image
+image: build
+	docker  build  \
+		-t $(IMAGE):$(VERSION) .
+
+.PHONY: push
+push: image
+	docker push $(IMAGE):$(VERSION)
 
 .PHONY: version
 version:

--- a/cmd/cloud-provider-oci/app/cloud_provider_oci.go
+++ b/cmd/cloud-provider-oci/app/cloud_provider_oci.go
@@ -1,0 +1,142 @@
+// Copyright 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	provisioner "github.com/oracle/oci-cloud-controller-manager/pkg/volume/provisioner/core"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+	cloudControllerManager "k8s.io/kubernetes/cmd/cloud-controller-manager/app"
+	cloudControllerManagerConfig "k8s.io/kubernetes/cmd/cloud-controller-manager/app/config"
+	"k8s.io/kubernetes/cmd/cloud-controller-manager/app/options"
+	"k8s.io/kubernetes/pkg/version/verflag"
+)
+
+var (
+	master, kubeconfig, minVolumeSize               string
+	enableVolumeProvisioning, volumeRoundingEnabled bool
+)
+
+// NewCloudProviderOCICommand creates a *cobra.Command object with default parameters
+func NewCloudProviderOCICommand(logger *zap.SugaredLogger) *cobra.Command {
+
+	// FIXME Create CLoudProviderOCIOptions struct that shall contain options for all the components
+	s, err := options.NewCloudControllerManagerOptions()
+	if err != nil {
+		logger.With(zap.Error(err)).Fatalf("unable to initialize command options")
+	}
+
+	command := &cobra.Command{
+		Use: "cloud-provider-oci",
+		Long: `The cloud provider oci daemon is a agglomeration of oci cloud controller
+manager and oci volume provisioner. It embeds the cloud specific control loops shipped with Kubernetes.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			verflag.PrintAndExitIfRequested()
+			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+				logger.Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+			})
+
+			c, err := s.Config()
+			if err != nil {
+				logger.With(zap.Error(err)).Fatalf("Unable to create cloud controller manager config")
+			}
+
+			run(logger, c.Complete(), s)
+
+		},
+	}
+
+	// cloud controller manager flag set
+	ccmFlagSet := pflag.NewFlagSet("cloud controller manager", pflag.ContinueOnError)
+	s.AddFlags(ccmFlagSet)
+
+	// volume provisioner flag set
+	vpFlagSet := pflag.NewFlagSet("volume provisioner", pflag.ContinueOnError)
+	vpFlagSet.BoolVar(&enableVolumeProvisioning, "enable-volume-provisioning", true, "When enabled volumes will be provisioned/deleted by cloud controller manager")
+	vpFlagSet.BoolVar(&volumeRoundingEnabled, "rounding-enabled", true, "When enabled volumes will be rounded up if less than 'minVolumeSizeMB'")
+	vpFlagSet.StringVar(&minVolumeSize, "min-volume-size", "50Gi", "The minimum size for a block volume. By default OCI only supports block volumes > 50GB")
+
+	// add complete flag set to command
+	command.Flags().AddFlagSet(ccmFlagSet)
+	command.Flags().AddFlagSet(vpFlagSet)
+
+	return command
+}
+
+func run(logger *zap.SugaredLogger, config *cloudControllerManagerConfig.CompletedConfig, options *options.CloudControllerManagerOptions) {
+	var wg sync.WaitGroup
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	sigs := make(chan os.Signal, 2)
+	defer close(sigs)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigs
+		cancelFunc()
+		<-sigs
+		os.Exit(1)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		logger := logger.With(zap.String("component", "volume-provisioner"))
+		if !enableVolumeProvisioning {
+			logger.Info("Volume provisioning is disabled")
+			return
+		}
+		// TODO Pass an options/config struct instead of config variables
+		if err := provisioner.Run(logger, options.Kubeconfig, options.Master, minVolumeSize, volumeRoundingEnabled, ctx.Done()); err != nil {
+			logger.With(zap.Error(err)).Error("Error running volume provisioner")
+		}
+		cancelFunc()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runOnce := make(chan struct{}, 1)
+		runOnce <- struct{}{}
+		defer close(runOnce)
+		// cloudControllerManager.Run does not accepts context. workaround to accept context
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-runOnce:
+				go func() {
+					// Run starts all the cloud controller manager control loops.
+					// TODO move to newer cloudControllerManager dependency that provides a way to pass channel/context
+					if err := cloudControllerManager.Run(config); err != nil {
+						logger.With(zap.Error(err)).Error("Error running cloud controller manager")
+					}
+					cancelFunc()
+				}()
+
+			}
+		}
+	}()
+
+	// wait for all the go routines to finish.
+	wg.Wait()
+}

--- a/cmd/cloud-provider-oci/main.go
+++ b/cmd/cloud-provider-oci/main.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	goflag "flag"
+	"go.uber.org/zap"
+	"math/rand"
+	"syscall"
+	"time"
+
+	"github.com/oracle/oci-cloud-controller-manager/cmd/cloud-provider-oci/app"
+	_ "github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci"
+	"github.com/oracle/oci-cloud-controller-manager/pkg/logging"
+	"github.com/spf13/pflag"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
+	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
+)
+
+var version string
+var build string
+
+func main() {
+	syscall.Umask(0)
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	log := logging.Logger()
+	defer log.Sync()
+	zap.ReplaceGlobals(log)
+	logger := log.Sugar()
+
+	command := app.NewCloudProviderOCICommand(logger)
+
+	// TODO: once we switch everything over to Cobra commands, we can go back to calling
+	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
+	// normalize func and add the go flag set by hand.
+	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	goflag.CommandLine.Parse([]string{})
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	logger.With("version", version, "build", build).Info("oci-cloud-controller-manager")
+
+	// run the main cloud controller loop
+	if err := command.Execute(); err != nil {
+		logger.With(zap.Error(err)).Fatal("error running cloud provider OCI")
+	}
+}

--- a/cmd/oci-volume-provisioner/main.go
+++ b/cmd/oci-volume-provisioner/main.go
@@ -16,45 +16,17 @@ package main
 
 import (
 	"flag"
-	"math/rand"
-	"os"
 	"syscall"
-	"time"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/logging"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/util/signals"
-	"github.com/oracle/oci-cloud-controller-manager/pkg/volume/provisioner/core"
+	provisioner "github.com/oracle/oci-cloud-controller-manager/pkg/volume/provisioner/core"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-)
-
-const (
-	resyncPeriod              = 15 * time.Second
-	minResyncPeriod           = 12 * time.Hour
-	exponentialBackOffOnError = false
-	failedRetryThreshold      = 5
-	leasePeriod               = controller.DefaultLeaseDuration
-	retryPeriod               = controller.DefaultRetryPeriod
-	renewDeadline             = controller.DefaultRenewDeadline
-	termLimit                 = controller.DefaultTermLimit
 )
 
 // version/build is set at build time to the version of the provisioner being built.
 var version string
 var build string
-
-// informerResyncPeriod computes the time interval a shared informer waits
-// before resyncing with the API server.
-func informerResyncPeriod(minResyncPeriod time.Duration) func() time.Duration {
-	return func() time.Duration {
-		factor := rand.Float64() + 1
-		return time.Duration(float64(minResyncPeriod.Nanoseconds()) * factor)
-	}
-}
 
 func main() {
 	syscall.Umask(0)
@@ -76,77 +48,7 @@ func main() {
 	// Set up signals so we handle the shutdown signal gracefully.
 	stopCh := signals.SetupSignalHandler()
 
-	// Create an InClusterConfig and use it to create a client for the controller
-	// to use to communicate with Kubernetes
-	config, err := clientcmd.BuildConfigFromFlags(*master, *kubeconfig)
-	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Failed to load config")
+	if err := provisioner.Run(logger, *kubeconfig, *master, *minVolumeSize, *volumeRoundingEnabled, stopCh); err != nil {
+		logger.With(zap.Error(err)).Fatal("error running volume provisioner")
 	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Failed to create Kubernetes client")
-	}
-
-	// The controller needs to know what the server version is because out-of-tree
-	// provisioners aren't officially supported until 1.5
-	serverVersion, err := clientset.Discovery().ServerVersion()
-	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Failed to get kube-apiserver version")
-	}
-
-	// TODO (owainlewis) ensure this is clearly documented
-	nodeName := os.Getenv("NODE_NAME")
-	if nodeName == "" {
-		logger.Fatal("env variable NODE_NAME must be set so that this provisioner can identify itself")
-	}
-
-	// Decides what type of provider to deploy, either block or fss
-	provisionerType := os.Getenv("PROVISIONER_TYPE")
-	if provisionerType == "" {
-		provisionerType = core.ProvisionerNameDefault
-	}
-
-	logger = logger.With("provisionerType", provisionerType)
-	logger.Infof("Starting volume provisioner in %q mode", provisionerType)
-
-	sharedInformerFactory := informers.NewSharedInformerFactory(clientset, informerResyncPeriod(minResyncPeriod)())
-
-	volumeSizeLowerBound, err := resource.ParseQuantity(*minVolumeSize)
-	if err != nil {
-		logger.With(zap.Error(err), "minimumVolumeSize", *minVolumeSize).Fatal("Failed to parse minimum volume size")
-	}
-
-	// Create the provisioner: it implements the Provisioner interface expected by
-	// the controller
-	ociProvisioner, err := core.NewOCIProvisioner(logger, clientset, sharedInformerFactory.Core().V1().Nodes(), provisionerType, nodeName, *volumeRoundingEnabled, volumeSizeLowerBound)
-	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Cannot create volume provisioner.")
-	}
-
-	// Start the provision controller which will dynamically provision oci
-	// PVs
-	pc := controller.NewProvisionController(
-		clientset,
-		provisionerType,
-		ociProvisioner,
-		serverVersion.GitVersion,
-		controller.ResyncPeriod(resyncPeriod),
-		controller.ExponentialBackOffOnError(exponentialBackOffOnError),
-		controller.FailedProvisionThreshold(failedRetryThreshold),
-		controller.LeaseDuration(leasePeriod),
-		controller.RenewDeadline(renewDeadline),
-		controller.RetryPeriod(retryPeriod),
-		controller.TermLimit(termLimit),
-	)
-
-	go sharedInformerFactory.Start(stopCh)
-
-	// We block waiting for Ready() after the shared informer factory has
-	// started so we don't deadlock waiting for caches to sync.
-	if err := ociProvisioner.Ready(stopCh); err != nil {
-		logger.With(zap.Error(err)).Fatal("Failed to start volume provisioner")
-	}
-
-	pc.Run(stopCh)
 }

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -202,8 +202,8 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
-    # dates can be 2017, 2018; company holder names can be anything
-    regexs["date"] = re.compile('(2017|2018)')
+    # dates can be 2017, 2018, 2019, 2020; company holder names can be anything
+    regexs["date"] = re.compile('(2017|2018|2019|2020)')
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts

--- a/pkg/cloudprovider/providers/oci/ccm.go
+++ b/pkg/cloudprovider/providers/oci/ccm.go
@@ -81,6 +81,7 @@ func NewCloudProvider(config *providercfg.Config) (cloudprovider.Interface, erro
 	// The global logger has been replaced with the logger we constructed in
 	// main.go so capture it here and then pass it into all components.
 	logger := zap.L()
+	logger = logger.With(zap.String("component", "cloud-controller-manager"))
 
 	cp, err := providercfg.NewConfigurationProvider(config)
 	if err != nil {

--- a/pkg/cloudprovider/providers/oci/load_balancer.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer.go
@@ -473,7 +473,7 @@ func (cp *CloudProvider) updateListener(ctx context.Context, lbID string, action
 
 	cp.logger.With(
 		"actionType", action.Type(),
-		"backendSetName", action.Name(),
+		"listenerName", action.Name(),
 		"ports", ports,
 		"loadBalancerID", lbID).Info("Applying action on listener")
 

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec.go
@@ -358,7 +358,7 @@ func getListeners(svc *v1.Service, sslCfg *SSLConfig) (map[string]loadbalancer.L
 			secretName = sslCfg.ListenerSSLSecretName
 		}
 		sslConfiguration := getSSLConfiguration(sslCfg, secretName, port)
-		name := getListenerName(protocol, port, sslConfiguration)
+		name := getListenerName(protocol, port)
 
 		listener := loadbalancer.ListenerDetails{
 			DefaultBackendSetName: common.String(getBackendSetName(string(servicePort.Protocol), int(servicePort.Port))),

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
@@ -15,7 +15,6 @@
 package oci
 
 import (
-	"fmt"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"reflect"
@@ -537,7 +536,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 				Internal: false,
 				Subnets:  []string{"one", "two"},
 				Listeners: map[string]loadbalancer.ListenerDetails{
-					fmt.Sprintf("TCP-443-%s", listenerSecret): {
+					"TCP-443": {
 						DefaultBackendSetName: common.String("TCP-443"),
 						Port:                  common.Int(443),
 						Protocol:              common.String("TCP"),

--- a/pkg/cloudprovider/providers/oci/load_balancer_util_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_util_test.go
@@ -93,6 +93,21 @@ func TestSortAndCombineActions(t *testing.T) {
 					actionType: Update,
 					BackendSet: loadbalancer.BackendSetDetails{},
 				},
+				&BackendSetAction{
+					name:       "TCP-445",
+					actionType: Update,
+					BackendSet: loadbalancer.BackendSetDetails{},
+				},
+				&BackendSetAction{
+					name:       "TCP-444",
+					actionType: Update,
+					BackendSet: loadbalancer.BackendSetDetails{},
+				},
+				&BackendSetAction{
+					name:       "TCP-442",
+					actionType: Update,
+					BackendSet: loadbalancer.BackendSetDetails{},
+				},
 			},
 			listenerActions: []Action{
 				&ListenerAction{
@@ -105,8 +120,33 @@ func TestSortAndCombineActions(t *testing.T) {
 					actionType: Update,
 					Listener:   loadbalancer.ListenerDetails{},
 				},
+				&ListenerAction{
+					name:       "TCP-445",
+					actionType: Update,
+					Listener:   loadbalancer.ListenerDetails{},
+				},
+				&ListenerAction{
+					name:       "TCP-442",
+					actionType: Update,
+					Listener:   loadbalancer.ListenerDetails{},
+				},
+				&ListenerAction{
+					name:       "TCP-444",
+					actionType: Update,
+					Listener:   loadbalancer.ListenerDetails{},
+				},
 			},
 			expected: []Action{
+				&ListenerAction{
+					name:       "TCP-442",
+					actionType: Update,
+					Listener:   loadbalancer.ListenerDetails{},
+				},
+				&BackendSetAction{
+					name:       "TCP-442",
+					actionType: Update,
+					BackendSet: loadbalancer.BackendSetDetails{},
+				},
 				&ListenerAction{
 					name:       "TCP-443",
 					actionType: Update,
@@ -114,6 +154,26 @@ func TestSortAndCombineActions(t *testing.T) {
 				},
 				&BackendSetAction{
 					name:       "TCP-443",
+					actionType: Update,
+					BackendSet: loadbalancer.BackendSetDetails{},
+				},
+				&ListenerAction{
+					name:       "TCP-444",
+					actionType: Update,
+					Listener:   loadbalancer.ListenerDetails{},
+				},
+				&BackendSetAction{
+					name:       "TCP-444",
+					actionType: Update,
+					BackendSet: loadbalancer.BackendSetDetails{},
+				},
+				&ListenerAction{
+					name:       "TCP-445",
+					actionType: Update,
+					Listener:   loadbalancer.ListenerDetails{},
+				},
+				&BackendSetAction{
+					name:       "TCP-445",
 					actionType: Update,
 					BackendSet: loadbalancer.BackendSetDetails{},
 				},
@@ -144,7 +204,7 @@ func TestSortAndCombineActions(t *testing.T) {
 			},
 			listenerActions: []Action{
 				&ListenerAction{
-					name:       "TCP-443",
+					name:       "TCP-443-secret",
 					actionType: Delete,
 					Listener:   loadbalancer.ListenerDetails{},
 				},
@@ -156,7 +216,7 @@ func TestSortAndCombineActions(t *testing.T) {
 			},
 			expected: []Action{
 				&ListenerAction{
-					name:       "TCP-443",
+					name:       "TCP-443-secret",
 					actionType: Delete,
 					Listener:   loadbalancer.ListenerDetails{},
 				},
@@ -465,6 +525,41 @@ func TestGetListenerChanges(t *testing.T) {
 			},
 		},
 		{
+			name: "remove listener [legacy listeners]",
+			desired: map[string]loadbalancer.ListenerDetails{
+				"TCP-80": loadbalancer.ListenerDetails{
+					DefaultBackendSetName: common.String("TCP-80"),
+					Protocol:              common.String("TCP"),
+					Port:                  common.Int(80),
+				},
+			},
+			actual: map[string]loadbalancer.Listener{
+				"TCP-443-secret": loadbalancer.Listener{
+					Name:                  common.String("TCP-443-secret"),
+					DefaultBackendSetName: common.String("TCP-443"),
+					Protocol:              common.String("TCP"),
+					Port:                  common.Int(443),
+				},
+				"TCP-80": loadbalancer.Listener{
+					Name:                  common.String("TCP-80"),
+					DefaultBackendSetName: common.String("TCP-80"),
+					Protocol:              common.String("TCP"),
+					Port:                  common.Int(80),
+				},
+			},
+			expected: []Action{
+				&ListenerAction{
+					name:       "TCP-443-secret",
+					actionType: Delete,
+					Listener: loadbalancer.ListenerDetails{
+						DefaultBackendSetName: common.String("TCP-443"),
+						Protocol:              common.String("TCP"),
+						Port:                  common.Int(443),
+					},
+				},
+			},
+		},
+		{
 			name: "no change",
 			desired: map[string]loadbalancer.ListenerDetails{
 				"TCP-80": loadbalancer.ListenerDetails{
@@ -476,6 +571,25 @@ func TestGetListenerChanges(t *testing.T) {
 			actual: map[string]loadbalancer.Listener{
 				"TCP-80": loadbalancer.Listener{
 					Name:                  common.String("TCP-80"),
+					DefaultBackendSetName: common.String("TCP-80"),
+					Protocol:              common.String("TCP"),
+					Port:                  common.Int(80),
+				},
+			},
+			expected: []Action{},
+		},
+		{
+			name: "no change [legacy listeners]",
+			desired: map[string]loadbalancer.ListenerDetails{
+				"TCP-80": loadbalancer.ListenerDetails{
+					DefaultBackendSetName: common.String("TCP-80"),
+					Protocol:              common.String("TCP"),
+					Port:                  common.Int(80),
+				},
+			},
+			actual: map[string]loadbalancer.Listener{
+				"TCP-80-secret": loadbalancer.Listener{
+					Name:                  common.String("TCP-80-secret"),
 					DefaultBackendSetName: common.String("TCP-80"),
 					Protocol:              common.String("TCP"),
 					Port:                  common.Int(80),
@@ -509,6 +623,44 @@ func TestGetListenerChanges(t *testing.T) {
 			expected: []Action{
 				&ListenerAction{
 					name:       "TCP-80",
+					actionType: Update,
+					Listener: loadbalancer.ListenerDetails{
+						DefaultBackendSetName: common.String("TCP-80"),
+						Protocol:              common.String("TCP"),
+						Port:                  common.Int(80),
+						SslConfiguration: &loadbalancer.SslConfigurationDetails{
+							CertificateName: common.String("desired"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ssl config change [legacy listeners]",
+			desired: map[string]loadbalancer.ListenerDetails{
+				"TCP-80": loadbalancer.ListenerDetails{
+					DefaultBackendSetName: common.String("TCP-80"),
+					Protocol:              common.String("TCP"),
+					Port:                  common.Int(80),
+					SslConfiguration: &loadbalancer.SslConfigurationDetails{
+						CertificateName: common.String("desired"),
+					},
+				},
+			},
+			actual: map[string]loadbalancer.Listener{
+				"TCP-80-secret": loadbalancer.Listener{
+					Name:                  common.String("TCP-80-secret"),
+					DefaultBackendSetName: common.String("TCP-80"),
+					Protocol:              common.String("TCP"),
+					Port:                  common.Int(80),
+					SslConfiguration: &loadbalancer.SslConfiguration{
+						CertificateName: common.String("arg"),
+					},
+				},
+			},
+			expected: []Action{
+				&ListenerAction{
+					name:       "TCP-80-secret",
 					actionType: Update,
 					Listener: loadbalancer.ListenerDetails{
 						DefaultBackendSetName: common.String("TCP-80"),
@@ -658,6 +810,63 @@ func TestGetLoadBalancerName(t *testing.T) {
 			result := GetLoadBalancerName(tc.service)
 			if result != tc.expected {
 				t.Errorf("Expected load balancer name `%s` but got `%s`", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetSanitizedName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		arg      string
+		expected string
+	}{
+		{
+			"legacy name (with suffix secret name added)",
+			"TCP-80-mysecret1",
+			"TCP-80",
+		},
+		{
+			"new name (suffix secret name omitted)",
+			"TCP-80",
+			"TCP-80",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getSanitizedName(tc.arg); got != tc.expected {
+				t.Errorf("Expected sanitized listener name '%s' but got '%s'", tc.expected, got)
+			}
+		})
+	}
+
+}
+
+func TestGetListenerName(t *testing.T) {
+	type args struct {
+		protocol string
+		port     int
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected string
+	}{
+		{
+			"name",
+			args{
+				"TCP",
+				80,
+			},
+			"TCP-80",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getListenerName(tt.args.protocol, tt.args.port); got != tt.expected {
+				t.Errorf("Expected listener name = %v, but got %v", tt.expected, got)
 			}
 		})
 	}

--- a/pkg/util/iscsi/iscsi.go
+++ b/pkg/util/iscsi/iscsi.go
@@ -147,7 +147,7 @@ func NewFromMountPointPath(logger *zap.SugaredLogger, mountPath string) (Interfa
 	if err != nil {
 		return nil, err
 	}
-	for _, diskByPath := range(diskByPaths) {
+	for _, diskByPath := range diskByPaths {
 		iface, err := NewFromDevicePath(logger, diskByPath)
 		if err == nil {
 			return iface, nil

--- a/pkg/volume/provisioner/block/block.go
+++ b/pkg/volume/provisioner/block/block.go
@@ -17,6 +17,7 @@ package block
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -40,8 +41,9 @@ const (
 	// OCIVolumeBackupID is the name of the oci volume backup id annotation.
 	OCIVolumeBackupID = "volume.beta.kubernetes.io/oci-volume-source"
 	// FSType is the name of the file storage type parameter for storage classes.
-	FSType                  = "fsType"
-	volumeRoundingUpEnabled = "volumeRoundingUpEnabled"
+	FSType                    = "fsType"
+	volumeRoundingUpEnabled   = "volumeRoundingUpEnabled"
+	volumeBackupOCIDPrefixExp = `^ocid[v]?[\d+]?[\.:]volumebackup[\.:]`
 )
 
 // blockProvisioner is the internal provisioner for OCI block volumes
@@ -143,8 +145,13 @@ func (block *blockProvisioner) Provision(options controller.VolumeOptions, ad *i
 
 	if value, ok := options.PVC.Annotations[OCIVolumeBackupID]; ok {
 		logger = logger.With("volumeBackupOCID", value)
-		logger.Info("Creating volume from backup.")
-		volumeDetails.SourceDetails = &core.VolumeSourceFromVolumeBackupDetails{Id: &value}
+		if isVolumeBackupOcid(value) {
+			logger.Info("Creating volume from block volume backup.")
+			volumeDetails.SourceDetails = &core.VolumeSourceFromVolumeBackupDetails{Id: &value}
+		} else {
+			logger.Info("Creating volume from block volume.")
+			volumeDetails.SourceDetails = &core.VolumeSourceFromVolumeDetails{Id: &value}
+		}
 	}
 
 	// Create the volume.
@@ -190,6 +197,11 @@ func (block *blockProvisioner) Provision(options controller.VolumeOptions, ad *i
 	}
 
 	return pv, nil
+}
+
+func isVolumeBackupOcid(ocid string) bool {
+	res, _ := regexp.MatchString(volumeBackupOCIDPrefixExp, ocid)
+	return res
 }
 
 // Delete destroys a OCI volume created by Provision

--- a/pkg/volume/provisioner/block/block_test.go
+++ b/pkg/volume/provisioner/block/block_test.go
@@ -440,6 +440,32 @@ func TestVolumeRoundingLogic(t *testing.T) {
 	}
 }
 
+func TestVolumeBackupOCID(t *testing.T) {
+	var volumeBackupOcidTests = []struct {
+		in  string
+		out bool
+	}{
+		{"ocid1.volumebackup.", true},
+		{"ocidv1:volumebackup.", true},
+		{"ocid2.volumebackup.", true},
+		{"ocidv2.volumebackup.", true},
+		{"ocid.volumebackup.", true},
+		{"ocid1.volumebackupsdfljf", false},
+		{"ocidv1:volume.", false},
+		{"ocid2.volume.", false},
+		{"ocidv2.volume.", false},
+	}
+	for i, tt := range volumeBackupOcidTests {
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			expected := tt.out
+			actual := isVolumeBackupOcid(tt.in)
+			if expected != actual {
+				t.Fatalf("Expected value to be %v but got %v", expected, actual)
+			}
+		})
+	}
+}
+
 func createPVC(size string) *v1.PersistentVolumeClaim {
 	return &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{},

--- a/pkg/volume/provisioner/core/provisioner.go
+++ b/pkg/volume/provisioner/core/provisioner.go
@@ -16,8 +16,10 @@ package core
 
 import (
 	"context"
+	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	providercfg "github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
@@ -30,10 +32,14 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/informers"
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/flowcontrol"
 	metav1 "k8s.io/kubernetes/pkg/kubelet/apis"
 )
@@ -52,8 +58,12 @@ const (
 )
 
 const (
-	rateLimitQPSDefault    = 20.0
-	rateLimitBucketDefault = 5
+	rateLimitQPSDefault       = 20.0
+	rateLimitBucketDefault    = 5
+	resyncPeriod              = 15 * time.Second
+	minResyncPeriod           = 12 * time.Hour
+	exponentialBackOffOnError = false
+	failedRetryThreshold      = 5
 )
 
 // OCIProvisioner is a dynamic volume provisioner that satisfies
@@ -73,15 +83,7 @@ type OCIProvisioner struct {
 }
 
 // NewOCIProvisioner creates a new OCI provisioner.
-func NewOCIProvisioner(
-	logger *zap.SugaredLogger,
-	kubeClient kubernetes.Interface,
-	nodeInformer informersv1.NodeInformer,
-	provisionerType string,
-	nodeName string,
-	volumeRoundingEnabled bool,
-	minVolumeSize resource.Quantity,
-) (*OCIProvisioner, error) {
+func NewOCIProvisioner(logger *zap.SugaredLogger, kubeClient kubernetes.Interface, nodeInformer informersv1.NodeInformer, provisionerType string, volumeRoundingEnabled bool, minVolumeSize resource.Quantity) (*OCIProvisioner, error) {
 	configPath, ok := os.LookupEnv("CONFIG_YAML_FILENAME")
 	if !ok {
 		configPath = configFilePath
@@ -89,17 +91,17 @@ func NewOCIProvisioner(
 
 	cfg, err := providercfg.FromFile(configPath)
 	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Failed to load configuration file at path %s", configPath)
+		return nil, errors.Wrapf(err, "failed to load configuration file at path %s", configPath)
 	}
 
 	err = cfg.Validate()
 	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Invalid configuration: %s", err)
+		return nil, errors.Wrapf(err, "invalid configuration")
 	}
 
 	metadata, mdErr := metadata.New().Get()
 	if mdErr != nil {
-		logger.With(zap.Error(mdErr)).Warnf("Unable to retrieve instance metadata.")
+		logger.With(zap.Error(mdErr)).Warnf("unable to retrieve instance metadata.")
 	}
 
 	if cfg.CompartmentID == "" {
@@ -113,12 +115,12 @@ func NewOCIProvisioner(
 
 	cp, err := providercfg.NewConfigurationProvider(cfg)
 	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Unable to create volume provisioner client.")
+		return nil, errors.Wrapf(err, "unable to create volume provisioner client.")
 	}
 
 	tenancyID, err := cp.TenancyOCID()
 	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Unable to detrimine tenancy")
+		return nil, errors.Wrapf(err, "unable to detrimine tenancy")
 	}
 
 	logger = logger.With(
@@ -137,7 +139,7 @@ func NewOCIProvisioner(
 		),
 	})
 	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Unable to construct OCI client")
+		return nil, errors.Wrapf(err, "unable to construct OCI client")
 	}
 
 	region, ok := os.LookupEnv("OCI_SHORT_REGION")
@@ -226,4 +228,86 @@ func (p *OCIProvisioner) Ready(stopCh <-chan struct{}) error {
 		return errors.New("unable to sync caches for OCI Volume Provisioner")
 	}
 	return nil
+}
+
+// informerResyncPeriod computes the time interval a shared informer waits
+// before resyncing with the API server.
+func informerResyncPeriod(minResyncPeriod time.Duration) func() time.Duration {
+	return func() time.Duration {
+		factor := rand.Float64() + 1
+		return time.Duration(float64(minResyncPeriod.Nanoseconds()) * factor)
+	}
+}
+
+// Run runs the volume provisoner control loop
+func Run(logger *zap.SugaredLogger, kubeconfig string, master string, minVolumeSize string, volumeRoundingEnabled bool, stopCh <-chan struct{}) error {
+
+	// Create an InClusterConfig and use it to create a client for the controller
+	// to use to communicate with Kubernetes
+	config, err := clientcmd.BuildConfigFromFlags(master, kubeconfig)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load config")
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create Kubernetes client")
+	}
+
+	// The controller needs to know what the server version is because out-of-tree
+	// provisioners aren't officially supported until 1.5
+	var serverVersion *version.Info
+	err = wait.PollUntil(15*time.Second, func() (done bool, err error) {
+		serverVersion, err = clientset.Discovery().ServerVersion()
+		if err != nil {
+			logger.With(zap.Error(err)).Info("failed to get kube-apiserver version, will retry again")
+			return false, nil
+		}
+		return true, nil
+	}, stopCh)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get kube-apiserver version")
+	}
+
+	// Decides what type of provider to deploy, either block or fss
+	provisionerType := os.Getenv("PROVISIONER_TYPE")
+	if provisionerType == "" {
+		provisionerType = ProvisionerNameDefault
+	}
+	logger = logger.With("provisionerType", provisionerType)
+	logger.Infof("Starting volume provisioner in %q mode", provisionerType)
+
+	// TODO Should use an existing informer factory instead of constructing a new one
+	sharedInformerFactory := informers.NewSharedInformerFactory(clientset, informerResyncPeriod(minResyncPeriod)())
+
+	volumeSizeLowerBound, err := resource.ParseQuantity(minVolumeSize)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse minimum volume size")
+	}
+
+	// Create the provisioner: it implements the Provisioner interface expected by
+	// the controller
+	ociProvisioner, err := NewOCIProvisioner(logger, clientset, sharedInformerFactory.Core().V1().Nodes(), provisionerType, volumeRoundingEnabled, volumeSizeLowerBound)
+	if err != nil {
+		return errors.Wrapf(err, "cannot create volume provisioner.")
+	}
+	// Start the provision controller which will dynamically provision oci
+	// PVs
+	pc := controller.NewProvisionController(
+		clientset,
+		provisionerType,
+		ociProvisioner,
+		serverVersion.GitVersion,
+		controller.ResyncPeriod(resyncPeriod),
+		controller.ExponentialBackOffOnError(exponentialBackOffOnError),
+		controller.FailedProvisionThreshold(failedRetryThreshold),
+		controller.Threadiness(2),
+	)
+	go sharedInformerFactory.Start(stopCh)
+	// We block waiting for Ready() after the shared informer factory has
+	// started so we don't deadlock waiting for caches to sync.
+	if err := ociProvisioner.Ready(stopCh); err != nil {
+		return errors.Wrapf(err, "failed to start volume provisioner")
+	}
+	pc.Run(stopCh)
+	return errors.Errorf("unreachable")
 }

--- a/pkg/volume/provisioner/fss/fss.go
+++ b/pkg/volume/provisioner/fss/fss.go
@@ -80,7 +80,7 @@ func NewFilesystemProvisioner(logger *zap.SugaredLogger, client client.Interface
 }
 
 func (fsp *filesystemProvisioner) getOrCreateFileSystem(ctx context.Context, logger *zap.SugaredLogger, ad, displayName string) (*fss.FileSystem, error) {
-	summary, err := fsp.client.FSS().GetFileSystemSummaryByDisplayName(ctx, ad, fsp.compartmentID, displayName)
+	summary, err := fsp.client.FSS().GetFileSystemSummaryByDisplayName(ctx, fsp.compartmentID, ad, displayName)
 	if err != nil && !client.IsNotFound(err) {
 		return nil, err
 	}

--- a/wercker.yml
+++ b/wercker.yml
@@ -75,72 +75,72 @@ publish-docker-image:
             docker push ${IMAGE}:latest
           fi
 
-ccm-e2e-test:
-  base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
-  steps:
-    - script:
-      name: Run CCM E2E tests
-      code: |
-        export VERSION=$(make version)
-        echo "Running CCM tests version: ${VERSION}"
-        export NODEPORT_TEST="true"
-        export CCM_SECLIST_ID="ocid1.securitylist.oc1.iad.aaaaaaaagekgnvc75yxb66xj2qgocejhyk5xuhojm6wimmteqa5fj43kk5lq"
-        export K8S_SECLIST_ID="ocid1.securitylist.oc1.iad.aaaaaaaajzgrgfma2xzzdv4erczaiphuyaflazbt2bvzw2cwj2pxo3fygo5a"
-
-        if [ -z "${KUBECONFIG}" ]; then
-            if [ -z "${KUBECONFIG_VAR}" ]; then
-                echo "KUBECONFIG or KUBECONFIG_VAR must be set"
-                exit 1
-            else
-                # NB: Wercker environment variables are base64 encoded.
-                echo "$KUBECONFIG_VAR" | openssl enc -base64 -d -A > /tmp/kubeconfig
-                export KUBECONFIG=/tmp/kubeconfig
-            fi
-        fi
-
-        if [ -z "${CLOUDCONFIG}" ]; then
-            if [ -z "${CLOUDCONFIG_VAR}" ]; then
-                echo "CLOUDCONFIG or CLOUDCONFIG_VAR must be set"
-                exit 1
-            else
-                # NB: Wercker environment variables are base64 encoded.
-                echo "$CLOUDCONFIG_VAR" | openssl enc -base64 -d -A > /tmp/cloudconfig
-                export CLOUDCONFIG=/tmp/cloudconfig
-            fi
-        fi
-
-        ginkgo                                 \
-          -v                                   \
-          -progress                            \
-          test/e2e/cloud-controller-manager -- \
-          --kubeconfig=${KUBECONFIG}           \
-          --cloud-config=${CLOUDCONFIG}        \
-          --delete-namespace=true
-
-volume-provisioner-e2e-test:
-  base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
-  steps:
-    - script:
-      name: Run volume provisioner E2E tests
-      code: |
-        export VERSION=$(cat dist/VERSION.txt)
-
-        export OCI_CONFIG="/tmp/ociconfig"
-        echo -n "${OCI_CONFIG_VAR}" | openssl enc -base64 -d -A > "${OCI_CONFIG}"
-
-        export KUBECONFIG="/tmp/kubeconfig"
-        echo -n "${KUBECONFIG_VAR}" | openssl enc -base64 -d -A > "${KUBECONFIG}"
-
-        export MOUNT_TARGET_ID="ocid1.mounttarget.oc1.iad.aaaaaby27vezbb5cnfqwillqojxwiotjmfsc2ylefuzqaaaa"
-
-        ginkgo \
-          -v \
-          test/e2e/volume-provisioner -- \
-          --kubeconfig="${KUBECONFIG}" \
-          --ociconfig="${OCI_CONFIG}" \
-          --mnt-target-id="${MOUNT_TARGET_ID}" \
-          --delete-namespace-on-failure=true \
-          --image="iad.ocir.io/oracle/cloud-provider-oci:${VERSION}"
+#ccm-e2e-test:
+#  base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
+#  steps:
+#    - script:
+#      name: Run CCM E2E tests
+#      code: |
+#        export VERSION=$(make version)
+#        echo "Running CCM tests version: ${VERSION}"
+#        export NODEPORT_TEST="true"
+#        export CCM_SECLIST_ID="ocid1.securitylist.oc1.iad.aaaaaaaagekgnvc75yxb66xj2qgocejhyk5xuhojm6wimmteqa5fj43kk5lq"
+#        export K8S_SECLIST_ID="ocid1.securitylist.oc1.iad.aaaaaaaajzgrgfma2xzzdv4erczaiphuyaflazbt2bvzw2cwj2pxo3fygo5a"
+#
+#        if [ -z "${KUBECONFIG}" ]; then
+#            if [ -z "${KUBECONFIG_VAR}" ]; then
+#                echo "KUBECONFIG or KUBECONFIG_VAR must be set"
+#                exit 1
+#            else
+#                # NB: Wercker environment variables are base64 encoded.
+#                echo "$KUBECONFIG_VAR" | openssl enc -base64 -d -A > /tmp/kubeconfig
+#                export KUBECONFIG=/tmp/kubeconfig
+#            fi
+#        fi
+#
+#        if [ -z "${CLOUDCONFIG}" ]; then
+#            if [ -z "${CLOUDCONFIG_VAR}" ]; then
+#                echo "CLOUDCONFIG or CLOUDCONFIG_VAR must be set"
+#                exit 1
+#            else
+#                # NB: Wercker environment variables are base64 encoded.
+#                echo "$CLOUDCONFIG_VAR" | openssl enc -base64 -d -A > /tmp/cloudconfig
+#                export CLOUDCONFIG=/tmp/cloudconfig
+#            fi
+#        fi
+#
+#        ginkgo                                 \
+#          -v                                   \
+#          -progress                            \
+#          test/e2e/cloud-controller-manager -- \
+#          --kubeconfig=${KUBECONFIG}           \
+#          --cloud-config=${CLOUDCONFIG}        \
+#          --delete-namespace=true
+#
+#volume-provisioner-e2e-test:
+#  base-path: "/go/src/github.com/oracle/oci-cloud-controller-manager"
+#  steps:
+#    - script:
+#      name: Run volume provisioner E2E tests
+#      code: |
+#        export VERSION=$(cat dist/VERSION.txt)
+#
+#        export OCI_CONFIG="/tmp/ociconfig"
+#        echo -n "${OCI_CONFIG_VAR}" | openssl enc -base64 -d -A > "${OCI_CONFIG}"
+#
+#        export KUBECONFIG="/tmp/kubeconfig"
+#        echo -n "${KUBECONFIG_VAR}" | openssl enc -base64 -d -A > "${KUBECONFIG}"
+#
+#        export MOUNT_TARGET_ID="ocid1.mounttarget.oc1.iad.aaaaaby27vezbb5cnfqwillqojxwiotjmfsc2ylefuzqaaaa"
+#
+#        ginkgo \
+#          -v \
+#          test/e2e/volume-provisioner -- \
+#          --kubeconfig="${KUBECONFIG}" \
+#          --ociconfig="${OCI_CONFIG}" \
+#          --mnt-target-id="${MOUNT_TARGET_ID}" \
+#          --delete-namespace-on-failure=true \
+#          --image="iad.ocir.io/oracle/cloud-provider-oci:${VERSION}"
 
 release:
   box:


### PR DESCRIPTION
pick commits from internal fork 

- Enable provisioning BV from another BV
- Fix review comments
- Fix review comments
- Add unit tests
- Deploy single container with CCM and FVP
- Fix polling error
- fix review comments
- Refactored to move command to app package, replace fatalf refrences with error, remove nodeName reference
- Cert rotation should avoid listener recreation
- fix review comments
- match params with called func signature 
- Fix test to avoid appending secret name to listeners name


### DEMO 

```
(t1) generated ❯ ks create -f ~/work/misc/nginx_service.yaml                                                                                                               master
deployment.apps/nginx created
service/nginx created
(t1) generated ❯ ks get svc nginx                                                                                                                                          master
NAME    TYPE           CLUSTER-IP   EXTERNAL-IP     PORT(S)        AGE
nginx   LoadBalancer   10.21.56.8   158.101.24.53   80:31351/TCP   46s

(t1) generated ❯ ks create -f demo_pvc.yaml                                                                                                                                master
persistentvolumeclaim/demooci created
(t1) generated ❯ ks get pvc demooci                                                                                                                                        master
NAME      STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
demooci   Pending                                      oci            36s
(t1) generated ❯ ks get pvc demooci                                                                                                                                        master
NAME      STATUS   VOLUME                                                                              CAPACITY   ACCESS MODES   STORAGECLASS   AGE
demooci   Bound    ocid1.volume.oc1.phx.abyhqljtfgzxepg5d73fvxwf75c2s4tsy7ciizq7pvqdlfnaen3kb5oavvta   50Gi       RWO            oci            46s
```

