### PR TITLE
Release 0.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ FROM oraclelinux:7-slim
 COPY --from=0 /go/src/github.com/oracle/oci-cloud-controller-manager/dist/* /usr/local/bin/
 COPY --from=0 /go/src/github.com/oracle/oci-cloud-controller-manager/image/* /usr/local/bin/
 
-RUN yum install -y iscsi-initiator-utils-6.2.0.874-10.0.5.el7 \
- && yum install -y e2fsprogs \
- && yum clean all
+RUN yum install -y util-linux \
+  && yum install -y e2fsprogs \
+  && yum clean all

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
     OSS_REGISTRY   ?= ${OSS_REGISTRY}
 endif
 IMAGE ?= $(OSS_REGISTRY)/cloud-provider-oci
-COMPONENT ?= oci-cloud-controller-manager oci-volume-provisioner oci-flexvolume-driver cloud-provider-oci oci-csi-controller-driver oci-csi-node-driver
+COMPONENT ?= oci-cloud-controller-manager oci-volume-provisioner oci-flexvolume-driver oci-csi-controller-driver oci-csi-node-driver
 
 ifeq "$(VERSION)" ""
     BUILD := $(shell git describe --exact-match 2> /dev/null || git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Infrastucture][1] (OCI).
 [![wercker status](https://app.wercker.com/status/17a52304e0309d138ad41f7ae9f9ea49/s/master "wercker status")](https://app.wercker.com/project/byKey/17a52304e0309d138ad41f7ae9f9ea49)
 [![Go Report Card](https://goreportcard.com/badge/github.com/oracle/oci-cloud-controller-manager)](https://goreportcard.com/report/github.com/oracle/oci-cloud-controller-manager)
 
-**WARNING**: this project is under active development and should be considered alpha.
-
 ## Introduction
 
 External cloud providers were introduced as an _Alpha_ feature in Kubernetes

--- a/container-storage-interface.md
+++ b/container-storage-interface.md
@@ -56,8 +56,8 @@ $ kubectl apply -f https://raw.githubusercontent.com/oracle/oci-cloud-controller
 Lastly, verify that the oci-csi-controller-driver and oci-csi-node-controller is running in your cluster. By default it runs in the 'kube-system' namespace.
 
 ```
-$ kubectl -n kube-system get po | grep oci-csi-controller-driver
-$ kubectl -n kube-system get po | grep oci-csi-node-controller
+$ kubectl -n kube-system get po | grep csi-oci-controller
+$ kubectl -n kube-system get po | grep csi-oci-node
 ```
 
 ## Tutorial

--- a/flex-volume-provisioner.md
+++ b/flex-volume-provisioner.md
@@ -51,7 +51,7 @@ $ kubectl apply -f https://raw.githubusercontent.com/oracle/oci-cloud-controller
 Lastly, verify that the oci-volume-provisioner is running in your cluster. By default it runs in the 'kube-system' namespace.
 
 ```
-$ kubectl -n kube-system get po | grep oci-volume-provisioner
+$ kubectl -n kube-system get po | grep oci-block-volume-provisioner
 ```
 
 ## Tutorial

--- a/manifests/container-storage-interface/oci-csi-node-driver.yaml
+++ b/manifests/container-storage-interface/oci-csi-node-driver.yaml
@@ -1,3 +1,24 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: oci-csi-iscsiadm
+  namespace: kube-system
+data:
+  iscsiadm: |
+    #!/bin/sh
+    if [ -x /host/sbin/iscsiadm ]; then
+      chroot /host /sbin/iscsiadm "$@"
+    elif [ -x /host/usr/local/sbin/iscsiadm ]; then
+      chroot /host /usr/local/sbin/iscsiadm "$@"
+    elif [ -x /host/bin/iscsiadm ]; then
+      chroot /host /bin/iscsiadm "$@"
+    elif [ -x /host/usr/local/bin/iscsiadm ]; then
+      chroot /host /usr/local/bin/iscsiadm "$@"
+    else
+      chroot /host iscsiadm "$@"
+    fi
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -33,6 +54,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: PATH
+              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/host/usr/bin:/host/sbin
           image: iad.ocir.io/oracle/cloud-provider-oci:latest
           securityContext:
             privileged: true
@@ -46,6 +69,11 @@ spec:
               name: device-dir
             - mountPath: /registration
               name: registration-dir
+            - mountPath: /host
+              name: host-root
+            - mountPath: /sbin/iscsiadm
+              name: chroot-iscsiadm
+              subPath: iscsiadm
         - name: csi-node-registrar
           args:
             - --csi-address=/csi/csi.sock
@@ -98,6 +126,14 @@ spec:
             path: /dev
             type: ""
           name: device-dir
+        - hostPath:
+            path: /
+            type: Directory
+          name: host-root
+        - configMap:
+            name: oci-csi-iscsiadm
+            defaultMode: 0755
+          name: chroot-iscsiadm
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/pkg/cloudprovider/providers/oci/load_balancer.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer.go
@@ -403,7 +403,10 @@ func getDefaultLBSubnets(subnet1, subnet2 string) []string {
 }
 
 func (cp *CloudProvider) getLoadBalancerSubnets(ctx context.Context, logger *zap.SugaredLogger, svc *v1.Service) ([]string, error) {
-	_, internal := svc.Annotations[ServiceAnnotationLoadBalancerInternal]
+	internal, err := isInternalLB(svc)
+	if err != nil {
+		return nil, err
+	}
 
 	// NOTE: These will be overridden for existing load balancers as load
 	// balancer subnets cannot be modified.

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
@@ -130,7 +130,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 					Name:      "testservice",
 					UID:       "test-uid",
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternal: "",
+						ServiceAnnotationLoadBalancerInternal: "true",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -188,7 +188,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 					Name:      "testservice",
 					UID:       "test-uid",
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternal: "",
+						ServiceAnnotationLoadBalancerInternal: "true",
 						ServiceAnnotationLoadBalancerSubnet1:  "regional-subnet",
 					},
 				},
@@ -247,7 +247,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 					Name:      "testservice",
 					UID:       "test-uid",
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternal: "",
+						ServiceAnnotationLoadBalancerInternal: "true",
 						ServiceAnnotationLoadBalancerSubnet2:  "regional-subnet",
 					},
 				},
@@ -304,7 +304,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 					Name:      "testservice",
 					UID:       "test-uid",
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternal: "",
+						ServiceAnnotationLoadBalancerInternal: "true",
 						ServiceAnnotationLoadBalancerSubnet1:  "annotation-one",
 					},
 				},
@@ -854,7 +854,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						Port:                  common.Int(80),
 						Protocol:              common.String("TCP"),
 						ConnectionConfiguration: &loadbalancer.ConnectionConfiguration{
-							IdleTimeout: common.Int64(300), // fallback to default timeout for TCP
+							IdleTimeout:                    common.Int64(300), // fallback to default timeout for TCP
 							BackendTcpProxyProtocolVersion: common.Int(2),
 						},
 					},
@@ -863,7 +863,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						Port:                  common.Int(443),
 						Protocol:              common.String("HTTP"),
 						ConnectionConfiguration: &loadbalancer.ConnectionConfiguration{
-							IdleTimeout: common.Int64(60), // fallback to default timeout for HTTP
+							IdleTimeout:                    common.Int64(60), // fallback to default timeout for HTTP
 							BackendTcpProxyProtocolVersion: common.Int(2),
 						},
 					},
@@ -872,11 +872,11 @@ func TestNewLBSpecSuccess(t *testing.T) {
 					"TCP-80": {
 						Backends: []loadbalancer.BackendDetails{},
 						HealthChecker: &loadbalancer.HealthCheckerDetails{
-							Protocol: common.String("HTTP"),
-							Port:     common.Int(10256),
-							UrlPath:  common.String("/healthz"),
-							Retries: common.Int(3),
-							TimeoutInMillis: common.Int(3000),
+							Protocol:         common.String("HTTP"),
+							Port:             common.Int(10256),
+							UrlPath:          common.String("/healthz"),
+							Retries:          common.Int(3),
+							TimeoutInMillis:  common.Int(3000),
 							IntervalInMillis: common.Int(10000),
 						},
 						Policy: common.String("ROUND_ROBIN"),
@@ -884,11 +884,11 @@ func TestNewLBSpecSuccess(t *testing.T) {
 					"HTTP-443": {
 						Backends: []loadbalancer.BackendDetails{},
 						HealthChecker: &loadbalancer.HealthCheckerDetails{
-							Protocol: common.String("HTTP"),
-							Port:     common.Int(10256),
-							UrlPath:  common.String("/healthz"),
-							Retries: common.Int(3),
-							TimeoutInMillis: common.Int(3000),
+							Protocol:         common.String("HTTP"),
+							Port:             common.Int(10256),
+							UrlPath:          common.String("/healthz"),
+							Retries:          common.Int(3),
+							TimeoutInMillis:  common.Int(3000),
 							IntervalInMillis: common.Int(10000),
 						},
 						Policy: common.String("ROUND_ROBIN"),
@@ -917,7 +917,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 					Name:      "testservice",
 					UID:       "test-uid",
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerConnectionIdleTimeout: "404",
+						ServiceAnnotationLoadBalancerConnectionIdleTimeout:          "404",
 						ServiceAnnotationLoadBalancerConnectionProxyProtocolVersion: "2",
 					},
 				},
@@ -942,7 +942,7 @@ func TestNewLBSpecSuccess(t *testing.T) {
 						Port:                  common.Int(80),
 						Protocol:              common.String("TCP"),
 						ConnectionConfiguration: &loadbalancer.ConnectionConfiguration{
-							IdleTimeout: common.Int64(404),
+							IdleTimeout:                    common.Int64(404),
 							BackendTcpProxyProtocolVersion: common.Int(2),
 						},
 					},
@@ -951,11 +951,11 @@ func TestNewLBSpecSuccess(t *testing.T) {
 					"TCP-80": {
 						Backends: []loadbalancer.BackendDetails{},
 						HealthChecker: &loadbalancer.HealthCheckerDetails{
-							Protocol: common.String("HTTP"),
-							Port:     common.Int(10256),
-							UrlPath:  common.String("/healthz"),
-							Retries: common.Int(3),
-							TimeoutInMillis: common.Int(3000),
+							Protocol:         common.String("HTTP"),
+							Port:             common.Int(10256),
+							UrlPath:          common.String("/healthz"),
+							Retries:          common.Int(3),
+							TimeoutInMillis:  common.Int(3000),
 							IntervalInMillis: common.Int(10000),
 						},
 						Policy: common.String("ROUND_ROBIN"),
@@ -1519,7 +1519,7 @@ func TestNewLBSpecFailure(t *testing.T) {
 					Name:      "testservice",
 					UID:       "test-uid",
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternal: "",
+						ServiceAnnotationLoadBalancerInternal: "true",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -1537,7 +1537,7 @@ func TestNewLBSpecFailure(t *testing.T) {
 					Name:      "testservice",
 					UID:       "test-uid",
 					Annotations: map[string]string{
-						ServiceAnnotationLoadBalancerInternal: "",
+						ServiceAnnotationLoadBalancerInternal: "true",
 						ServiceAnnotationLoadBalancerSubnet1:  "",
 					},
 				},
@@ -1548,6 +1548,20 @@ func TestNewLBSpecFailure(t *testing.T) {
 				},
 			},
 			expectedErrMsg: "a configuration for subnet1 must be specified for an internal load balancer",
+		},
+		"non boolean internal lb": {
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationLoadBalancerInternal: "yes",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					SessionAffinity: v1.ServiceAffinityNone,
+					Ports:           []v1.ServicePort{},
+				},
+			},
+			expectedErrMsg: fmt.Sprintf("invalid value: yes provided for annotation: %s: strconv.ParseBool: parsing \"yes\": invalid syntax", ServiceAnnotationLoadBalancerInternal),
 		},
 	}
 
@@ -2112,6 +2126,86 @@ func Test_getBackends(t *testing.T) {
 			logger := zap.L()
 			if got := getBackends(logger.Sugar(), tt.args.nodes, tt.args.nodePort); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getBackends() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInternal(t *testing.T) {
+	testCases := map[string]struct {
+		service    *v1.Service
+		isInternal bool
+		err        error
+	}{
+		"no ServiceAnnotationLoadBalancerInternal annotation": {
+			service:    &v1.Service{},
+			isInternal: false,
+			err:        nil,
+		},
+		"ServiceAnnotationLoadBalancerInternal is true": {
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationLoadBalancerInternal: "true",
+					},
+				},
+			},
+			isInternal: true,
+			err:        nil,
+		},
+		"ServiceAnnotationLoadBalancerInternal is TRUE": {
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationLoadBalancerInternal: "TRUE",
+					},
+				},
+			},
+			isInternal: true,
+			err:        nil,
+		},
+		"ServiceAnnotationLoadBalancerInternal is FALSE": {
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationLoadBalancerInternal: "FALSE",
+					},
+				},
+			},
+			isInternal: false,
+			err:        nil,
+		},
+		"ServiceAnnotationLoadBalancerInternal is false": {
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationLoadBalancerInternal: "FALSE",
+					},
+				},
+			},
+			isInternal: false,
+			err:        nil,
+		},
+		"ServiceAnnotationLoadBalancerInternal is non boolean": {
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationLoadBalancerInternal: "yes",
+					},
+				},
+			},
+			isInternal: false,
+			err:        errors.New(fmt.Sprintf("invalid value: yes provided for annotation: %s: strconv.ParseBool: parsing \"yes\": invalid syntax", ServiceAnnotationLoadBalancerInternal)),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			internal, err := isInternalLB(tc.service)
+			if err != nil && err.Error() != tc.err.Error() {
+				t.Errorf("Expected internal LB error\n%+v\nbut got\n%+v", tc.err, err)
+			}
+			if internal != tc.isInternal {
+				t.Errorf("Expected internal LB\n%+v\nbut got\n%+v", tc.isInternal, internal)
 			}
 		})
 	}

--- a/pkg/cloudprovider/providers/oci/node_info_controller_test.go
+++ b/pkg/cloudprovider/providers/oci/node_info_controller_test.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"github.com/oracle/oci-go-sdk/common"
 	"reflect"
 	"testing"
 
@@ -106,7 +107,11 @@ func TestGetInstanceByNode(t *testing.T) {
 				ociClient: MockOCIClient{},
 			},
 			expectedInstance: &core.Instance{
-				Id: &instanceID,
+				AvailabilityDomain: common.String("NWuj:PHX-AD-1"),
+				CompartmentId:      common.String("default"),
+				Id:                 &instanceID,
+				Region:             common.String("PHX"),
+				Shape:              common.String("VM.Standard1.2"),
 			},
 		},
 		"Get Instance when providerID is prefixed with providerName": {
@@ -119,7 +124,11 @@ func TestGetInstanceByNode(t *testing.T) {
 				ociClient: MockOCIClient{},
 			},
 			expectedInstance: &core.Instance{
-				Id: &instanceID,
+				AvailabilityDomain: common.String("NWuj:PHX-AD-1"),
+				CompartmentId:      common.String("default"),
+				Id:                 &instanceID,
+				Region:             common.String("PHX"),
+				Shape:              common.String("VM.Standard1.2"),
 			},
 		},
 	}

--- a/pkg/csi/driver/controller_test.go
+++ b/pkg/csi/driver/controller_test.go
@@ -1,0 +1,589 @@
+package driver
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	providercfg "github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
+	"github.com/oracle/oci-cloud-controller-manager/pkg/oci/client"
+	"github.com/oracle/oci-go-sdk/common"
+	"github.com/oracle/oci-go-sdk/core"
+	"github.com/oracle/oci-go-sdk/filestorage"
+	"github.com/oracle/oci-go-sdk/identity"
+	"github.com/oracle/oci-go-sdk/loadbalancer"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	testMinimumVolumeSizeInBytes int64 = 50 * client.GiB
+)
+
+type MockBlockStorageClient struct {
+}
+
+type MockProvisionerClient struct {
+	Storage *MockBlockStorageClient
+}
+
+func (c *MockBlockStorageClient) AwaitVolumeAvailableORTimeout(ctx context.Context, id string) (*core.Volume, error) {
+	return &core.Volume{}, nil
+}
+
+func (c *MockBlockStorageClient) GetVolume(ctx context.Context, id string) (*core.Volume, error) {
+	return nil, nil
+}
+
+func (c *MockBlockStorageClient) GetVolumesByName(ctx context.Context, volumeName, compartmentID string) ([]core.Volume, error) {
+	return []core.Volume{}, nil
+}
+
+// CreateVolume mocks the BlockStorage CreateVolume implementation
+func (c *MockBlockStorageClient) CreateVolume(ctx context.Context, details core.CreateVolumeDetails) (*core.Volume, error) {
+	id := "oc1.volume1.xxxx"
+	ad := "zkJl:US-ASHBURN-AD-1"
+	return &core.Volume{
+		Id:                 &id,
+		AvailabilityDomain: &ad,
+	}, nil
+}
+
+// DeleteVolume mocks the BlockStorage DeleteVolume implementation
+func (c *MockBlockStorageClient) DeleteVolume(ctx context.Context, id string) error {
+	return nil
+}
+
+func (c *MockBlockStorageClient) AwaitVolumeAvailable(ctx context.Context, id string) (*core.Volume, error) {
+	return nil, nil
+}
+
+// BlockStorage mocks client BlockStorage implementation
+func (p *MockProvisionerClient) BlockStorage() client.BlockStorageInterface {
+	return p.Storage
+}
+
+// MockVirtualNetworkClient mocks VirtualNetwork client implementation
+type MockVirtualNetworkClient struct {
+}
+
+// GetPrivateIP mocks the VirtualNetwork GetPrivateIP implementation
+func (c *MockVirtualNetworkClient) GetPrivateIP(ctx context.Context, id string) (*core.PrivateIp, error) {
+	return nil, nil
+}
+
+func (c *MockVirtualNetworkClient) GetSubnet(ctx context.Context, id string) (*core.Subnet, error) {
+	return nil, nil
+}
+
+func (c *MockVirtualNetworkClient) GetSubnetFromCacheByIP(ip string) (*core.Subnet, error) {
+	return nil, nil
+}
+
+func (c *MockVirtualNetworkClient) GetVcn(ctx context.Context, id string) (*core.Vcn, error) {
+	return &core.Vcn{}, nil
+}
+
+func (c *MockVirtualNetworkClient) GetSecurityList(ctx context.Context, id string) (core.GetSecurityListResponse, error) {
+	return core.GetSecurityListResponse{}, nil
+}
+
+func (c *MockVirtualNetworkClient) UpdateSecurityList(ctx context.Context, id string, etag string, ingressRules []core.IngressSecurityRule, egressRules []core.EgressSecurityRule) (core.UpdateSecurityListResponse, error) {
+	return core.UpdateSecurityListResponse{}, nil
+}
+
+func (c *MockVirtualNetworkClient) IsRegionalSubnet(ctx context.Context, id string) (bool, error) {
+	return true, nil
+}
+
+// Networking mocks client VirtualNetwork implementation.
+func (p *MockProvisionerClient) Networking() client.NetworkingInterface {
+	return &MockVirtualNetworkClient{}
+}
+
+type MockLoadBalancerClient struct{}
+
+func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details loadbalancer.CreateLoadBalancerDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) GetLoadBalancer(ctx context.Context, id string) (*loadbalancer.LoadBalancer, error) {
+	return nil, nil
+}
+
+func (c *MockLoadBalancerClient) GetLoadBalancerByName(ctx context.Context, compartmentID, name string) (*loadbalancer.LoadBalancer, error) {
+	return nil, nil
+}
+
+func (c *MockLoadBalancerClient) DeleteLoadBalancer(ctx context.Context, id string) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) GetCertificateByName(ctx context.Context, lbID, name string) (*loadbalancer.Certificate, error) {
+	return nil, nil
+}
+
+func (c *MockLoadBalancerClient) CreateCertificate(ctx context.Context, lbID string, cert loadbalancer.CertificateDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) CreateBackendSet(ctx context.Context, lbID, name string, details loadbalancer.BackendSetDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) UpdateBackendSet(ctx context.Context, lbID, name string, details loadbalancer.BackendSetDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) DeleteBackendSet(ctx context.Context, lbID, name string) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) UpdateListener(ctx context.Context, lbID, name string, details loadbalancer.ListenerDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) CreateListener(ctx context.Context, lbID, name string, details loadbalancer.ListenerDetails) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) DeleteListener(ctx context.Context, lbID, name string) (string, error) {
+	return "", nil
+}
+
+func (c *MockLoadBalancerClient) AwaitWorkRequest(ctx context.Context, id string) (*loadbalancer.WorkRequest, error) {
+	return nil, nil
+}
+
+func (c *MockLoadBalancerClient) CreateBackend(ctx context.Context, lbID, bsName string, details loadbalancer.BackendDetails) (string, error) {
+	return "", nil
+}
+func (c *MockLoadBalancerClient) DeleteBackend(ctx context.Context, lbID, bsName, name string) (string, error) {
+	return "", nil
+}
+
+// Networking mocks client VirtualNetwork implementation.
+func (p *MockProvisionerClient) LoadBalancer() client.LoadBalancerInterface {
+	return &MockLoadBalancerClient{}
+}
+
+type MockComputeClient struct{}
+
+// GetInstance gets information about the specified instance.
+func (c *MockComputeClient) GetInstance(ctx context.Context, id string) (*core.Instance, error) {
+	return nil, nil
+}
+
+// GetInstanceByNodeName gets the OCI instance corresponding to the given
+// Kubernetes node name.
+func (c *MockComputeClient) GetInstanceByNodeName(ctx context.Context, compartmentID, vcnID, nodeName string) (*core.Instance, error) {
+	return nil, nil
+}
+
+func (c *MockComputeClient) GetPrimaryVNICForInstance(ctx context.Context, compartmentID, instanceID string) (*core.Vnic, error) {
+	return nil, nil
+}
+
+func (c *MockComputeClient) FindVolumeAttachment(ctx context.Context, compartmentID, volumeID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (c *MockComputeClient) FindActiveVolumeAttachment(ctx context.Context, compartmentID, volumeID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (c *MockComputeClient) AttachVolume(ctx context.Context, instanceID, volumeID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (c *MockComputeClient) WaitForVolumeAttached(ctx context.Context, attachmentID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
+func (c *MockComputeClient) DetachVolume(ctx context.Context, id string) error { return nil }
+
+func (c *MockComputeClient) WaitForVolumeDetached(ctx context.Context, attachmentID string) error {
+	return nil
+}
+
+func (p *MockProvisionerClient) Compute() client.ComputeInterface {
+	return &MockComputeClient{}
+}
+
+// MockIdentityClient mocks identity client structure
+type MockIdentityClient struct {
+	common.BaseClient
+}
+
+func (client MockIdentityClient) ListAvailabilityDomains(ctx context.Context, compartmentID string) ([]identity.AvailabilityDomain, error) {
+	return nil, nil
+}
+
+// ListAvailabilityDomains mocks the client ListAvailabilityDomains implementation
+func (client MockIdentityClient) GetAvailabilityDomainByName(ctx context.Context, compartmentID, name string) (*identity.AvailabilityDomain, error) {
+	ad1 := "AD1"
+	return &identity.AvailabilityDomain{Name: &ad1}, nil
+}
+
+// Identity mocks client Identity implementation
+func (p *MockProvisionerClient) Identity() client.IdentityInterface {
+	return &MockIdentityClient{}
+}
+
+type MockFileStorageClient struct{}
+
+// CreateFileSystem mocks the FileStorage CreateFileSystem implementation.
+func (c *MockFileStorageClient) CreateFileSystem(ctx context.Context, details filestorage.CreateFileSystemDetails) (*filestorage.FileSystem, error) {
+	return nil, nil
+}
+
+// GetFileSystem mocks the FileStorage GetFileSystem implementation.
+func (c *MockFileStorageClient) GetFileSystem(ctx context.Context, id string) (*filestorage.FileSystem, error) {
+	return nil, nil
+}
+
+func (c *MockFileStorageClient) AwaitFileSystemActive(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.FileSystem, error) {
+	return nil, nil
+}
+
+func (c *MockFileStorageClient) GetFileSystemSummaryByDisplayName(ctx context.Context, compartmentID, ad, displayName string) (*filestorage.FileSystemSummary, error) {
+	return nil, nil
+}
+
+// DeleteFileSystem mocks the FileStorage DeleteFileSystem implementation
+func (c *MockFileStorageClient) DeleteFileSystem(ctx context.Context, id string) error {
+	return nil
+}
+
+// CreateExport mocks the FileStorage CreateExport implementation
+func (c *MockFileStorageClient) CreateExport(ctx context.Context, details filestorage.CreateExportDetails) (*filestorage.Export, error) {
+	return nil, nil
+}
+
+// GetExport mocks the FileStorage CreateExport implementation.
+func (c *MockFileStorageClient) GetExport(ctx context.Context, request filestorage.GetExportRequest) (response filestorage.GetExportResponse, err error) {
+	return filestorage.GetExportResponse{}, nil
+}
+func (c *MockFileStorageClient) AwaitExportActive(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.Export, error) {
+	return nil, nil
+}
+
+func (c *MockFileStorageClient) FindExport(ctx context.Context, compartmentID, fsID, exportSetID string) (*filestorage.ExportSummary, error) {
+	return nil, nil
+}
+
+// DeleteExport mocks the FileStorage DeleteExport implementation
+func (c *MockFileStorageClient) DeleteExport(ctx context.Context, id string) error {
+	return nil
+}
+
+// GetMountTarget mocks the FileStorage GetMountTarget implementation
+func (c *MockFileStorageClient) AwaitMountTargetActive(ctx context.Context, logger *zap.SugaredLogger, id string) (*filestorage.MountTarget, error) {
+	return nil, nil
+}
+
+// FSS mocks client FileStorage implementation
+func (p *MockProvisionerClient) FSS() client.FileStorageInterface {
+	return &MockFileStorageClient{}
+}
+
+func NewClientProvisioner(pcData client.Interface, storage *MockBlockStorageClient) client.Interface {
+	return &MockProvisionerClient{Storage: storage}
+}
+
+func TestControllerDriver_CreateVolume(t *testing.T) {
+	type fields struct {
+		KubeClient kubernetes.Interface
+		logger     *zap.SugaredLogger
+		config     *providercfg.Config
+		client     client.Interface
+		util       *Util
+	}
+	type args struct {
+		ctx context.Context
+		req *csi.CreateVolumeRequest
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *csi.CreateVolumeResponse
+		wantErr error
+	}{
+		{
+			name:   "Error for name not provided for creating volume",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.CreateVolumeRequest{Name: ""},
+			},
+			want:    nil,
+			wantErr: errors.New("CreateVolume Name must be provided"),
+		},
+		{
+			name:   "Error for unsupported VolumeCapabilities: MULTI_NODE_MULTI_WRITER provided in CreateVolumeRequest",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.CreateVolumeRequest{
+					Name: "ut-volume",
+					VolumeCapabilities: []*csi.VolumeCapability{&csi.VolumeCapability{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					}},
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("invalid volume capabilities requested"),
+		},
+		{
+			name:   "Error for no VolumeCapabilities provided in CreateVolumeRequest",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.CreateVolumeRequest{
+					Name:               "ut-volume",
+					VolumeCapabilities: []*csi.VolumeCapability{},
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("VolumeCapabilities must be provided in CreateVolumeRequest"),
+		},
+		{
+			name:   "Error for unsupported VolumeCapabilities: MULTI_NODE_READER_ONLY provided in CreateVolumeRequest",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.CreateVolumeRequest{
+					Name: "ut-volume",
+					VolumeCapabilities: []*csi.VolumeCapability{&csi.VolumeCapability{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+						},
+					}},
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("invalid volume capabilities requested"),
+		},
+		{
+			name:   "Error for unsupported VolumeCapabilities: MULTI_NODE_SINGLE_WRITER provided in CreateVolumeRequest",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.CreateVolumeRequest{
+					Name: "ut-volume",
+					VolumeCapabilities: []*csi.VolumeCapability{&csi.VolumeCapability{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
+						},
+					}},
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("invalid volume capabilities requested"),
+		},
+		{
+			name:   "Error for exceeding capacity range",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.CreateVolumeRequest{
+					Name: "ut-volume",
+					VolumeCapabilities: []*csi.VolumeCapability{&csi.VolumeCapability{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					}},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: int64(maximumVolumeSizeInBytes) + int64(1024),
+						LimitBytes:    minimumVolumeSizeInBytes,
+					},
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("invalid capacity range"),
+		},
+		{
+			name:   "Error in finding topology requirement",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.CreateVolumeRequest{
+					Name: "ut-volume",
+					VolumeCapabilities: []*csi.VolumeCapability{
+						&csi.VolumeCapability{
+							AccessMode: &csi.VolumeCapability_AccessMode{
+								Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+							},
+						}},
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: int64(maximumVolumeSizeInBytes),
+					},
+					AccessibilityRequirements: &csi.TopologyRequirement{Requisite: []*csi.Topology{
+						{
+							Segments: map[string]string{"x": "ad1"},
+						},
+					},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("required in PreferredTopologies or allowedTopologies"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &ControllerDriver{
+				KubeClient: nil,
+				logger:     zap.S(),
+				config:     &providercfg.Config{CompartmentID: ""},
+				client:     NewClientProvisioner(nil, &MockBlockStorageClient{}),
+				util:       &Util{},
+			}
+			got, err := d.CreateVolume(tt.args.ctx, tt.args.req)
+			if tt.wantErr == nil && err != nil {
+				t.Errorf("got error %q, want none", err)
+			}
+			if tt.wantErr != nil && !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				t.Errorf("want error %q to include %q", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ControllerDriver.CreateVolume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestControllerDriver_DeleteVolume(t *testing.T) {
+	type fields struct {
+		KubeClient kubernetes.Interface
+		logger     *zap.SugaredLogger
+		config     *providercfg.Config
+		client     client.Interface
+		util       *Util
+	}
+	type args struct {
+		ctx context.Context
+		req *csi.DeleteVolumeRequest
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *csi.DeleteVolumeResponse
+		wantErr error
+	}{
+		{
+			name:   "Error for volume OCID missing in delete block volume",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.DeleteVolumeRequest{},
+			},
+			want:    nil,
+			wantErr: errors.New("DeleteVolume Volume ID must be provided"),
+		},
+		{
+			name:   "Delete volume and get empty response",
+			fields: fields{},
+			args: args{
+				ctx: context.Background(),
+				req: &csi.DeleteVolumeRequest{VolumeId: "oc1.volume1.xxxx"},
+			},
+			want:    &csi.DeleteVolumeResponse{},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &ControllerDriver{
+				KubeClient: nil,
+				logger:     zap.S(),
+				config:     &providercfg.Config{CompartmentID: ""},
+				client:     NewClientProvisioner(nil, &MockBlockStorageClient{}),
+				util:       &Util{},
+			}
+			got, err := d.DeleteVolume(tt.args.ctx, tt.args.req)
+			if tt.wantErr == nil && err != nil {
+				t.Errorf("got error %q, want none", err)
+			}
+			if tt.wantErr != nil && !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				t.Errorf("want error %q to include %q", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ControllerDriver.CreateVolume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_extractStorage(t *testing.T) {
+	type args struct {
+		capRange *csi.CapacityRange
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int64
+		wantErr bool
+	}{
+		{
+			name: "Nil CapacityRange",
+			args: args{capRange:  nil},
+			want: testMinimumVolumeSizeInBytes,
+			wantErr: false,
+		},
+		{
+			name: "Empty CapacityRange",
+			args: args{capRange:  &csi.CapacityRange{}},
+			want: testMinimumVolumeSizeInBytes,
+			wantErr: false,
+		},
+		{
+			name: "Limit bytes is less than required",
+			args: args{capRange:  &csi.CapacityRange{
+				RequiredBytes: 100*client.GiB,
+				LimitBytes: 50*client.GiB,
+				},
+			},
+			want: 0,
+			wantErr: true,
+		},
+		{
+			name: "Required set and limit not set",
+			args: args{capRange:  &csi.CapacityRange{
+				RequiredBytes: 100*client.GiB,
+			},
+			},
+			want: 100*client.GiB,
+			wantErr: false,
+		},
+		{
+			name: "Required set and limit set",
+			args: args{capRange:  &csi.CapacityRange{
+				RequiredBytes: 70*client.GiB,
+				LimitBytes: 100*client.GiB,
+			},
+			},
+			want: 100*client.GiB,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractStorage(tt.args.capRange)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractStorage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("extractStorage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/csi/driver/node.go
+++ b/pkg/csi/driver/node.go
@@ -74,7 +74,7 @@ func (d *NodeDriver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 
 	if !d.util.waitForPathToExist(devicePath, 20) {
 		logger.Error("failed to wait for device to exist.")
-		return nil, status.Error(codes.DeadlineExceeded, err.Error())
+		return nil, status.Error(codes.DeadlineExceeded, "Failed to wait for device to exist.")
 	}
 
 	mnt := req.VolumeCapability.GetMount()

--- a/pkg/csi/driver/utils_test.go
+++ b/pkg/csi/driver/utils_test.go
@@ -1,0 +1,101 @@
+package driver
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestUtil_getAvailableDomainInNodeLabel(t *testing.T) {
+	type fields struct {
+		logger *zap.SugaredLogger
+	}
+	type args struct {
+		fullAD string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "Get AD name from the tenancy specific AD name.",
+			fields: fields{
+				logger: zap.S(),
+			},
+			args: args{fullAD: "zkJl:US-ASHBURN-AD-1"},
+			want: "US-ASHBURN-AD-1",
+		},
+		{
+			name: "Get AD name from the tenancy specific AD name for empty string",
+			fields: fields{
+				logger: zap.S(),
+			},
+			args: args{fullAD: ""},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &Util{
+				logger: tt.fields.logger,
+			}
+			if got := u.getAvailableDomainInNodeLabel(tt.args.fullAD); got != tt.want {
+				t.Errorf("Util.getAvailableDomainInNodeLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_validateFsType(t *testing.T) {
+	type args struct {
+		logger *zap.SugaredLogger
+		fsType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Return ext4",
+			args: args{
+				logger: zap.S(),
+				fsType: "ext4",
+			},
+			want: "ext4",
+		},
+		{
+			name: "Return ext3",
+			args: args{
+				logger: zap.S(),
+				fsType: "ext3",
+			},
+			want: "ext3",
+		},
+		{
+			name: "Return default ext4 for empty string",
+			args: args{
+				logger: zap.S(),
+				fsType: "",
+			},
+			want: "ext4",
+		},
+		{
+			name: "Return default ext4 for unsupported string",
+			args: args{
+				logger: zap.S(),
+				fsType: "xxxxx",
+			},
+			want: "ext4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateFsType(tt.args.logger, tt.args.fsType); got != tt.want {
+				t.Errorf("validateFsType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/volume/provisioner/block/block_test.go
+++ b/pkg/volume/provisioner/block/block_test.go
@@ -203,6 +203,10 @@ func (c *MockComputeClient) WaitForVolumeDetached(ctx context.Context, attachmen
 	return nil
 }
 
+func (c *MockComputeClient) FindActiveVolumeAttachment(ctx context.Context, compartmentID, volumeID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
 // MockVirtualNetworkClient mocks VirtualNetwork client implementation
 type MockVirtualNetworkClient struct {
 }

--- a/pkg/volume/provisioner/fss/fss_test.go
+++ b/pkg/volume/provisioner/fss/fss_test.go
@@ -202,6 +202,10 @@ func (c *MockComputeClient) WaitForVolumeDetached(ctx context.Context, attachmen
 	return nil
 }
 
+func (c *MockComputeClient) FindActiveVolumeAttachment(ctx context.Context, compartmentID, volumeID string) (core.VolumeAttachment, error) {
+	return nil, nil
+}
+
 // MockVirtualNetworkClient mocks VirtualNetwork client implementation
 type MockVirtualNetworkClient struct {
 }


### PR DESCRIPTION
Following is the summary of changes taken as a part of this release PR

- Service annotation oci-load-balancer-internal: false is not honoured

- CSI - Wait for volume to reach DETACHED state before attempting to attach

- Add unit tests for CSI

- Pin the version of iSCSI in node driver

- If the version of iscsid is not compatible between worker nodes and on CSI node pods
the connection to volume fails.

- Fix Backup Restore E2E test for multi Attach Error

- Drop iSCSI package installation and add util-linux to the cloud-provider-oci image

# Test

## Tested on k8s 1.18 cluster 
[1-18-e2e-logs.log](https://github.com/oracle/oci-cloud-controller-manager/files/5677338/1-18-e2e-logs.log)

Dec  1 20:17:57.561: INFO: Running AfterSuite actions on all node

Ran 26 of 26 Specs in 2842.442 seconds
26 Passed 0 Failed 0 Pending 0 Skipped
PASS

Ginkgo ran 1 suite in 47m31.508923802s
Test Suite Passed

## Tested on k8s 1.17 cluster 
[1-17-e2e-logs.log](https://github.com/oracle/oci-cloud-controller-manager/files/5677340/1-17-e2e-logs.log)

Dec 11 02:15:02.090: INFO: Running AfterSuite actions on all node

Ran 26 of 26 Specs in 3485.905 seconds
26 Passed 0 Failed 0 Pending 0 Skipped
PASS

Ginkgo ran 1 suite in 58m15.475039235s
Test Suite Passed

## Tested on k8s 1.16 cluster
[1-16-e2e-logs.log](https://github.com/oracle/oci-cloud-controller-manager/files/5677342/1-16-e2e-logs.log)

Dec 10 23:14:40.593: INFO: Running AfterSuite actions on all node

Ran 26 of 26 Specs in 2829.689 seconds
26 Passed 0 Failed 0 Pending 0 Skipped
PASS

Ginkgo ran 1 suite in 47m29.381830335s
Test Suite Passed


