### PR TITLE
Manifests: Add get nodes RBAC permission

### DIFF
--- a/manifests/volume-provisioner/oci-volume-provisioner-rbac.yaml
+++ b/manifests/volume-provisioner/oci-volume-provisioner-rbac.yaml
@@ -21,7 +21,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list", "watch"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]


### PR DESCRIPTION
To prevent an ERROR message about this permission missing.

Fixes Issue https://github.com/oracle/oci-cloud-controller-manager/issues/342