### PR TITLE
Update manifest yaml files to use CCM 0.12.0 release tag

### DIFF
--- a/manifests/cloud-controller-manager/oci-cloud-controller-manager.yaml
+++ b/manifests/cloud-controller-manager/oci-cloud-controller-manager.yaml
@@ -39,7 +39,7 @@ spec:
             path: /etc/kubernetes
       containers:
         - name: oci-cloud-controller-manager
-          image: iad.ocir.io/oracle/cloud-provider-oci:latest
+          image: iad.ocir.io/oracle/cloud-provider-oci:0.12.0
           command: ["/usr/local/bin/oci-cloud-controller-manager"]
           args:
             - --cloud-config=/etc/oci/cloud-provider.yaml

--- a/manifests/container-storage-interface/oci-csi-controller-driver.yaml
+++ b/manifests/container-storage-interface/oci-csi-controller-driver.yaml
@@ -56,7 +56,7 @@ spec:
             - --endpoint=unix://var/run/shared-tmpfs/csi.sock
           command:
             - /usr/local/bin/oci-csi-controller-driver
-          image: iad.ocir.io/oracle/cloud-provider-oci:latest
+          image: iad.ocir.io/oracle/cloud-provider-oci:0.12.0
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/manifests/container-storage-interface/oci-csi-node-driver.yaml
+++ b/manifests/container-storage-interface/oci-csi-node-driver.yaml
@@ -56,7 +56,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: PATH
               value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/host/usr/bin:/host/sbin
-          image: iad.ocir.io/oracle/cloud-provider-oci:latest
+          image: iad.ocir.io/oracle/cloud-provider-oci:0.12.0
           securityContext:
             privileged: true
           volumeMounts:

--- a/manifests/flexvolume-driver/oci-flexvolume-driver.yaml
+++ b/manifests/flexvolume-driver/oci-flexvolume-driver.yaml
@@ -37,7 +37,7 @@ spec:
             secretName: oci-flexvolume-driver
       containers:
         - name: oci-flexvolume-driver
-          image: iad.ocir.io/oracle/cloud-provider-oci:latest
+          image: iad.ocir.io/oracle/cloud-provider-oci:0.12.0
           command: ["/usr/local/bin/install.py", "-c", "/tmp/config.yaml"]
           securityContext:
             privileged: true
@@ -73,7 +73,7 @@ spec:
             type: DirectoryOrCreate
       containers:
         - name: oci-flexvolume-driver
-          image: iad.ocir.io/oracle/cloud-provider-oci:latest
+          image: iad.ocir.io/oracle/cloud-provider-oci:0.12.0
           command: ["/usr/local/bin/install.py"]
           securityContext:
             privileged: true

--- a/manifests/volume-provisioner/oci-volume-provisioner-fss.yaml
+++ b/manifests/volume-provisioner/oci-volume-provisioner-fss.yaml
@@ -22,7 +22,7 @@ spec:
             secretName: oci-volume-provisioner
       containers:
         - name: oci-volume-provisioner
-          image: iad.ocir.io/oracle/cloud-provider-oci:latest
+          image: iad.ocir.io/oracle/cloud-provider-oci:0.12.0
           command: ["/usr/local/bin/oci-volume-provisioner"]
           env:
             - name: NODE_NAME

--- a/manifests/volume-provisioner/oci-volume-provisioner.yaml
+++ b/manifests/volume-provisioner/oci-volume-provisioner.yaml
@@ -22,7 +22,7 @@ spec:
             secretName: oci-volume-provisioner
       containers:
         - name: oci-volume-provisioner
-          image: iad.ocir.io/oracle/cloud-provider-oci:latest
+          image: iad.ocir.io/oracle/cloud-provider-oci:0.12.0
           command: ["/usr/local/bin/oci-volume-provisioner"]
           env:
             - name: NODE_NAME


### PR DESCRIPTION
Our manifests should use the current release tag. We should avoid
using the `latest` tag for containers. This makes it hard to track
which version is running and hard to roll back.