### PR TITLE
Match nodes by complete hostame rather than prefix to avoid false +

### DIFF
--- a/pkg/oci/client/compute.go
+++ b/pkg/oci/client/compute.go
@@ -16,8 +16,6 @@ package client
 
 import (
 	"context"
-	"strings"
-
 	"github.com/oracle/oci-go-sdk/v50/core"
 	"github.com/pkg/errors"
 )
@@ -203,7 +201,7 @@ func (c *client) GetInstanceByNodeName(ctx context.Context, compartmentID, vcnID
 
 			if (vnic.PublicIp != nil && *vnic.PublicIp == nodeName) ||
 				(vnic.PrivateIp != nil && *vnic.PrivateIp == nodeName) ||
-				(vnic.HostnameLabel != nil && (*vnic.HostnameLabel != "" && strings.HasPrefix(nodeName, *vnic.HostnameLabel))) {
+				(vnic.HostnameLabel != nil && (*vnic.HostnameLabel != "" && nodeName == *vnic.HostnameLabel)) {
 				instance, err := c.GetInstance(ctx, *attachment.InstanceId)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Greetings!

This pull-request resolves #388 by matching the complete hostname when looking for a node. 

Note that this is not a theoretical issue, we have a customer who's (instance pool backed) nodes are causing this to happen:

```
ERROR cloud/node_controller.go:140 GetInstanceByNodeName: too many instances returned for node name "ashburn-ops-node-ad1-vnic-850450": 2
```

the above fix resolve the issue for them.