### PR TITLE
OSS release v1.27.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ cloud-provider specific code out of the Kubernetes codebase.
 | v1.23.0   | v1.23                  | -                      |
 | v1.24.2   | v1.24                  | -                      |
 | v1.25.2   | v1.25                  | -                      |
-| v1.26.1   | v1.26                  | -                      |
-| v1.27.0   | v1.27                  | -                      |
+| v1.26.2   | v1.26                  | -                      |
+| v1.27.1   | v1.27                  | -                      |
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v6 v6.2.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.7
-	github.com/oracle/oci-go-sdk/v65 v65.49.2
+	github.com/oracle/oci-go-sdk/v65 v65.56.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.15.1
 	github.com/spf13/cobra v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/oracle/oci-go-sdk/v65 v65.49.2 h1:optOfjGIVmZZMT3a/8ri/CVV1loDG0ab1p2tEpNW5ro=
-github.com/oracle/oci-go-sdk/v65 v65.49.2/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
+github.com/oracle/oci-go-sdk/v65 v65.56.0 h1:o5na2VTSoH6LDLDrIB81XAjgtok6utLrixNO1TySN7c=
+github.com/oracle/oci-go-sdk/v65 v65.56.0/go.mod h1:IBEV9l1qBzUpo7zgGaRUhbB05BVfcDGYRFBCPlTcPp0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/manifests/cloud-controller-manager/oci-cloud-controller-manager.yaml
+++ b/manifests/cloud-controller-manager/oci-cloud-controller-manager.yaml
@@ -42,7 +42,7 @@ spec:
             path: /etc/kubernetes
       containers:
         - name: oci-cloud-controller-manager
-          image: ghcr.io/oracle/cloud-provider-oci:v1.27.0
+          image: ghcr.io/oracle/cloud-provider-oci:v1.27.1
           command: ["/usr/local/bin/oci-cloud-controller-manager"]
           args:
             - --cloud-config=/etc/oci/cloud-provider.yaml

--- a/manifests/container-storage-interface/oci-csi-controller-driver.yaml
+++ b/manifests/container-storage-interface/oci-csi-controller-driver.yaml
@@ -96,7 +96,7 @@ spec:
             - --fss-csi-endpoint=unix://var/run/shared-tmpfs/csi-fss.sock
           command:
             - /usr/local/bin/oci-csi-controller-driver
-          image: ghcr.io/oracle/cloud-provider-oci:v1.27.0
+          image: ghcr.io/oracle/cloud-provider-oci:v1.27.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/manifests/container-storage-interface/oci-csi-node-driver.yaml
+++ b/manifests/container-storage-interface/oci-csi-node-driver.yaml
@@ -117,7 +117,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: PATH
               value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/host/usr/bin:/host/sbin
-          image: ghcr.io/oracle/cloud-provider-oci:v1.27.0
+          image: ghcr.io/oracle/cloud-provider-oci:v1.27.1
           securityContext:
             privileged: true
           volumeMounts:

--- a/manifests/flexvolume-driver/oci-flexvolume-driver.yaml
+++ b/manifests/flexvolume-driver/oci-flexvolume-driver.yaml
@@ -40,7 +40,7 @@ spec:
             secretName: oci-flexvolume-driver
       containers:
         - name: oci-flexvolume-driver
-          image: ghcr.io/oracle/cloud-provider-oci:v1.27.0
+          image: ghcr.io/oracle/cloud-provider-oci:v1.27.1
           command: ["/usr/local/bin/install.py", "-c", "/tmp/config.yaml"]
           securityContext:
             privileged: true
@@ -76,7 +76,7 @@ spec:
             type: DirectoryOrCreate
       containers:
         - name: oci-flexvolume-driver
-          image: ghcr.io/oracle/cloud-provider-oci:v1.27.0
+          image: ghcr.io/oracle/cloud-provider-oci:v1.27.1
           command: ["/usr/local/bin/install.py"]
           securityContext:
             privileged: true

--- a/manifests/volume-provisioner/oci-volume-provisioner-fss.yaml
+++ b/manifests/volume-provisioner/oci-volume-provisioner-fss.yaml
@@ -35,7 +35,7 @@ spec:
             secretName: oci-volume-provisioner
       containers:
         - name: oci-volume-provisioner
-          image: ghcr.io/oracle/cloud-provider-oci:v1.27.0
+          image: ghcr.io/oracle/cloud-provider-oci:v1.27.1
           command: ["/usr/local/bin/oci-volume-provisioner"]
           env:
             - name: NODE_NAME

--- a/manifests/volume-provisioner/oci-volume-provisioner.yaml
+++ b/manifests/volume-provisioner/oci-volume-provisioner.yaml
@@ -35,7 +35,7 @@ spec:
             secretName: oci-volume-provisioner
       containers:
         - name: oci-volume-provisioner
-          image: ghcr.io/oracle/cloud-provider-oci:v1.27.0
+          image: ghcr.io/oracle/cloud-provider-oci:v1.27.1
           command: ["/usr/local/bin/oci-volume-provisioner"]
           env:
             - name: NODE_NAME

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/certificate_retriever.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/certificate_retriever.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/configuration.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/dispatcher_modifier.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/dispatcher_modifier.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/federation_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/federation_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 // Package auth provides supporting functions and structs for authentication

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/federation_client_oke_workload_identity.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/federation_client_oke_workload_identity.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/instance_principal_delegation_token_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/instance_principal_delegation_token_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/instance_principal_key_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/instance_principal_key_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/jwt.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/jwt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principal_delegation_token_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principal_delegation_token_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principal_key_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principal_key_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principal_token_path_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principal_token_path_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principals_v1.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/resource_principals_v1.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/utils.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/auth/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package auth

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/circuit_breaker.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/circuit_breaker.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 // Package common provides supporting functions and structs used by service packages
@@ -7,13 +7,10 @@ package common
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -23,6 +20,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -103,12 +101,35 @@ const (
 	//circuitBreakerNumberOfHistoryResponseEnv is the number of recorded history responses
 	circuitBreakerNumberOfHistoryResponseEnv = "OCI_SDK_CIRCUITBREAKER_NUM_HISTORY_RESPONSE"
 
+	// ociDefaultRefreshIntervalForCustomCerts is the env var for overriding the defaultRefreshIntervalForCustomCerts.
+	// The value represents the refresh interval in minutes and has a higher precedence than defaultRefreshIntervalForCustomCerts
+	// but has a lower precedence then the refresh interval configured via OciGlobalRefreshIntervalForCustomCerts
+	// If the value is negative, then it is assumed that this property is not configured
+	// if the value is Zero, then the refresh of custom certs will be disabled
+	ociDefaultRefreshIntervalForCustomCerts = "OCI_DEFAULT_REFRESH_INTERVAL_FOR_CUSTOM_CERTS"
+
 	// ociDefaultCertsPath is the env var for the path to the SSL cert file
 	ociDefaultCertsPath = "OCI_DEFAULT_CERTS_PATH"
 
+	// ociDefaultClientCertsPath is the env var for the path to the custom client cert
+	ociDefaultClientCertsPath = "OCI_DEFAULT_CLIENT_CERTS_PATH"
+
+	// ociDefaultClientCertsPrivateKeyPath is the env var for the path to the custom client cert private key
+	ociDefaultClientCertsPrivateKeyPath = "OCI_DEFAULT_CLIENT_CERTS_PRIVATE_KEY_PATH"
+
 	//maxAttemptsForRefreshableRetry is the number of retry when 401 happened on a refreshable auth type
 	maxAttemptsForRefreshableRetry = 3
+
+	//defaultRefreshIntervalForCustomCerts is the default refresh interval in minutes
+	defaultRefreshIntervalForCustomCerts = 30
 )
+
+// OciGlobalRefreshIntervalForCustomCerts is the global policy for overriding the refresh interval in minutes.
+// This variable has a higher precedence than the env variable OCI_DEFAULT_REFRESH_INTERVAL_FOR_CUSTOM_CERTS
+// and the defaultRefreshIntervalForCustomCerts values.
+// If the value is negative, then it is assumed that this property is not configured
+// if the value is Zero, then the refresh of custom certs will be disabled
+var OciGlobalRefreshIntervalForCustomCerts int = -1
 
 // RequestInterceptor function used to customize the request before calling the underlying service
 type RequestInterceptor func(*http.Request) error
@@ -213,32 +234,13 @@ func newBaseClient(signer HTTPRequestSigner, dispatcher HTTPRequestDispatcher) B
 
 func defaultHTTPDispatcher() http.Client {
 	var httpClient http.Client
-	var tp = http.DefaultTransport.(*http.Transport)
-	if isExpectHeaderDisabled := IsEnvVarFalse(UsingExpectHeaderEnvVar); !isExpectHeaderDisabled {
-		tp.Proxy = http.ProxyFromEnvironment
-		tp.DialContext = (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext
-		tp.ForceAttemptHTTP2 = true
-		tp.MaxIdleConns = 100
-		tp.IdleConnTimeout = 90 * time.Second
-		tp.TLSHandshakeTimeout = 10 * time.Second
-		tp.ExpectContinueTimeout = 3 * time.Second
+	refreshInterval := getCustomCertRefreshInterval()
+	if refreshInterval <= 0 {
+		Debug("Custom cert refresh has been disabled")
 	}
-	if certFile, ok := os.LookupEnv(ociDefaultCertsPath); ok {
-		pool := x509.NewCertPool()
-		pemCert := readCertPem(certFile)
-		cert, err := x509.ParseCertificate(pemCert)
-		if err != nil {
-			Logf("unable to parse content to cert fallback to pem format from env var value: %s", certFile)
-			pool.AppendCertsFromPEM(pemCert)
-		} else {
-			Logf("using custom cert parsed from env var value: %s", certFile)
-			pool.AddCert(cert)
-		}
-		tp.TLSClientConfig = &tls.Config{RootCAs: pool}
+	var tp = &OciHTTPTransportWrapper{
+		RefreshRate:       time.Duration(refreshInterval) * time.Minute,
+		TLSConfigProvider: GetTLSConfigTemplateForTransport(),
 	}
 	httpClient = http.Client{
 		Timeout:   defaultTimeout,
@@ -547,7 +549,7 @@ func (rsc *OCIReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
 		return rsc.rc.(io.Seeker).Seek(offset, whence)
 	}
 	// once the binary request body is wrapped with ioutil.NopCloser:
-	if rsc.isNopCloser() {
+	if isNopCloser(rsc.rc) {
 		unwrappedInterface := reflect.ValueOf(rsc.rc).Field(0).Interface()
 		if _, ok := unwrappedInterface.(io.Seeker); ok {
 			return unwrappedInterface.(io.Seeker).Seek(offset, whence)
@@ -585,18 +587,10 @@ func (rsc *OCIReadSeekCloser) Seekable() bool {
 		return true
 	}
 	// once the binary request body is wrapped with ioutil.NopCloser:
-	if rsc.isNopCloser() {
+	if isNopCloser(rsc.rc) {
 		if _, ok := reflect.ValueOf(rsc.rc).Field(0).Interface().(io.Seeker); ok {
 			return true
 		}
-	}
-	return false
-}
-
-// Helper function to judge if this struct is a nopCloser or nopCloserWriterTo
-func (rsc *OCIReadSeekCloser) isNopCloser() bool {
-	if reflect.TypeOf(rsc.rc) == reflect.TypeOf(ioutil.NopCloser(nil)) || reflect.TypeOf(rsc.rc) == reflect.TypeOf(ioutil.NopCloser(bytes.NewReader(nil))) {
-		return true
 	}
 	return false
 }
@@ -730,4 +724,22 @@ func (client BaseClient) IsOciRealmSpecificServiceEndpointTemplateEnabled() bool
 		return *client.Configuration.RealmSpecificServiceEndpointTemplateEnabled
 	}
 	return IsEnvVarTrue(OciRealmSpecificServiceEndpointTemplateEnabledEnvVar)
+}
+
+func getCustomCertRefreshInterval() int {
+	if OciGlobalRefreshIntervalForCustomCerts >= 0 {
+		Debugf("Setting refresh interval as %d for custom certs via OciGlobalRefreshIntervalForCustomCerts", OciGlobalRefreshIntervalForCustomCerts)
+		return OciGlobalRefreshIntervalForCustomCerts
+	}
+	if refreshIntervalValue, ok := os.LookupEnv(ociDefaultRefreshIntervalForCustomCerts); ok {
+		refreshInterval, err := strconv.Atoi(refreshIntervalValue)
+		if err != nil || refreshInterval < 0 {
+			Debugf("The environment variable %s is not a valid int or is a negative value, skipping this configuration", ociDefaultRefreshIntervalForCustomCerts)
+		} else {
+			Debugf("Setting refresh interval as %d for custom certs via the env variable %s", refreshInterval, ociDefaultRefreshIntervalForCustomCerts)
+			return refreshInterval
+		}
+	}
+	Debugf("Setting the default refresh interval %d for custom certs", defaultRefreshIntervalForCustomCerts)
+	return defaultRefreshIntervalForCustomCerts
 }

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/common.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common
@@ -56,25 +56,29 @@ var OciRealmSpecificServiceEndpointTemplateEnabled *bool = nil
 // OciSdkEnabledServicesMap is a list of services that are enabled, default is an empty list which means all services are enabled
 var OciSdkEnabledServicesMap map[string]bool
 
-// OciAlloyConfigFilePathEnvVar is the environment variable name for the OCI Alloy Config File Path
-const OciAlloyConfigFilePathEnvVar = "OCI_ALLOY_CONFIG_FILE_PATH"
+// OciDeveloperToolConfigurationFilePathEnvVar is the environment variable name for the OCI Developer Tool Config File Path
+const OciDeveloperToolConfigurationFilePathEnvVar = "OCI_DEVELOPER_TOOL_CONFIGURATION_FILE_PATH"
 
-// OciAlloyRegionCoexistEnvVar is the environment variable name for the OCI Alloy Region Coexist
-const OciAlloyRegionCoexistEnvVar = "OCI_ALLOY_REGION_COEXIST"
+// OciAllowOnlyDeveloperToolConfigurationRegionsEnvVar is the environment variable name for the OCI Allow only Dev Tool Config Regions
+const OciAllowOnlyDeveloperToolConfigurationRegionsEnvVar = "OCI_ALLOW_ONLY_DEVELOPER_TOOL_CONFIGURATION_REGIONS"
 
-// defaultRealmForUnknownAlloyRegion is the default realm for unknown alloy region
-const defaultRealmForUnknownAlloyRegion = "oraclecloud.com"
+// defaultRealmForUnknownDeveloperToolConfigurationRegion is the default realm for unknown Developer Tool Configuration Regions
+const defaultRealmForUnknownDeveloperToolConfigurationRegion = "oraclecloud.com"
 
-// OciAlloyConfigFileProvider is the provider name for the OCI Alloy Config File
-var OciAlloyConfigFileProvider string
+// OciDeveloperToolConfigurationProvider is the provider name for the OCI Developer Tool Configuration file
+var OciDeveloperToolConfigurationProvider string
 
-// ociAlloyRegionCoexist is the flag to enable the OCI Alloy Region Coexist. This one has lower priority than the environment variable.
-var ociAlloyRegionCoexist bool
+// ociAllowOnlyDeveloperToolConfigurationRegions is the flag to enable the OCI Allow Only Developer Tool Configuration Regions. This one has lower priority than the environment variable.
+var ociAllowOnlyDeveloperToolConfigurationRegions bool
 
-var ociAlloyRegionSchemaList []map[string]string
+var ociDeveloperToolConfigurationRegionSchemaList []map[string]string
 
 // Endpoint returns a endpoint for a service
 func (region Region) Endpoint(service string) string {
+	// Endpoint for dotted region
+	if strings.Contains(string(region), ".") {
+		return fmt.Sprintf("%s.%s", service, region)
+	}
 	return fmt.Sprintf("%s.%s.%s", service, region, region.secondLevelDomain())
 }
 
@@ -155,7 +159,7 @@ func (region Region) secondLevelDomain() string {
 	}
 	Debugf("cannot find realm for region : %s, return default realm value.", region)
 	if _, ok := realm["oc1"]; !ok {
-		return defaultRealmForUnknownAlloyRegion
+		return defaultRealmForUnknownDeveloperToolConfigurationRegion
 	}
 	return realm["oc1"]
 }
@@ -173,16 +177,16 @@ func (region Region) RealmID() (string, error) {
 func StringToRegion(stringRegion string) (r Region) {
 	regionStr := strings.ToLower(stringRegion)
 	// check for PLC related regions
-	if !checkAllowOCIRegionCoexist() && (checkAlloyConfigFile() || len(ociAlloyRegionSchemaList) != 0) {
-		Debugf("Alloy config detected and OCI_ALLOY_REGION_COEXIST is not set to True, SDK will only use regions defined for Alloy regions")
-		setRegionMetadataFromAlloyCfgFile(&stringRegion)
-		if len(ociAlloyRegionSchemaList) != 0 {
+	if checkAllowOnlyDeveloperToolConfigurationRegions() && (checkDeveloperToolConfigurationFile() || len(ociDeveloperToolConfigurationRegionSchemaList) != 0) {
+		Debugf("Developer Tool config detected and OCI_ALLOW_ONLY_DEVELOPER_TOOL_CONFIGURATION_REGIONS is set to True, SDK will only use regions defined for Developer Tool Configuration Regions")
+		setRegionMetadataFromDeveloperToolConfigurationFile(&stringRegion)
+		if len(ociDeveloperToolConfigurationRegionSchemaList) != 0 {
 			resetRegionInfo()
-			bulkAddRegionSchema(ociAlloyRegionSchemaList)
+			bulkAddRegionSchema(ociDeveloperToolConfigurationRegionSchemaList)
 		}
 		r = Region(stringRegion)
 		if _, ok := regionRealm[r]; !ok {
-			Logf("You're using the %s Alloy configuration file, the region you're targeting is not declared in this config file. Please check if this is the correct region you're targeting or contact the %s cloud provider for help. If you want to target both OCI regions and %s regions, please set the OCI_PLC_REGION_COEXIST env var to True.", OciAlloyConfigFileProvider, OciAlloyConfigFileProvider, regionStr)
+			Logf("You're using the %s Developer Tool configuration file, the region you're targeting is not declared in this config file. Please check if this is the correct region you're targeting or contact the %s cloud provider for help. If you want to target both OCI regions and %s regions, please set the OCI_ALLOW_ONLY_DEVELOPER_TOOL_CONFIGURATION_REGIONS env var to False.", OciDeveloperToolConfigurationProvider, OciDeveloperToolConfigurationProvider, regionStr)
 		}
 		return r
 	}
@@ -271,7 +275,7 @@ func setRegionMetadataFromEnvVar(region *string) bool {
 }
 
 func setRegionMetadataFromCfgFile(region *string) bool {
-	if setRegionMetadataFromAlloyCfgFile(region) {
+	if setRegionMetadataFromDeveloperToolConfigurationFile(region) {
 		return true
 	}
 	if setRegionMetadataFromRegionCfgFile(region) {
@@ -310,13 +314,13 @@ func setRegionMetadataFromRegionCfgFile(region *string) bool {
 	return false
 }
 
-// setRegionMetadataFromAlloyFile checks if alloy config file is provided, once it's there, parse and add all
-// The default location of the alloy config file is ~/.oci/alloy-config.json. It will also check the environment variable
+// setRegionMetadataFromDeveloperToolConfigurationFile checks if Developer Tool config file is provided, once it's there, parse and add all
+// The default location of the Developer Tool config file is ~/.oci/developer-tool-configuration.json. It will also check the environment variable
 // the valid regions to region map, the configuration file can only be visited once.
 // Once successfully find the expected region(region name or short code), return true, region name will be stored in
 // the input pointer.
-func setRegionMetadataFromAlloyCfgFile(region *string) bool {
-	if jsonArr, ok := readAndParseAlloyConfigFile(); ok {
+func setRegionMetadataFromDeveloperToolConfigurationFile(region *string) bool {
+	if jsonArr, ok := readAndParseDeveloperToolConfigurationFile(); ok {
 		added := false
 		if jsonArr["regions"] == nil {
 			return false
@@ -331,7 +335,7 @@ func setRegionMetadataFromAlloyCfgFile(region *string) bool {
 			return false
 		}
 
-		if !IsEnvVarTrue(OciAlloyRegionCoexistEnvVar) {
+		if IsEnvVarTrue(OciAllowOnlyDeveloperToolConfigurationRegionsEnvVar) {
 			resetRegionInfo()
 		}
 		for _, jsonItem := range regionJSON {
@@ -363,14 +367,14 @@ func readAndParseConfigFile(configFileName *string) (fileContent []map[string]st
 	return
 }
 
-func readAndParseAlloyConfigFile() (fileContent map[string]interface{}, ok bool) {
+func readAndParseDeveloperToolConfigurationFile() (fileContent map[string]interface{}, ok bool) {
 	homeFolder := getHomeFolder()
-	configFileName := filepath.Join(homeFolder, regionMetadataCfgDirName, "alloy-config.json")
-	if path := os.Getenv(OciAlloyConfigFilePathEnvVar); path != "" {
+	configFileName := filepath.Join(homeFolder, regionMetadataCfgDirName, "developer-tool-configuration.json")
+	if path := os.Getenv(OciDeveloperToolConfigurationFilePathEnvVar); path != "" {
 		configFileName = path
 	}
 	if content, err := ioutil.ReadFile(configFileName); err == nil {
-		Debugf("Raw content of alloy config file content:", string(content[:]))
+		Debugf("Raw content of Developer Tool config file content:", string(content[:]))
 		if err := json.Unmarshal(content, &fileContent); err != nil {
 			Debugf("Can't unmarshal env var, the error info is", err)
 			return
@@ -378,14 +382,14 @@ func readAndParseAlloyConfigFile() (fileContent map[string]interface{}, ok bool)
 		ok = true
 		return
 	}
-	Debugf("No Alloy Config File provided.")
+	Debugf("No Developer Tool Config File provided.")
 	return
 }
 
-func checkAlloyConfigFile() bool {
+func checkDeveloperToolConfigurationFile() bool {
 	homeFolder := getHomeFolder()
-	configFileName := filepath.Join(homeFolder, regionMetadataCfgDirName, "alloy-config.json")
-	if path := os.Getenv(OciAlloyConfigFilePathEnvVar); path != "" {
+	configFileName := filepath.Join(homeFolder, regionMetadataCfgDirName, "developer-tool-configuration.json")
+	if path := os.Getenv(OciDeveloperToolConfigurationFilePathEnvVar); path != "" {
 		configFileName = path
 	}
 	if _, err := os.Stat(configFileName); err == nil {
@@ -409,7 +413,7 @@ func addRegionSchema(regionSchema map[string]string) {
 
 // AddRegionSchemaForPlc add region schema to region map
 func AddRegionSchemaForPlc(regionSchema map[string]string) {
-	ociAlloyRegionSchemaList = append(ociAlloyRegionSchemaList, regionSchema)
+	ociDeveloperToolConfigurationRegionSchemaList = append(ociDeveloperToolConfigurationRegionSchemaList, regionSchema)
 	addRegionSchema(regionSchema)
 	// if !IsEnvVarTrue(OciPlcRegionExclusiveEnvVar) {
 	// 	addRegionSchema(regionSchema)
@@ -555,12 +559,12 @@ func SetMissingTemplateParams(client *BaseClient) {
 
 func getOciSdkEnabledServicesMap() map[string]bool {
 	var enabledMap = make(map[string]bool)
-	if jsonArr, ok := readAndParseAlloyConfigFile(); ok {
+	if jsonArr, ok := readAndParseDeveloperToolConfigurationFile(); ok {
 		if jsonArr["provider"] != nil {
-			OciAlloyConfigFileProvider = jsonArr["provider"].(string)
+			OciDeveloperToolConfigurationProvider = jsonArr["provider"].(string)
 		}
-		if jsonArr["ociRegionCoexist"] != nil && jsonArr["ociRegionCoexist"] == true {
-			ociAlloyRegionCoexist = jsonArr["ociRegionCoexist"].(bool)
+		if jsonArr["allowOnlyDeveloperToolConfigurationRegions"] != nil && jsonArr["allowOnlyDeveloperToolConfigurationRegions"] == false {
+			ociAllowOnlyDeveloperToolConfigurationRegions = jsonArr["allowOnlyDeveloperToolConfigurationRegions"].(bool)
 		}
 		if jsonArr["services"] == nil {
 			return enabledMap
@@ -609,13 +613,13 @@ func CheckForEnabledServices(serviceName string) bool {
 	return OciSdkEnabledServicesMap[serviceName]
 }
 
-// CheckAllowOCIRegionCoexist checks if the OCI region coexist is allowed.
-// This function will first check if the OCI_REGION_COEXIST environment variable is set.
+// CheckAllowOnlyDeveloperToolConfigurationRegions checks if only developer tool configuration regions are allowed
+// This function will first check if the OCI_ALLOW_ONLY_DEVELOPER_TOOL_CONFIGURATION_REGIONS environment variable is set.
 // If it is set, it will return the value.
-// If it is not set, it will return the value from the OciAlloyRegionCoexist variable.
-func checkAllowOCIRegionCoexist() bool {
-	if val, ok := os.LookupEnv("OCI_REGION_COEXIST"); ok {
+// If it is not set, it will return the value from the ociAllowOnlyDeveloperToolConfigurationRegions variable.
+func checkAllowOnlyDeveloperToolConfigurationRegions() bool {
+	if val, ok := os.LookupEnv("OCI_ALLOW_ONLY_DEVELOPER_TOOL_CONFIGURATION_REGIONS"); ok {
 		return val == "true"
 	}
-	return ociAlloyRegionCoexist
+	return ociAllowOnlyDeveloperToolConfigurationRegions
 }

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/configuration.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/errors.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/eventual_consistency.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/eventual_consistency.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common
@@ -51,6 +51,7 @@ var (
 		{400, "RelatedResourceNotAuthorizedOrNotFound"}: true,
 		{404, "NotAuthorizedOrNotFound"}:                true,
 		{409, "NotAuthorizedOrResourceAlreadyExists"}:   true,
+		{409, "ResourceAlreadyExists"}:                  true,
 		{400, "InsufficientServicePermissions"}:         true,
 		{400, "ResourceDisabled"}:                       true,
 	}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/helpers.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/helpers.go
@@ -1,5 +1,7 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+//lint:file-ignore SA1019 older versions of staticcheck (those compatible with Golang 1.17) falsely flag x509.IsEncryptedPEMBlock and x509.DecryptPEMBlock.
 
 package common
 
@@ -9,7 +11,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/textproto"
 	"os"
 	"reflect"
@@ -295,13 +296,4 @@ func IsEnvVarFalse(envVarKey string) bool {
 func IsEnvVarTrue(envVarKey string) bool {
 	val, existed := os.LookupEnv(envVarKey)
 	return existed && strings.ToLower(val) == "true"
-}
-
-// Reads the certs from pem file pointed by the R1_CERT_PEM env variable
-func readCertPem(path string) []byte {
-	pem, err := ioutil.ReadFile(path)
-	if err != nil {
-		panic("can not read cert " + err.Error())
-	}
-	return pem
 }

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/http.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/http.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common
@@ -296,7 +296,7 @@ func addToBody(request *http.Request, value reflect.Value, field reflect.StructF
 }
 
 func checkBinaryBodyLength(request *http.Request) (contentLen int64, err error) {
-	if reflect.TypeOf(request.Body) == reflect.TypeOf(ioutil.NopCloser(nil)) {
+	if isNopCloser(request.Body) {
 		ioReader := reflect.ValueOf(request.Body).Field(0).Interface().(io.Reader)
 		switch t := ioReader.(type) {
 		case *bytes.Reader:
@@ -319,7 +319,32 @@ func checkBinaryBodyLength(request *http.Request) (contentLen int64, err error) 
 	return getNormalBinaryBodyLength(request)
 }
 
+// Helper function to judge if this struct is a nopCloser or nopCloserWriterTo
+func isNopCloser(readCloser io.ReadCloser) bool {
+	if reflect.TypeOf(readCloser) == reflect.TypeOf(io.NopCloser(nil)) || reflect.TypeOf(readCloser) == reflect.TypeOf(io.NopCloser(struct {
+		io.Reader
+		io.WriterTo
+	}{})) {
+		return true
+	}
+	return false
+}
+
 func getNormalBinaryBodyLength(request *http.Request) (contentLen int64, err error) {
+	// If binary body is seekable
+	seeker := getSeeker(request.Body)
+	if seeker != nil {
+		// save the current position, calculate the unread body length and seek it back to current position
+		if curPos, err := seeker.Seek(0, io.SeekCurrent); err == nil {
+			if endPos, err := seeker.Seek(0, io.SeekEnd); err == nil {
+				contentLen = endPos - curPos
+				if _, err = seeker.Seek(curPos, io.SeekStart); err == nil {
+					return contentLen, nil
+				}
+			}
+		}
+	}
+
 	var dumpRequestBody io.ReadCloser
 	if dumpRequestBody, request.Body, err = drainBody(request.Body); err != nil {
 		return contentLen, err
@@ -329,6 +354,19 @@ func getNormalBinaryBodyLength(request *http.Request) (contentLen int64, err err
 		return contentLen, err
 	}
 	return int64(len(contentBody)), nil
+}
+
+func getSeeker(readCloser io.ReadCloser) (seeker io.Seeker) {
+	if seeker, ok := readCloser.(io.Seeker); ok {
+		return seeker
+	}
+	// the binary body is wrapped with io.NopCloser
+	if isNopCloser(readCloser) {
+		if seeker, ok := reflect.ValueOf(readCloser).Field(0).Interface().(io.Seeker); ok {
+			return seeker
+		}
+	}
+	return seeker
 }
 
 func addToQuery(request *http.Request, value reflect.Value, field reflect.StructField) (e error) {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/http_signer.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/http_signer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/log.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/log.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/oci_http_transport_wrapper.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/oci_http_transport_wrapper.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+package common
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// OciHTTPTransportWrapper is a http.RoundTripper that periodically refreshes
+// the underlying http.Transport according to its templates.
+// Upon the first use (or once the RefreshRate duration is elapsed),
+// a new transport will be created from the TransportTemplate (if set).
+type OciHTTPTransportWrapper struct {
+	// RefreshRate specifies the duration at which http.Transport
+	// (with its tls.Config) must be refreshed.
+	// Defaults to 5 minutes.
+	RefreshRate time.Duration
+
+	// TLSConfigProvider creates a new tls.Config.
+	// If not set, nil tls.Config is returned.
+	TLSConfigProvider TLSConfigProvider
+
+	// ClientTemplate is responsible for creating a new http.Client with
+	// a given tls.Config.
+	//
+	// If not set, a new http.Client with a cloned http.DefaultTransport is returned.
+	TransportTemplate TransportTemplateProvider
+
+	// mutable properties
+	mux             sync.RWMutex
+	lastRefreshedAt time.Time
+	delegate        http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *OciHTTPTransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
+	delegate, err := t.refreshDelegate(false /* force */)
+	if err != nil {
+		return nil, err
+	}
+
+	return delegate.RoundTrip(req)
+}
+
+// Refresh forces refresh of the underlying delegate.
+func (t *OciHTTPTransportWrapper) Refresh(force bool) error {
+	_, err := t.refreshDelegate(force)
+	return err
+}
+
+// Delegate returns the currently active http.RoundTripper.
+// Might be nil.
+func (t *OciHTTPTransportWrapper) Delegate() http.RoundTripper {
+	t.mux.RLock()
+	defer t.mux.RUnlock()
+
+	return t.delegate
+}
+
+// refreshDelegate refreshes the delegate (and its TLS config) if:
+//   - force is true
+//   - it's been more than RefreshRate since the last time the client was refreshed.
+func (t *OciHTTPTransportWrapper) refreshDelegate(force bool) (http.RoundTripper, error) {
+	// read-lock first, since it's cheaper than write lock
+	t.mux.RLock()
+	if !t.shouldRefreshLocked(force) {
+		delegate := t.delegate
+		t.mux.RUnlock()
+
+		return delegate, nil
+	}
+
+	// upgrade to write-lock, and we'll need to check again for the same condition as above
+	// to avoid multiple initializations by multiple "refresher" goroutines
+	t.mux.RUnlock()
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	if !t.shouldRefreshLocked(force) {
+		return t.delegate, nil
+	}
+
+	// For this check we need the delegate to be set once before we check for change in cert files
+	if t.delegate != nil && !t.TLSConfigProvider.WatchedFilesModified() {
+		Debug("No modification in custom certs or ca bundle skipping refresh")
+		// Updating the last refresh time to make sure the next check is only done after the refresh interval has passed
+		t.lastRefreshedAt = time.Now()
+		return t.delegate, nil
+	}
+
+	Logf("Loading tls config from TLSConfigProvider")
+	tlsConfig, err := t.TLSConfigProvider.NewOrDefault()
+	if err != nil {
+		return nil, fmt.Errorf("refreshing tls.Config from template: %w", err)
+	}
+
+	t.delegate, err = t.TransportTemplate.NewOrDefault(tlsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("refreshing http.RoundTripper from template: %w", err)
+	}
+
+	t.lastRefreshedAt = time.Now()
+	return t.delegate, nil
+}
+
+// shouldRefreshLocked returns whether the client (and its TLS config)
+// needs to be refreshed.
+func (t *OciHTTPTransportWrapper) shouldRefreshLocked(force bool) bool {
+	if force || t.delegate == nil {
+		return true
+	}
+	return t.refreshRate() > 0 && time.Since(t.lastRefreshedAt) > t.refreshRate()
+}
+
+func (t *OciHTTPTransportWrapper) refreshRate() time.Duration {
+	return t.RefreshRate
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/regions.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/regions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common
@@ -74,6 +74,12 @@ const (
 	RegionUSChicago1 Region = "us-chicago-1"
 	//RegionMXMonterrey1 region Monterrey
 	RegionMXMonterrey1 Region = "mx-monterrey-1"
+	//RegionUSSaltlake2 region Saltlake
+	RegionUSSaltlake2 Region = "us-saltlake-2"
+	//RegionSABogota1 region Bogota
+	RegionSABogota1 Region = "sa-bogota-1"
+	//RegionSAValparaiso1 region Valparaiso
+	RegionSAValparaiso1 Region = "sa-valparaiso-1"
 	//RegionUSLangley1 region Langley
 	RegionUSLangley1 Region = "us-langley-1"
 	//RegionUSLuke1 region Luke
@@ -114,6 +120,8 @@ const (
 	RegionEUFrankfurt2 Region = "eu-frankfurt-2"
 	//RegionEUJovanovac1 region Jovanovac
 	RegionEUJovanovac1 Region = "eu-jovanovac-1"
+	//RegionEUDccZurich1 region Zurich
+	RegionEUDccZurich1 Region = "eu-dcc-zurich-1"
 )
 
 var shortNameRegion = map[string]Region{
@@ -152,6 +160,9 @@ var shortNameRegion = map[string]Region{
 	"mad": RegionEUMadrid1,
 	"ord": RegionUSChicago1,
 	"mty": RegionMXMonterrey1,
+	"aga": RegionUSSaltlake2,
+	"bog": RegionSABogota1,
+	"vap": RegionSAValparaiso1,
 	"lfi": RegionUSLangley1,
 	"luf": RegionUSLuke1,
 	"ric": RegionUSGovAshburn1,
@@ -172,6 +183,7 @@ var shortNameRegion = map[string]Region{
 	"vll": RegionEUMadrid2,
 	"str": RegionEUFrankfurt2,
 	"beg": RegionEUJovanovac1,
+	"avz": RegionEUDccZurich1,
 }
 
 var realm = map[string]string{
@@ -185,6 +197,7 @@ var realm = map[string]string{
 	"oc14": "oraclecloud14.com",
 	"oc19": "oraclecloud.eu",
 	"oc20": "oraclecloud20.com",
+	"oc24": "oraclecloud24.com",
 }
 
 var regionRealm = map[Region]string{
@@ -223,6 +236,9 @@ var regionRealm = map[Region]string{
 	RegionEUMadrid1:       "oc1",
 	RegionUSChicago1:      "oc1",
 	RegionMXMonterrey1:    "oc1",
+	RegionUSSaltlake2:     "oc1",
+	RegionSABogota1:       "oc1",
+	RegionSAValparaiso1:   "oc1",
 
 	RegionUSLangley1: "oc2",
 	RegionUSLuke1:    "oc2",
@@ -252,4 +268,6 @@ var regionRealm = map[Region]string{
 	RegionEUFrankfurt2: "oc19",
 
 	RegionEUJovanovac1: "oc20",
+
+	RegionEUDccZurich1: "oc24",
 }

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/regions.json
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/regions.json
@@ -328,5 +328,29 @@
         "realmKey": "oc1",
         "regionIdentifier": "mx-monterrey-1",
         "realmDomainComponent": "oraclecloud.com"
+    },
+    {
+        "regionKey": "aga",
+        "realmKey": "oc1",
+        "regionIdentifier": "us-saltlake-2",
+        "realmDomainComponent": "oraclecloud.com"
+    },
+    {
+        "regionKey": "avz",
+        "realmKey": "oc24",
+        "regionIdentifier": "eu-dcc-zurich-1",
+        "realmDomainComponent": "oraclecloud24.com"
+    },
+    {
+        "regionKey": "bog",
+        "realmKey": "oc1",
+        "regionIdentifier": "sa-bogota-1",
+        "realmDomainComponent": "oraclecloud.com"
+    },
+    {
+        "regionKey": "vap",
+        "realmKey": "oc1",
+        "regionIdentifier": "sa-valparaiso-1",
+        "realmDomainComponent": "oraclecloud.com"
     }
 ]

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/retry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/retry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 
 package common

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/tls_config_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/tls_config_provider.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+package common
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// GetTLSConfigTemplateForTransport returns the TLSConfigTemplate to used depending on whether any additional
+// CA Bundle or client side certs have been configured
+func GetTLSConfigTemplateForTransport() TLSConfigProvider {
+	certPath := os.Getenv(ociDefaultClientCertsPath)
+	keyPath := os.Getenv(ociDefaultClientCertsPrivateKeyPath)
+	caBundlePath := os.Getenv(ociDefaultCertsPath)
+	if certPath != "" && keyPath != "" {
+		return &DefaultMTLSConfigProvider{
+			caBundlePath:         caBundlePath,
+			clientCertPath:       certPath,
+			clientKeyPath:        keyPath,
+			watchedFilesStatsMap: make(map[string]os.FileInfo),
+		}
+	}
+	return &DefaultTLSConfigProvider{
+		caBundlePath: caBundlePath,
+	}
+}
+
+// TLSConfigProvider is an interface the defines a function that creates a new *tls.Config.
+type TLSConfigProvider interface {
+	NewOrDefault() (*tls.Config, error)
+	WatchedFilesModified() bool
+}
+
+// DefaultTLSConfigProvider is a provider that provides a TLS tls.config for the HTTPTransport
+type DefaultTLSConfigProvider struct {
+	caBundlePath string
+	mux          sync.Mutex
+	currentStat  os.FileInfo
+}
+
+// NewOrDefault returns a default tls.Config which
+// sets its RootCAs to be a *x509.CertPool from caBundlePath.
+func (t *DefaultTLSConfigProvider) NewOrDefault() (*tls.Config, error) {
+	if t.caBundlePath == "" {
+		return &tls.Config{}, nil
+	}
+
+	// Keep the current Stat info from the ca bundle in a map
+	Debugf("Getting Initial Stats for file: %s", t.caBundlePath)
+	caBundleStat, err := os.Stat(t.caBundlePath)
+	if err != nil {
+		return nil, err
+	}
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	t.currentStat = caBundleStat
+
+	rootCAs, err := CertPoolFrom(t.caBundlePath)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		RootCAs: rootCAs,
+	}, nil
+}
+
+// WatchedFilesModified returns true if any files in the watchedFilesStatsMap has been modified else returns false
+func (t *DefaultTLSConfigProvider) WatchedFilesModified() bool {
+	modified := false
+	if t.caBundlePath != "" {
+		newStat, err := os.Stat(t.caBundlePath)
+		if err == nil && (t.currentStat.Size() != newStat.Size() || t.currentStat.ModTime() != newStat.ModTime()) {
+			Logf("Modification detected in cert/ca-bundle file: %s", t.caBundlePath)
+			modified = true
+			t.mux.Lock()
+			defer t.mux.Unlock()
+			t.currentStat = newStat
+		}
+	}
+	return modified
+}
+
+// DefaultMTLSConfigProvider is a provider that provides a MTLS tls.config for the HTTPTransport
+type DefaultMTLSConfigProvider struct {
+	caBundlePath         string
+	clientCertPath       string
+	clientKeyPath        string
+	mux                  sync.Mutex
+	watchedFilesStatsMap map[string]os.FileInfo
+}
+
+// NewOrDefault returns a default tls.Config which sets its RootCAs
+// to be a *x509.CertPool from caBundlePath and calls
+// tls.LoadX509KeyPair(clientCertPath, clientKeyPath) to set mtls client certs.
+func (t *DefaultMTLSConfigProvider) NewOrDefault() (*tls.Config, error) {
+	rootCAs, err := CertPoolFrom(t.caBundlePath)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := tls.LoadX509KeyPair(t.clientCertPath, t.clientKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure the initial certs file stats, error skipped because we error out before this if the files don't exist
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	t.watchedFilesStatsMap[t.caBundlePath], _ = os.Stat(t.caBundlePath)
+	t.watchedFilesStatsMap[t.clientCertPath], _ = os.Stat(t.clientCertPath)
+	t.watchedFilesStatsMap[t.clientKeyPath], _ = os.Stat(t.clientKeyPath)
+
+	return &tls.Config{
+		RootCAs:      rootCAs,
+		Certificates: []tls.Certificate{cert},
+	}, nil
+}
+
+// WatchedFilesModified returns true if any files in the watchedFilesStatsMap has been modified else returns false
+func (t *DefaultMTLSConfigProvider) WatchedFilesModified() bool {
+	modified := false
+
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	for k, v := range t.watchedFilesStatsMap {
+		if k != "" {
+			currentStat, err := os.Stat(k)
+			if err == nil && (v.Size() != currentStat.Size() || v.ModTime() != currentStat.ModTime()) {
+				modified = true
+				Logf("Modification detected in cert/ca-bundle file: %s", k)
+				t.watchedFilesStatsMap[k] = currentStat
+			}
+		}
+	}
+
+	return modified
+}
+
+// CertPoolFrom creates a new x509.CertPool from a given file.
+func CertPoolFrom(caBundleFile string) (*x509.CertPool, error) {
+	pemCerts, err := os.ReadFile(caBundleFile)
+	if err != nil {
+		return nil, err
+	}
+
+	trust := x509.NewCertPool()
+	if !trust.AppendCertsFromPEM(pemCerts) {
+		return nil, fmt.Errorf("creating a new x509.CertPool from %s: no certs added", caBundleFile)
+	}
+
+	return trust, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/transport_template_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/transport_template_provider.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
+package common
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// TransportTemplateProvider defines a function that creates a new http transport
+// from a given TLS client config.
+type TransportTemplateProvider func(tlsClientConfig *tls.Config) (http.RoundTripper, error)
+
+// NewOrDefault creates a new TransportTemplate
+// If t is nil, then DefaultTransport is returned
+func (t TransportTemplateProvider) NewOrDefault(tlsClientConfig *tls.Config) (http.RoundTripper, error) {
+	if t == nil {
+		return DefaultTransport(tlsClientConfig)
+	}
+	return t(tlsClientConfig)
+}
+
+// DefaultTransport creates a clone of http.DefaultTransport
+// and applies the tlsClientConfig on top of it.
+// The result is never nil, to prevent panics in client code.
+// Never returns any errors, but needs to return an error
+// to adhere to TransportTemplate interface.
+func DefaultTransport(tlsClientConfig *tls.Config) (*http.Transport, error) {
+	transport := CloneHTTPDefaultTransport()
+	if isExpectHeaderDisabled := IsEnvVarFalse(UsingExpectHeaderEnvVar); !isExpectHeaderDisabled {
+		transport.Proxy = http.ProxyFromEnvironment
+		transport.DialContext = (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext
+		transport.ForceAttemptHTTP2 = true
+		transport.MaxIdleConns = 100
+		transport.IdleConnTimeout = 90 * time.Second
+		transport.TLSHandshakeTimeout = 10 * time.Second
+		transport.ExpectContinueTimeout = 3 * time.Second
+	}
+	transport.TLSClientConfig = tlsClientConfig
+	return transport, nil
+}
+
+// CloneHTTPDefaultTransport returns a clone of http.DefaultTransport.
+func CloneHTTPDefaultTransport() *http.Transport {
+	return http.DefaultTransport.(*http.Transport).Clone()
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/common/version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/common/version.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	major = "65"
-	minor = "49"
-	patch = "2"
+	minor = "56"
+	patch = "0"
 	tag   = ""
 )
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/accept_shielded_integrity_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/accept_shielded_integrity_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_distribution_statement_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_distribution_statement_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_distribution_statements_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_distribution_statements_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_distribution_statements_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_distribution_statements_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_rule_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_rule_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_rules_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_rules_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_drg_route_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_image_shape_compatibility_entry_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_image_shape_compatibility_entry_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_image_shape_compatibility_entry_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_image_shape_compatibility_entry_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_ipv6_subnet_cidr_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_ipv6_subnet_cidr_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_ipv6_vcn_cidr_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_ipv6_vcn_cidr_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_network_security_group_security_rules_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_network_security_group_security_rules_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_network_security_group_security_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_network_security_group_security_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_public_ip_pool_capacity_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_public_ip_pool_capacity_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_public_ip_pool_capacity_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_public_ip_pool_capacity_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_security_rule_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_security_rule_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_subnet_ipv6_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_subnet_ipv6_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_vcn_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_vcn_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_vcn_cidr_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_vcn_cidr_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/add_vcn_ipv6_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/add_vcn_ipv6_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/added_network_security_group_security_rules.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/added_network_security_group_security_rules.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/advertise_byoip_range_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/advertise_byoip_range_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/allowed_ike_ip_sec_parameters.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/allowed_ike_ip_sec_parameters.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/allowed_phase_one_parameters.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/allowed_phase_one_parameters.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/allowed_phase_two_parameters.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/allowed_phase_two_parameters.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_milan_bm_gpu_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_milan_bm_gpu_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_milan_bm_gpu_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_milan_bm_gpu_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_milan_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_milan_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_milan_bm_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_milan_bm_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_rome_bm_gpu_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_rome_bm_gpu_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_rome_bm_gpu_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_rome_bm_gpu_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_rome_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_rome_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_rome_bm_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_rome_bm_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_vm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_vm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_vm_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/amd_vm_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing_resource_version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing_resource_version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing_resource_version_agreements.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing_resource_version_agreements.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing_resource_version_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing_resource_version_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_listing_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_subscription.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_subscription.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_subscription_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/app_catalog_subscription_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_boot_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_boot_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_boot_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_boot_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_emulated_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_emulated_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_i_scsi_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_i_scsi_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_instance_pool_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_instance_pool_instance_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_instance_pool_instance_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_instance_pool_instance_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_load_balancer_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_load_balancer_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_paravirtualized_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_paravirtualized_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_service_determined_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_service_determined_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_service_id_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_service_id_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_vnic_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_vnic_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_vnic_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_vnic_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/attach_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/autotune_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/autotune_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/bgp_session_info.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/bgp_session_info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/block_volume_replica.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/block_volume_replica.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/block_volume_replica_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/block_volume_replica_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/block_volume_replica_info.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/block_volume_replica_info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boolean_image_capability_schema_descriptor.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boolean_image_capability_schema_descriptor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_attachment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_backup.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_backup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_kms_key.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_kms_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_replica.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_replica.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_replica_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_replica_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_replica_info.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_replica_info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_source_from_boot_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_source_from_boot_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_source_from_boot_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_source_from_boot_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_source_from_boot_volume_replica_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/boot_volume_source_from_boot_volume_replica_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/bulk_add_virtual_circuit_public_prefixes_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/bulk_add_virtual_circuit_public_prefixes_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/bulk_add_virtual_circuit_public_prefixes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/bulk_add_virtual_circuit_public_prefixes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/bulk_delete_virtual_circuit_public_prefixes_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/bulk_delete_virtual_circuit_public_prefixes_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/bulk_delete_virtual_circuit_public_prefixes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/bulk_delete_virtual_circuit_public_prefixes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_allocated_range_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_allocated_range_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_allocated_range_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_allocated_range_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_range.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_range.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_range_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_range_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_range_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_range_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_range_vcn_ipv6_allocation_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/byoip_range_vcn_ipv6_allocation_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/byoipv6_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/byoipv6_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/capacity_report_instance_shape_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/capacity_report_instance_shape_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/capacity_report_shape_availability.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/capacity_report_shape_availability.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/capacity_reservation_instance_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/capacity_reservation_instance_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/capacity_source.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/capacity_source.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CapacitySource A capacity source of bare metal hosts.
+type CapacitySource interface {
+}
+
+type capacitysource struct {
+	JsonData     []byte
+	CapacityType string `json:"capacityType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *capacitysource) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercapacitysource capacitysource
+	s := struct {
+		Model Unmarshalercapacitysource
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CapacityType = s.Model.CapacityType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *capacitysource) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.CapacityType {
+	case "DEDICATED":
+		mm := DedicatedCapacitySource{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for CapacitySource: %s.", m.CapacityType)
+		return *m, nil
+	}
+}
+
+func (m capacitysource) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m capacitysource) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CapacitySourceCapacityTypeEnum Enum with underlying type: string
+type CapacitySourceCapacityTypeEnum string
+
+// Set of constants representing the allowable values for CapacitySourceCapacityTypeEnum
+const (
+	CapacitySourceCapacityTypeDedicated CapacitySourceCapacityTypeEnum = "DEDICATED"
+)
+
+var mappingCapacitySourceCapacityTypeEnum = map[string]CapacitySourceCapacityTypeEnum{
+	"DEDICATED": CapacitySourceCapacityTypeDedicated,
+}
+
+var mappingCapacitySourceCapacityTypeEnumLowerCase = map[string]CapacitySourceCapacityTypeEnum{
+	"dedicated": CapacitySourceCapacityTypeDedicated,
+}
+
+// GetCapacitySourceCapacityTypeEnumValues Enumerates the set of values for CapacitySourceCapacityTypeEnum
+func GetCapacitySourceCapacityTypeEnumValues() []CapacitySourceCapacityTypeEnum {
+	values := make([]CapacitySourceCapacityTypeEnum, 0)
+	for _, v := range mappingCapacitySourceCapacityTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetCapacitySourceCapacityTypeEnumStringValues Enumerates the set of values in String for CapacitySourceCapacityTypeEnum
+func GetCapacitySourceCapacityTypeEnumStringValues() []string {
+	return []string{
+		"DEDICATED",
+	}
+}
+
+// GetMappingCapacitySourceCapacityTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingCapacitySourceCapacityTypeEnum(val string) (CapacitySourceCapacityTypeEnum, bool) {
+	enum, ok := mappingCapacitySourceCapacityTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/capture_console_history_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/capture_console_history_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/capture_console_history_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/capture_console_history_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/capture_filter.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/capture_filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -58,6 +58,9 @@ type CaptureFilter struct {
 
 	// The set of rules governing what traffic a VTAP mirrors.
 	VtapCaptureFilterRules []VtapCaptureFilterRuleDetails `mandatory:"false" json:"vtapCaptureFilterRules"`
+
+	// The set of rules governing what traffic the VCN flow log collects.
+	FlowLogCaptureFilterRules []FlowLogCaptureFilterRuleDetails `mandatory:"false" json:"flowLogCaptureFilterRules"`
 }
 
 func (m CaptureFilter) String() string {
@@ -141,15 +144,18 @@ type CaptureFilterFilterTypeEnum string
 
 // Set of constants representing the allowable values for CaptureFilterFilterTypeEnum
 const (
-	CaptureFilterFilterTypeVtap CaptureFilterFilterTypeEnum = "VTAP"
+	CaptureFilterFilterTypeVtap    CaptureFilterFilterTypeEnum = "VTAP"
+	CaptureFilterFilterTypeFlowlog CaptureFilterFilterTypeEnum = "FLOWLOG"
 )
 
 var mappingCaptureFilterFilterTypeEnum = map[string]CaptureFilterFilterTypeEnum{
-	"VTAP": CaptureFilterFilterTypeVtap,
+	"VTAP":    CaptureFilterFilterTypeVtap,
+	"FLOWLOG": CaptureFilterFilterTypeFlowlog,
 }
 
 var mappingCaptureFilterFilterTypeEnumLowerCase = map[string]CaptureFilterFilterTypeEnum{
-	"vtap": CaptureFilterFilterTypeVtap,
+	"vtap":    CaptureFilterFilterTypeVtap,
+	"flowlog": CaptureFilterFilterTypeFlowlog,
 }
 
 // GetCaptureFilterFilterTypeEnumValues Enumerates the set of values for CaptureFilterFilterTypeEnum
@@ -165,6 +171,7 @@ func GetCaptureFilterFilterTypeEnumValues() []CaptureFilterFilterTypeEnum {
 func GetCaptureFilterFilterTypeEnumStringValues() []string {
 	return []string{
 		"VTAP",
+		"FLOWLOG",
 	}
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_boot_volume_backup_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_boot_volume_backup_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_boot_volume_backup_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_boot_volume_backup_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_boot_volume_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_boot_volume_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_boot_volume_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_boot_volume_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_byoip_range_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_byoip_range_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_byoip_range_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_byoip_range_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_capture_filter_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_capture_filter_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_capture_filter_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_capture_filter_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cluster_network_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cluster_network_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cluster_network_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cluster_network_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_capacity_reservation_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_capacity_reservation_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_capacity_reservation_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_capacity_reservation_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_capacity_topology_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_capacity_topology_compartment_details.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ChangeComputeCapacityTopologyCompartmentDetails Specifies the compartment to move the compute capacity topology to.
+type ChangeComputeCapacityTopologyCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment
+	// to move the compute capacity topology to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeComputeCapacityTopologyCompartmentDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ChangeComputeCapacityTopologyCompartmentDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_capacity_topology_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_capacity_topology_compartment_request_response.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ChangeComputeCapacityTopologyCompartmentRequest wrapper for the ChangeComputeCapacityTopologyCompartment operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ChangeComputeCapacityTopologyCompartment.go.html to see an example of how to use ChangeComputeCapacityTopologyCompartmentRequest.
+type ChangeComputeCapacityTopologyCompartmentRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" contributesTo:"path" name:"computeCapacityTopologyId"`
+
+	// The configuration details for the move operation.
+	ChangeComputeCapacityTopologyCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeComputeCapacityTopologyCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeComputeCapacityTopologyCompartmentRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ChangeComputeCapacityTopologyCompartmentRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeComputeCapacityTopologyCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ChangeComputeCapacityTopologyCompartmentRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ChangeComputeCapacityTopologyCompartmentResponse wrapper for the ChangeComputeCapacityTopologyCompartment operation
+type ChangeComputeCapacityTopologyCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
+	// Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/latest/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response ChangeComputeCapacityTopologyCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeComputeCapacityTopologyCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_cluster_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_cluster_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_cluster_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_cluster_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_image_capability_schema_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_image_capability_schema_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_image_capability_schema_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_compute_image_capability_schema_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cpe_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cpe_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cpe_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cpe_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cross_connect_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cross_connect_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cross_connect_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cross_connect_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cross_connect_group_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cross_connect_group_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cross_connect_group_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_cross_connect_group_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_dedicated_vm_host_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_dedicated_vm_host_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_dedicated_vm_host_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_dedicated_vm_host_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_dhcp_options_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_dhcp_options_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_dhcp_options_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_dhcp_options_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_drg_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_drg_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_drg_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_drg_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_i_p_sec_connection_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_i_p_sec_connection_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_image_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_image_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_image_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_image_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_configuration_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_configuration_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_configuration_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_configuration_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_pool_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_pool_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_pool_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_instance_pool_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_internet_gateway_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_internet_gateway_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_internet_gateway_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_internet_gateway_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_ip_sec_connection_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_ip_sec_connection_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_local_peering_gateway_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_local_peering_gateway_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_local_peering_gateway_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_local_peering_gateway_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_nat_gateway_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_nat_gateway_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_nat_gateway_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_nat_gateway_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_network_security_group_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_network_security_group_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_network_security_group_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_network_security_group_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_public_ip_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_public_ip_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_public_ip_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_public_ip_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_public_ip_pool_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_public_ip_pool_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_public_ip_pool_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_public_ip_pool_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_remote_peering_connection_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_remote_peering_connection_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_remote_peering_connection_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_remote_peering_connection_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_route_table_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_route_table_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_route_table_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_route_table_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_security_list_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_security_list_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_security_list_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_security_list_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_service_gateway_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_service_gateway_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_service_gateway_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_service_gateway_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_subnet_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_subnet_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_subnet_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_subnet_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vcn_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vcn_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vcn_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vcn_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_virtual_circuit_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_virtual_circuit_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_virtual_circuit_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_virtual_circuit_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vlan_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vlan_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vlan_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vlan_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_backup_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_backup_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_backup_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_backup_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_group_backup_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_group_backup_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_group_backup_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_group_backup_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_group_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_group_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_group_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_volume_group_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vtap_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vtap_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vtap_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/change_vtap_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_network.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_network.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_network_placement_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_network_placement_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_network_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cluster_network_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compartment_internal.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compartment_internal.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_bare_metal_host.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_bare_metal_host.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeBareMetalHost A compute bare metal host.
+type ComputeBareMetalHost struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" json:"computeCapacityTopologyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute bare metal host.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The shape of the compute instance that runs on the compute bare metal host.
+	InstanceShape *string `mandatory:"true" json:"instanceShape"`
+
+	// The current state of the compute bare metal host.
+	LifecycleState ComputeBareMetalHostLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time that the compute bare metal host was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time that the compute bare metal host was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute HPC island.
+	ComputeHpcIslandId *string `mandatory:"false" json:"computeHpcIslandId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute local block.
+	ComputeLocalBlockId *string `mandatory:"false" json:"computeLocalBlockId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute network block.
+	ComputeNetworkBlockId *string `mandatory:"false" json:"computeNetworkBlockId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute instance that runs on the compute bare metal host.
+	InstanceId *string `mandatory:"false" json:"instanceId"`
+
+	// The lifecycle state details of the compute bare metal host.
+	LifecycleDetails ComputeBareMetalHostLifecycleDetailsEnum `mandatory:"false" json:"lifecycleDetails,omitempty"`
+}
+
+func (m ComputeBareMetalHost) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeBareMetalHost) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingComputeBareMetalHostLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetComputeBareMetalHostLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if _, ok := GetMappingComputeBareMetalHostLifecycleDetailsEnum(string(m.LifecycleDetails)); !ok && m.LifecycleDetails != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleDetails: %s. Supported values are: %s.", m.LifecycleDetails, strings.Join(GetComputeBareMetalHostLifecycleDetailsEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ComputeBareMetalHostLifecycleDetailsEnum Enum with underlying type: string
+type ComputeBareMetalHostLifecycleDetailsEnum string
+
+// Set of constants representing the allowable values for ComputeBareMetalHostLifecycleDetailsEnum
+const (
+	ComputeBareMetalHostLifecycleDetailsAvailable   ComputeBareMetalHostLifecycleDetailsEnum = "AVAILABLE"
+	ComputeBareMetalHostLifecycleDetailsDegraded    ComputeBareMetalHostLifecycleDetailsEnum = "DEGRADED"
+	ComputeBareMetalHostLifecycleDetailsUnavailable ComputeBareMetalHostLifecycleDetailsEnum = "UNAVAILABLE"
+)
+
+var mappingComputeBareMetalHostLifecycleDetailsEnum = map[string]ComputeBareMetalHostLifecycleDetailsEnum{
+	"AVAILABLE":   ComputeBareMetalHostLifecycleDetailsAvailable,
+	"DEGRADED":    ComputeBareMetalHostLifecycleDetailsDegraded,
+	"UNAVAILABLE": ComputeBareMetalHostLifecycleDetailsUnavailable,
+}
+
+var mappingComputeBareMetalHostLifecycleDetailsEnumLowerCase = map[string]ComputeBareMetalHostLifecycleDetailsEnum{
+	"available":   ComputeBareMetalHostLifecycleDetailsAvailable,
+	"degraded":    ComputeBareMetalHostLifecycleDetailsDegraded,
+	"unavailable": ComputeBareMetalHostLifecycleDetailsUnavailable,
+}
+
+// GetComputeBareMetalHostLifecycleDetailsEnumValues Enumerates the set of values for ComputeBareMetalHostLifecycleDetailsEnum
+func GetComputeBareMetalHostLifecycleDetailsEnumValues() []ComputeBareMetalHostLifecycleDetailsEnum {
+	values := make([]ComputeBareMetalHostLifecycleDetailsEnum, 0)
+	for _, v := range mappingComputeBareMetalHostLifecycleDetailsEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetComputeBareMetalHostLifecycleDetailsEnumStringValues Enumerates the set of values in String for ComputeBareMetalHostLifecycleDetailsEnum
+func GetComputeBareMetalHostLifecycleDetailsEnumStringValues() []string {
+	return []string{
+		"AVAILABLE",
+		"DEGRADED",
+		"UNAVAILABLE",
+	}
+}
+
+// GetMappingComputeBareMetalHostLifecycleDetailsEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingComputeBareMetalHostLifecycleDetailsEnum(val string) (ComputeBareMetalHostLifecycleDetailsEnum, bool) {
+	enum, ok := mappingComputeBareMetalHostLifecycleDetailsEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ComputeBareMetalHostLifecycleStateEnum Enum with underlying type: string
+type ComputeBareMetalHostLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ComputeBareMetalHostLifecycleStateEnum
+const (
+	ComputeBareMetalHostLifecycleStateActive   ComputeBareMetalHostLifecycleStateEnum = "ACTIVE"
+	ComputeBareMetalHostLifecycleStateInactive ComputeBareMetalHostLifecycleStateEnum = "INACTIVE"
+)
+
+var mappingComputeBareMetalHostLifecycleStateEnum = map[string]ComputeBareMetalHostLifecycleStateEnum{
+	"ACTIVE":   ComputeBareMetalHostLifecycleStateActive,
+	"INACTIVE": ComputeBareMetalHostLifecycleStateInactive,
+}
+
+var mappingComputeBareMetalHostLifecycleStateEnumLowerCase = map[string]ComputeBareMetalHostLifecycleStateEnum{
+	"active":   ComputeBareMetalHostLifecycleStateActive,
+	"inactive": ComputeBareMetalHostLifecycleStateInactive,
+}
+
+// GetComputeBareMetalHostLifecycleStateEnumValues Enumerates the set of values for ComputeBareMetalHostLifecycleStateEnum
+func GetComputeBareMetalHostLifecycleStateEnumValues() []ComputeBareMetalHostLifecycleStateEnum {
+	values := make([]ComputeBareMetalHostLifecycleStateEnum, 0)
+	for _, v := range mappingComputeBareMetalHostLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetComputeBareMetalHostLifecycleStateEnumStringValues Enumerates the set of values in String for ComputeBareMetalHostLifecycleStateEnum
+func GetComputeBareMetalHostLifecycleStateEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"INACTIVE",
+	}
+}
+
+// GetMappingComputeBareMetalHostLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingComputeBareMetalHostLifecycleStateEnum(val string) (ComputeBareMetalHostLifecycleStateEnum, bool) {
+	enum, ok := mappingComputeBareMetalHostLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_bare_metal_host_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_bare_metal_host_collection.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeBareMetalHostCollection A list of compute bare metal hosts.
+type ComputeBareMetalHostCollection struct {
+
+	// The list of compute bare metal hosts.
+	Items []ComputeBareMetalHostSummary `mandatory:"true" json:"items"`
+}
+
+func (m ComputeBareMetalHostCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeBareMetalHostCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_bare_metal_host_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_bare_metal_host_summary.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeBareMetalHostSummary Summary information for a compute bare metal host.
+type ComputeBareMetalHostSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" json:"computeCapacityTopologyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute bare metal host.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The shape of the compute instance that runs on the compute bare metal host.
+	InstanceShape *string `mandatory:"true" json:"instanceShape"`
+
+	// The current state of the compute bare metal host.
+	LifecycleState ComputeBareMetalHostLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time that the compute bare metal host was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time that the compute bare metal host was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute HPC island.
+	ComputeHpcIslandId *string `mandatory:"false" json:"computeHpcIslandId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute network block.
+	ComputeLocalBlockId *string `mandatory:"false" json:"computeLocalBlockId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute local block.
+	ComputeNetworkBlockId *string `mandatory:"false" json:"computeNetworkBlockId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute instance that runs on the compute bare metal host.
+	InstanceId *string `mandatory:"false" json:"instanceId"`
+
+	// The lifecycle state details of the compute bare metal host.
+	LifecycleDetails ComputeBareMetalHostLifecycleDetailsEnum `mandatory:"false" json:"lifecycleDetails,omitempty"`
+}
+
+func (m ComputeBareMetalHostSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeBareMetalHostSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingComputeBareMetalHostLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetComputeBareMetalHostLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if _, ok := GetMappingComputeBareMetalHostLifecycleDetailsEnum(string(m.LifecycleDetails)); !ok && m.LifecycleDetails != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleDetails: %s. Supported values are: %s.", m.LifecycleDetails, strings.Join(GetComputeBareMetalHostLifecycleDetailsEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_report.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_report.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_reservation.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_reservation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_reservation_instance_shape_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_reservation_instance_shape_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_reservation_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_reservation_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_topology.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_topology.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeCapacityTopology A compute capacity topology that allows you to query your bare metal hosts and their RDMA network topology.
+type ComputeCapacityTopology struct {
+
+	// The availability domain of the compute capacity topology.
+	// Example: `Uocm:US-CHICAGO-1-AD-2`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	CapacitySource CapacitySource `mandatory:"true" json:"capacitySource"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the compute capacity topology.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The current state of the compute capacity topology.
+	LifecycleState ComputeCapacityTopologyLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time that the compute capacity topology was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time that the compute capacity topology was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m ComputeCapacityTopology) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeCapacityTopology) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingComputeCapacityTopologyLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetComputeCapacityTopologyLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ComputeCapacityTopology) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DefinedTags        map[string]map[string]interface{}         `json:"definedTags"`
+		DisplayName        *string                                   `json:"displayName"`
+		FreeformTags       map[string]string                         `json:"freeformTags"`
+		AvailabilityDomain *string                                   `json:"availabilityDomain"`
+		CapacitySource     capacitysource                            `json:"capacitySource"`
+		CompartmentId      *string                                   `json:"compartmentId"`
+		Id                 *string                                   `json:"id"`
+		LifecycleState     ComputeCapacityTopologyLifecycleStateEnum `json:"lifecycleState"`
+		TimeCreated        *common.SDKTime                           `json:"timeCreated"`
+		TimeUpdated        *common.SDKTime                           `json:"timeUpdated"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DefinedTags = model.DefinedTags
+
+	m.DisplayName = model.DisplayName
+
+	m.FreeformTags = model.FreeformTags
+
+	m.AvailabilityDomain = model.AvailabilityDomain
+
+	nn, e = model.CapacitySource.UnmarshalPolymorphicJSON(model.CapacitySource.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.CapacitySource = nn.(CapacitySource)
+	} else {
+		m.CapacitySource = nil
+	}
+
+	m.CompartmentId = model.CompartmentId
+
+	m.Id = model.Id
+
+	m.LifecycleState = model.LifecycleState
+
+	m.TimeCreated = model.TimeCreated
+
+	m.TimeUpdated = model.TimeUpdated
+
+	return
+}
+
+// ComputeCapacityTopologyLifecycleStateEnum Enum with underlying type: string
+type ComputeCapacityTopologyLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ComputeCapacityTopologyLifecycleStateEnum
+const (
+	ComputeCapacityTopologyLifecycleStateActive   ComputeCapacityTopologyLifecycleStateEnum = "ACTIVE"
+	ComputeCapacityTopologyLifecycleStateCreating ComputeCapacityTopologyLifecycleStateEnum = "CREATING"
+	ComputeCapacityTopologyLifecycleStateUpdating ComputeCapacityTopologyLifecycleStateEnum = "UPDATING"
+	ComputeCapacityTopologyLifecycleStateDeleted  ComputeCapacityTopologyLifecycleStateEnum = "DELETED"
+	ComputeCapacityTopologyLifecycleStateDeleting ComputeCapacityTopologyLifecycleStateEnum = "DELETING"
+)
+
+var mappingComputeCapacityTopologyLifecycleStateEnum = map[string]ComputeCapacityTopologyLifecycleStateEnum{
+	"ACTIVE":   ComputeCapacityTopologyLifecycleStateActive,
+	"CREATING": ComputeCapacityTopologyLifecycleStateCreating,
+	"UPDATING": ComputeCapacityTopologyLifecycleStateUpdating,
+	"DELETED":  ComputeCapacityTopologyLifecycleStateDeleted,
+	"DELETING": ComputeCapacityTopologyLifecycleStateDeleting,
+}
+
+var mappingComputeCapacityTopologyLifecycleStateEnumLowerCase = map[string]ComputeCapacityTopologyLifecycleStateEnum{
+	"active":   ComputeCapacityTopologyLifecycleStateActive,
+	"creating": ComputeCapacityTopologyLifecycleStateCreating,
+	"updating": ComputeCapacityTopologyLifecycleStateUpdating,
+	"deleted":  ComputeCapacityTopologyLifecycleStateDeleted,
+	"deleting": ComputeCapacityTopologyLifecycleStateDeleting,
+}
+
+// GetComputeCapacityTopologyLifecycleStateEnumValues Enumerates the set of values for ComputeCapacityTopologyLifecycleStateEnum
+func GetComputeCapacityTopologyLifecycleStateEnumValues() []ComputeCapacityTopologyLifecycleStateEnum {
+	values := make([]ComputeCapacityTopologyLifecycleStateEnum, 0)
+	for _, v := range mappingComputeCapacityTopologyLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetComputeCapacityTopologyLifecycleStateEnumStringValues Enumerates the set of values in String for ComputeCapacityTopologyLifecycleStateEnum
+func GetComputeCapacityTopologyLifecycleStateEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"CREATING",
+		"UPDATING",
+		"DELETED",
+		"DELETING",
+	}
+}
+
+// GetMappingComputeCapacityTopologyLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingComputeCapacityTopologyLifecycleStateEnum(val string) (ComputeCapacityTopologyLifecycleStateEnum, bool) {
+	enum, ok := mappingComputeCapacityTopologyLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_topology_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_topology_collection.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeCapacityTopologyCollection A list of compute capacity topologies.
+type ComputeCapacityTopologyCollection struct {
+
+	// The list of compute capacity topologies.
+	Items []ComputeCapacityTopologySummary `mandatory:"true" json:"items"`
+}
+
+func (m ComputeCapacityTopologyCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeCapacityTopologyCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_topology_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_capacity_topology_summary.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeCapacityTopologySummary Summary information for a compute capacity topology.
+type ComputeCapacityTopologySummary struct {
+
+	// The availability domain of the compute capacity topology.
+	// Example: `Uocm:US-CHICAGO-1-AD-2`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the compute capacity topology.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The current state of the compute capacity topology.
+	LifecycleState ComputeCapacityTopologyLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time that the compute capacity topology was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time that the compute capacity topology was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m ComputeCapacityTopologySummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeCapacityTopologySummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingComputeCapacityTopologyLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetComputeCapacityTopologyLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_cluster.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_cluster.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_cluster_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_cluster_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_cluster_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_cluster_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_global_image_capability_schema.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_global_image_capability_schema.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_global_image_capability_schema_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_global_image_capability_schema_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_global_image_capability_schema_version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_global_image_capability_schema_version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_global_image_capability_schema_version_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_global_image_capability_schema_version_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_hpc_island.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_hpc_island.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeHpcIsland A compute HPC island.
+type ComputeHpcIsland struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" json:"computeCapacityTopologyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute HPC island.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The current state of the compute HPC island.
+	LifecycleState ComputeHpcIslandLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time that the compute HPC island was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time that the compute HPC island was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// The total number of compute bare metal hosts located in this compute HPC island.
+	TotalComputeBareMetalHostCount *int64 `mandatory:"true" json:"totalComputeBareMetalHostCount"`
+}
+
+func (m ComputeHpcIsland) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeHpcIsland) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingComputeHpcIslandLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetComputeHpcIslandLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ComputeHpcIslandLifecycleStateEnum Enum with underlying type: string
+type ComputeHpcIslandLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ComputeHpcIslandLifecycleStateEnum
+const (
+	ComputeHpcIslandLifecycleStateActive   ComputeHpcIslandLifecycleStateEnum = "ACTIVE"
+	ComputeHpcIslandLifecycleStateInactive ComputeHpcIslandLifecycleStateEnum = "INACTIVE"
+)
+
+var mappingComputeHpcIslandLifecycleStateEnum = map[string]ComputeHpcIslandLifecycleStateEnum{
+	"ACTIVE":   ComputeHpcIslandLifecycleStateActive,
+	"INACTIVE": ComputeHpcIslandLifecycleStateInactive,
+}
+
+var mappingComputeHpcIslandLifecycleStateEnumLowerCase = map[string]ComputeHpcIslandLifecycleStateEnum{
+	"active":   ComputeHpcIslandLifecycleStateActive,
+	"inactive": ComputeHpcIslandLifecycleStateInactive,
+}
+
+// GetComputeHpcIslandLifecycleStateEnumValues Enumerates the set of values for ComputeHpcIslandLifecycleStateEnum
+func GetComputeHpcIslandLifecycleStateEnumValues() []ComputeHpcIslandLifecycleStateEnum {
+	values := make([]ComputeHpcIslandLifecycleStateEnum, 0)
+	for _, v := range mappingComputeHpcIslandLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetComputeHpcIslandLifecycleStateEnumStringValues Enumerates the set of values in String for ComputeHpcIslandLifecycleStateEnum
+func GetComputeHpcIslandLifecycleStateEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"INACTIVE",
+	}
+}
+
+// GetMappingComputeHpcIslandLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingComputeHpcIslandLifecycleStateEnum(val string) (ComputeHpcIslandLifecycleStateEnum, bool) {
+	enum, ok := mappingComputeHpcIslandLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_hpc_island_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_hpc_island_collection.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeHpcIslandCollection A list of compute HPC islands.
+type ComputeHpcIslandCollection struct {
+
+	// The list of compute HPC islands.
+	Items []ComputeHpcIslandSummary `mandatory:"true" json:"items"`
+}
+
+func (m ComputeHpcIslandCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeHpcIslandCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_hpc_island_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_hpc_island_summary.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeHpcIslandSummary Summary information for a compute HPC island.
+type ComputeHpcIslandSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" json:"computeCapacityTopologyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute HPC island.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The current state of the compute HPC island.
+	LifecycleState ComputeHpcIslandLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time that the compute HPC island was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time that the compute HPC island was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// The total number of compute bare metal hosts located in this compute HPC island.
+	TotalComputeBareMetalHostCount *int64 `mandatory:"true" json:"totalComputeBareMetalHostCount"`
+}
+
+func (m ComputeHpcIslandSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeHpcIslandSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingComputeHpcIslandLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetComputeHpcIslandLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_image_capability_schema.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_image_capability_schema.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_image_capability_schema_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_image_capability_schema_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_instance_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_instance_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_instance_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_network_block.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_network_block.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeNetworkBlock A compute network block.
+type ComputeNetworkBlock struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" json:"computeCapacityTopologyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute HPC island.
+	ComputeHpcIslandId *string `mandatory:"true" json:"computeHpcIslandId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute network block.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The current state of the compute network block.
+	LifecycleState ComputeNetworkBlockLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time that the compute network block was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time that the compute network block was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// The total number of compute bare metal hosts located in this compute network block.
+	TotalComputeBareMetalHostCount *int64 `mandatory:"true" json:"totalComputeBareMetalHostCount"`
+}
+
+func (m ComputeNetworkBlock) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeNetworkBlock) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingComputeNetworkBlockLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetComputeNetworkBlockLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ComputeNetworkBlockLifecycleStateEnum Enum with underlying type: string
+type ComputeNetworkBlockLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ComputeNetworkBlockLifecycleStateEnum
+const (
+	ComputeNetworkBlockLifecycleStateActive   ComputeNetworkBlockLifecycleStateEnum = "ACTIVE"
+	ComputeNetworkBlockLifecycleStateInactive ComputeNetworkBlockLifecycleStateEnum = "INACTIVE"
+)
+
+var mappingComputeNetworkBlockLifecycleStateEnum = map[string]ComputeNetworkBlockLifecycleStateEnum{
+	"ACTIVE":   ComputeNetworkBlockLifecycleStateActive,
+	"INACTIVE": ComputeNetworkBlockLifecycleStateInactive,
+}
+
+var mappingComputeNetworkBlockLifecycleStateEnumLowerCase = map[string]ComputeNetworkBlockLifecycleStateEnum{
+	"active":   ComputeNetworkBlockLifecycleStateActive,
+	"inactive": ComputeNetworkBlockLifecycleStateInactive,
+}
+
+// GetComputeNetworkBlockLifecycleStateEnumValues Enumerates the set of values for ComputeNetworkBlockLifecycleStateEnum
+func GetComputeNetworkBlockLifecycleStateEnumValues() []ComputeNetworkBlockLifecycleStateEnum {
+	values := make([]ComputeNetworkBlockLifecycleStateEnum, 0)
+	for _, v := range mappingComputeNetworkBlockLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetComputeNetworkBlockLifecycleStateEnumStringValues Enumerates the set of values in String for ComputeNetworkBlockLifecycleStateEnum
+func GetComputeNetworkBlockLifecycleStateEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"INACTIVE",
+	}
+}
+
+// GetMappingComputeNetworkBlockLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingComputeNetworkBlockLifecycleStateEnum(val string) (ComputeNetworkBlockLifecycleStateEnum, bool) {
+	enum, ok := mappingComputeNetworkBlockLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_network_block_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_network_block_collection.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeNetworkBlockCollection A list of compute network blocks.
+type ComputeNetworkBlockCollection struct {
+
+	// The list of compute network blocks.
+	Items []ComputeNetworkBlockSummary `mandatory:"true" json:"items"`
+}
+
+func (m ComputeNetworkBlockCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeNetworkBlockCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_network_block_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/compute_network_block_summary.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ComputeNetworkBlockSummary Summary information for a compute network block.
+type ComputeNetworkBlockSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" json:"computeCapacityTopologyId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute HPC island.
+	ComputeHpcIslandId *string `mandatory:"true" json:"computeHpcIslandId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute network block.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The current state of the compute network block.
+	LifecycleState ComputeNetworkBlockLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time that the compute network block was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time that the compute network block was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// The total number of compute bare metal hosts located in the compute network block.
+	TotalComputeBareMetalHostCount *int64 `mandatory:"true" json:"totalComputeBareMetalHostCount"`
+}
+
+func (m ComputeNetworkBlockSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ComputeNetworkBlockSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingComputeNetworkBlockLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetComputeNetworkBlockLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/connect_local_peering_gateways_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/connect_local_peering_gateways_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/connect_local_peering_gateways_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/connect_local_peering_gateways_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/connect_remote_peering_connections_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/connect_remote_peering_connections_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/connect_remote_peering_connections_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/connect_remote_peering_connections_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/console_history.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/console_history.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_boot_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_boot_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_boot_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_boot_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_volume_group_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_volume_group_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_volume_group_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/copy_volume_group_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/core_blockstorage_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/core_blockstorage_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -33,7 +33,7 @@ type BlockstorageClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewBlockstorageClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client BlockstorageClient, err error) {
 	if enabled := common.CheckForEnabledServices("core"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/core_compute_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/core_compute_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -33,7 +33,7 @@ type ComputeClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewComputeClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client ComputeClient, err error) {
 	if enabled := common.CheckForEnabledServices("core"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {
@@ -535,6 +535,70 @@ func (client ComputeClient) changeComputeCapacityReservationCompartment(ctx cont
 	if err != nil {
 		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityReservation/ChangeComputeCapacityReservationCompartment"
 		err = common.PostProcessServiceError(err, "Compute", "ChangeComputeCapacityReservationCompartment", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ChangeComputeCapacityTopologyCompartment Moves a compute capacity topology into a different compartment. For information about moving resources between
+// compartments, see Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ChangeComputeCapacityTopologyCompartment.go.html to see an example of how to use ChangeComputeCapacityTopologyCompartment API.
+// A default retry strategy applies to this operation ChangeComputeCapacityTopologyCompartment()
+func (client ComputeClient) ChangeComputeCapacityTopologyCompartment(ctx context.Context, request ChangeComputeCapacityTopologyCompartmentRequest) (response ChangeComputeCapacityTopologyCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeComputeCapacityTopologyCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeComputeCapacityTopologyCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeComputeCapacityTopologyCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeComputeCapacityTopologyCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeComputeCapacityTopologyCompartmentResponse")
+	}
+	return
+}
+
+// changeComputeCapacityTopologyCompartment implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) changeComputeCapacityTopologyCompartment(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/computeCapacityTopologies/{computeCapacityTopologyId}/actions/changeCompartment", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeComputeCapacityTopologyCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityTopology/ChangeComputeCapacityTopologyCompartment"
+		err = common.PostProcessServiceError(err, "Compute", "ChangeComputeCapacityTopologyCompartment", apiReferenceLink)
 		return response, err
 	}
 
@@ -1062,6 +1126,72 @@ func (client ComputeClient) createComputeCapacityReservation(ctx context.Context
 	return response, err
 }
 
+// CreateComputeCapacityTopology Creates a new compute capacity topology in the specified compartment and availability domain.
+// Compute capacity topologies provide the RDMA network topology of your bare metal hosts so that you can launch
+// instances on your bare metal hosts with targeted network locations.
+// Compute capacity topologies report the health status of your bare metal hosts.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/CreateComputeCapacityTopology.go.html to see an example of how to use CreateComputeCapacityTopology API.
+// A default retry strategy applies to this operation CreateComputeCapacityTopology()
+func (client ComputeClient) CreateComputeCapacityTopology(ctx context.Context, request CreateComputeCapacityTopologyRequest) (response CreateComputeCapacityTopologyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createComputeCapacityTopology, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateComputeCapacityTopologyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateComputeCapacityTopologyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateComputeCapacityTopologyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateComputeCapacityTopologyResponse")
+	}
+	return
+}
+
+// createComputeCapacityTopology implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) createComputeCapacityTopology(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/computeCapacityTopologies", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateComputeCapacityTopologyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := ""
+		err = common.PostProcessServiceError(err, "Compute", "CreateComputeCapacityTopology", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // CreateComputeCluster Creates an empty compute cluster (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/compute-clusters.htm). A compute cluster
 // is a remote direct memory access (RDMA) network group.
 // After the compute cluster is created, you can use the compute cluster's OCID with the
@@ -1512,6 +1642,64 @@ func (client ComputeClient) deleteComputeCapacityReservation(ctx context.Context
 	if err != nil {
 		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityReservation/DeleteComputeCapacityReservation"
 		err = common.PostProcessServiceError(err, "Compute", "DeleteComputeCapacityReservation", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteComputeCapacityTopology Deletes the specified compute capacity topology.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/DeleteComputeCapacityTopology.go.html to see an example of how to use DeleteComputeCapacityTopology API.
+// A default retry strategy applies to this operation DeleteComputeCapacityTopology()
+func (client ComputeClient) DeleteComputeCapacityTopology(ctx context.Context, request DeleteComputeCapacityTopologyRequest) (response DeleteComputeCapacityTopologyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteComputeCapacityTopology, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteComputeCapacityTopologyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteComputeCapacityTopologyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteComputeCapacityTopologyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteComputeCapacityTopologyResponse")
+	}
+	return
+}
+
+// deleteComputeCapacityTopology implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) deleteComputeCapacityTopology(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/computeCapacityTopologies/{computeCapacityTopologyId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteComputeCapacityTopologyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityTopology/DeleteComputeCapacityTopology"
+		err = common.PostProcessServiceError(err, "Compute", "DeleteComputeCapacityTopology", apiReferenceLink)
 		return response, err
 	}
 
@@ -2399,6 +2587,64 @@ func (client ComputeClient) getComputeCapacityReservation(ctx context.Context, r
 	if err != nil {
 		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityReservation/GetComputeCapacityReservation"
 		err = common.PostProcessServiceError(err, "Compute", "GetComputeCapacityReservation", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetComputeCapacityTopology Gets information about the specified compute capacity topology.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/GetComputeCapacityTopology.go.html to see an example of how to use GetComputeCapacityTopology API.
+// A default retry strategy applies to this operation GetComputeCapacityTopology()
+func (client ComputeClient) GetComputeCapacityTopology(ctx context.Context, request GetComputeCapacityTopologyRequest) (response GetComputeCapacityTopologyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getComputeCapacityTopology, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetComputeCapacityTopologyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetComputeCapacityTopologyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetComputeCapacityTopologyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetComputeCapacityTopologyResponse")
+	}
+	return
+}
+
+// getComputeCapacityTopology implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) getComputeCapacityTopology(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeCapacityTopologies/{computeCapacityTopologyId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetComputeCapacityTopologyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityTopology/GetComputeCapacityTopology"
+		err = common.PostProcessServiceError(err, "Compute", "GetComputeCapacityTopology", apiReferenceLink)
 		return response, err
 	}
 
@@ -3925,6 +4171,239 @@ func (client ComputeClient) listComputeCapacityReservations(ctx context.Context,
 	return response, err
 }
 
+// ListComputeCapacityTopologies Lists the compute capacity topologies in the specified compartment. You can filter the list by a compute
+// capacity topology display name.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListComputeCapacityTopologies.go.html to see an example of how to use ListComputeCapacityTopologies API.
+// A default retry strategy applies to this operation ListComputeCapacityTopologies()
+func (client ComputeClient) ListComputeCapacityTopologies(ctx context.Context, request ListComputeCapacityTopologiesRequest) (response ListComputeCapacityTopologiesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeCapacityTopologies, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeCapacityTopologiesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeCapacityTopologiesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeCapacityTopologiesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeCapacityTopologiesResponse")
+	}
+	return
+}
+
+// listComputeCapacityTopologies implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeCapacityTopologies(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeCapacityTopologies", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeCapacityTopologiesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityTopology/ListComputeCapacityTopologies"
+		err = common.PostProcessServiceError(err, "Compute", "ListComputeCapacityTopologies", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListComputeCapacityTopologyComputeBareMetalHosts Lists compute bare metal hosts in the specified compute capacity topology.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListComputeCapacityTopologyComputeBareMetalHosts.go.html to see an example of how to use ListComputeCapacityTopologyComputeBareMetalHosts API.
+// A default retry strategy applies to this operation ListComputeCapacityTopologyComputeBareMetalHosts()
+func (client ComputeClient) ListComputeCapacityTopologyComputeBareMetalHosts(ctx context.Context, request ListComputeCapacityTopologyComputeBareMetalHostsRequest) (response ListComputeCapacityTopologyComputeBareMetalHostsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeCapacityTopologyComputeBareMetalHosts, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeCapacityTopologyComputeBareMetalHostsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeCapacityTopologyComputeBareMetalHostsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeCapacityTopologyComputeBareMetalHostsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeCapacityTopologyComputeBareMetalHostsResponse")
+	}
+	return
+}
+
+// listComputeCapacityTopologyComputeBareMetalHosts implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeCapacityTopologyComputeBareMetalHosts(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeCapacityTopologies/{computeCapacityTopologyId}/computeBareMetalHosts", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeCapacityTopologyComputeBareMetalHostsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeBareMetalHost/ListComputeCapacityTopologyComputeBareMetalHosts"
+		err = common.PostProcessServiceError(err, "Compute", "ListComputeCapacityTopologyComputeBareMetalHosts", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListComputeCapacityTopologyComputeHpcIslands Lists compute HPC islands in the specified compute capacity topology.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListComputeCapacityTopologyComputeHpcIslands.go.html to see an example of how to use ListComputeCapacityTopologyComputeHpcIslands API.
+// A default retry strategy applies to this operation ListComputeCapacityTopologyComputeHpcIslands()
+func (client ComputeClient) ListComputeCapacityTopologyComputeHpcIslands(ctx context.Context, request ListComputeCapacityTopologyComputeHpcIslandsRequest) (response ListComputeCapacityTopologyComputeHpcIslandsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeCapacityTopologyComputeHpcIslands, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeCapacityTopologyComputeHpcIslandsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeCapacityTopologyComputeHpcIslandsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeCapacityTopologyComputeHpcIslandsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeCapacityTopologyComputeHpcIslandsResponse")
+	}
+	return
+}
+
+// listComputeCapacityTopologyComputeHpcIslands implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeCapacityTopologyComputeHpcIslands(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeCapacityTopologies/{computeCapacityTopologyId}/computeHpcIslands", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeCapacityTopologyComputeHpcIslandsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeHpcIsland/ListComputeCapacityTopologyComputeHpcIslands"
+		err = common.PostProcessServiceError(err, "Compute", "ListComputeCapacityTopologyComputeHpcIslands", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListComputeCapacityTopologyComputeNetworkBlocks Lists compute network blocks in the specified compute capacity topology.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListComputeCapacityTopologyComputeNetworkBlocks.go.html to see an example of how to use ListComputeCapacityTopologyComputeNetworkBlocks API.
+// A default retry strategy applies to this operation ListComputeCapacityTopologyComputeNetworkBlocks()
+func (client ComputeClient) ListComputeCapacityTopologyComputeNetworkBlocks(ctx context.Context, request ListComputeCapacityTopologyComputeNetworkBlocksRequest) (response ListComputeCapacityTopologyComputeNetworkBlocksResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeCapacityTopologyComputeNetworkBlocks, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeCapacityTopologyComputeNetworkBlocksResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeCapacityTopologyComputeNetworkBlocksResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeCapacityTopologyComputeNetworkBlocksResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeCapacityTopologyComputeNetworkBlocksResponse")
+	}
+	return
+}
+
+// listComputeCapacityTopologyComputeNetworkBlocks implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeCapacityTopologyComputeNetworkBlocks(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeCapacityTopologies/{computeCapacityTopologyId}/computeNetworkBlocks", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeCapacityTopologyComputeNetworkBlocksResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeNetworkBlock/ListComputeCapacityTopologyComputeNetworkBlocks"
+		err = common.PostProcessServiceError(err, "Compute", "ListComputeCapacityTopologyComputeNetworkBlocks", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ListComputeClusters Lists the compute clusters in the specified compartment.
 // A compute cluster (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/compute-clusters.htm) is a remote direct memory access (RDMA) network group.
 //
@@ -5110,6 +5589,64 @@ func (client ComputeClient) updateComputeCapacityReservation(ctx context.Context
 	if err != nil {
 		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityReservation/UpdateComputeCapacityReservation"
 		err = common.PostProcessServiceError(err, "Compute", "UpdateComputeCapacityReservation", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateComputeCapacityTopology Updates the specified compute capacity topology. Fields that are not provided in the request will not be updated.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/UpdateComputeCapacityTopology.go.html to see an example of how to use UpdateComputeCapacityTopology API.
+// A default retry strategy applies to this operation UpdateComputeCapacityTopology()
+func (client ComputeClient) UpdateComputeCapacityTopology(ctx context.Context, request UpdateComputeCapacityTopologyRequest) (response UpdateComputeCapacityTopologyResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateComputeCapacityTopology, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateComputeCapacityTopologyResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateComputeCapacityTopologyResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateComputeCapacityTopologyResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateComputeCapacityTopologyResponse")
+	}
+	return
+}
+
+// updateComputeCapacityTopology implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) updateComputeCapacityTopology(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/computeCapacityTopologies/{computeCapacityTopologyId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateComputeCapacityTopologyResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/iaas/20160918/ComputeCapacityTopology/UpdateComputeCapacityTopology"
+		err = common.PostProcessServiceError(err, "Compute", "UpdateComputeCapacityTopology", apiReferenceLink)
 		return response, err
 	}
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/core_computemanagement_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/core_computemanagement_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -33,7 +33,7 @@ type ComputeManagementClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewComputeManagementClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client ComputeManagementClient, err error) {
 	if enabled := common.CheckForEnabledServices("core"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/core_virtualnetwork_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/core_virtualnetwork_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -33,7 +33,7 @@ type VirtualNetworkClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewVirtualNetworkClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client VirtualNetworkClient, err error) {
 	if enabled := common.CheckForEnabledServices("core"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_config_answer.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_config_answer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_config_question.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_config_question.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_info.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_shape_detail.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_shape_detail.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_shape_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cpe_device_shape_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_app_catalog_subscription_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_app_catalog_subscription_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_app_catalog_subscription_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_app_catalog_subscription_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_boot_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_boot_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_boot_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_boot_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_boot_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_boot_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_boot_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_boot_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_byoip_range_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_byoip_range_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_byoip_range_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_byoip_range_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_capacity_report_shape_availability_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_capacity_report_shape_availability_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_capacity_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_capacity_source_details.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateCapacitySourceDetails A capacity source of bare metal hosts.
+type CreateCapacitySourceDetails interface {
+}
+
+type createcapacitysourcedetails struct {
+	JsonData     []byte
+	CapacityType string `json:"capacityType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *createcapacitysourcedetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalercreatecapacitysourcedetails createcapacitysourcedetails
+	s := struct {
+		Model Unmarshalercreatecapacitysourcedetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CapacityType = s.Model.CapacityType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *createcapacitysourcedetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.CapacityType {
+	case "DEDICATED":
+		mm := CreateDedicatedCapacitySourceDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for CreateCapacitySourceDetails: %s.", m.CapacityType)
+		return *m, nil
+	}
+}
+
+func (m createcapacitysourcedetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m createcapacitysourcedetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_capture_filter_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_capture_filter_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -46,6 +46,9 @@ type CreateCaptureFilterDetails struct {
 
 	// The set of rules governing what traffic a VTAP mirrors.
 	VtapCaptureFilterRules []VtapCaptureFilterRuleDetails `mandatory:"false" json:"vtapCaptureFilterRules"`
+
+	// The set of rules governing what traffic the VCN flow log collects.
+	FlowLogCaptureFilterRules []FlowLogCaptureFilterRuleDetails `mandatory:"false" json:"flowLogCaptureFilterRules"`
 }
 
 func (m CreateCaptureFilterDetails) String() string {
@@ -72,15 +75,18 @@ type CreateCaptureFilterDetailsFilterTypeEnum string
 
 // Set of constants representing the allowable values for CreateCaptureFilterDetailsFilterTypeEnum
 const (
-	CreateCaptureFilterDetailsFilterTypeVtap CreateCaptureFilterDetailsFilterTypeEnum = "VTAP"
+	CreateCaptureFilterDetailsFilterTypeVtap    CreateCaptureFilterDetailsFilterTypeEnum = "VTAP"
+	CreateCaptureFilterDetailsFilterTypeFlowlog CreateCaptureFilterDetailsFilterTypeEnum = "FLOWLOG"
 )
 
 var mappingCreateCaptureFilterDetailsFilterTypeEnum = map[string]CreateCaptureFilterDetailsFilterTypeEnum{
-	"VTAP": CreateCaptureFilterDetailsFilterTypeVtap,
+	"VTAP":    CreateCaptureFilterDetailsFilterTypeVtap,
+	"FLOWLOG": CreateCaptureFilterDetailsFilterTypeFlowlog,
 }
 
 var mappingCreateCaptureFilterDetailsFilterTypeEnumLowerCase = map[string]CreateCaptureFilterDetailsFilterTypeEnum{
-	"vtap": CreateCaptureFilterDetailsFilterTypeVtap,
+	"vtap":    CreateCaptureFilterDetailsFilterTypeVtap,
+	"flowlog": CreateCaptureFilterDetailsFilterTypeFlowlog,
 }
 
 // GetCreateCaptureFilterDetailsFilterTypeEnumValues Enumerates the set of values for CreateCaptureFilterDetailsFilterTypeEnum
@@ -96,6 +102,7 @@ func GetCreateCaptureFilterDetailsFilterTypeEnumValues() []CreateCaptureFilterDe
 func GetCreateCaptureFilterDetailsFilterTypeEnumStringValues() []string {
 	return []string{
 		"VTAP",
+		"FLOWLOG",
 	}
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_capture_filter_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_capture_filter_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cluster_network_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cluster_network_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cluster_network_instance_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cluster_network_instance_pool_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cluster_network_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cluster_network_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_report_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_report_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_report_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_report_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_reservation_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_reservation_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_reservation_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_reservation_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_topology_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_topology_details.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateComputeCapacityTopologyDetails The details for creating a new compute capacity topology.
+type CreateComputeCapacityTopologyDetails struct {
+
+	// The availability domain of this compute capacity topology.
+	// Example: `Uocm:US-CHICAGO-1-AD-2`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	CapacitySource CreateCapacitySourceDetails `mandatory:"true" json:"capacitySource"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains this compute capacity topology.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m CreateComputeCapacityTopologyDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateComputeCapacityTopologyDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateComputeCapacityTopologyDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DefinedTags        map[string]map[string]interface{} `json:"definedTags"`
+		DisplayName        *string                           `json:"displayName"`
+		FreeformTags       map[string]string                 `json:"freeformTags"`
+		AvailabilityDomain *string                           `json:"availabilityDomain"`
+		CapacitySource     createcapacitysourcedetails       `json:"capacitySource"`
+		CompartmentId      *string                           `json:"compartmentId"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DefinedTags = model.DefinedTags
+
+	m.DisplayName = model.DisplayName
+
+	m.FreeformTags = model.FreeformTags
+
+	m.AvailabilityDomain = model.AvailabilityDomain
+
+	nn, e = model.CapacitySource.UnmarshalPolymorphicJSON(model.CapacitySource.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.CapacitySource = nn.(CreateCapacitySourceDetails)
+	} else {
+		m.CapacitySource = nil
+	}
+
+	m.CompartmentId = model.CompartmentId
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_topology_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_capacity_topology_request_response.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateComputeCapacityTopologyRequest wrapper for the CreateComputeCapacityTopology operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/CreateComputeCapacityTopology.go.html to see an example of how to use CreateComputeCapacityTopologyRequest.
+type CreateComputeCapacityTopologyRequest struct {
+
+	// Details for creating a new compute capacity topology.
+	CreateComputeCapacityTopologyDetails `contributesTo:"body"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateComputeCapacityTopologyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateComputeCapacityTopologyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateComputeCapacityTopologyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateComputeCapacityTopologyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateComputeCapacityTopologyRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateComputeCapacityTopologyResponse wrapper for the CreateComputeCapacityTopology operation
+type CreateComputeCapacityTopologyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeCapacityTopology instance
+	ComputeCapacityTopology `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Location of the resource.
+	Location *string `presentIn:"header" name:"location"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
+	// Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/latest/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response CreateComputeCapacityTopologyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateComputeCapacityTopologyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_cluster_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_cluster_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_cluster_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_image_capability_schema_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_image_capability_schema_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_compute_image_capability_schema_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cpe_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cpe_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cpe_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cpe_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cross_connect_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cross_connect_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cross_connect_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cross_connect_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cross_connect_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cross_connect_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cross_connect_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_cross_connect_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dedicated_capacity_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dedicated_capacity_source_details.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateDedicatedCapacitySourceDetails A capacity source of bare metal hosts that is dedicated to a customer.
+type CreateDedicatedCapacitySourceDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment of this capacity source.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+}
+
+func (m CreateDedicatedCapacitySourceDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateDedicatedCapacitySourceDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m CreateDedicatedCapacitySourceDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeCreateDedicatedCapacitySourceDetails CreateDedicatedCapacitySourceDetails
+	s := struct {
+		DiscriminatorParam string `json:"capacityType"`
+		MarshalTypeCreateDedicatedCapacitySourceDetails
+	}{
+		"DEDICATED",
+		(MarshalTypeCreateDedicatedCapacitySourceDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dedicated_vm_host_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dedicated_vm_host_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dedicated_vm_host_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dedicated_vm_host_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dhcp_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dhcp_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dhcp_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_dhcp_options_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_attachment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_attachment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_route_distribution_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_route_distribution_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_route_distribution_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_route_distribution_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_route_table_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_route_table_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_route_table_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_drg_route_table_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_i_p_sec_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_i_p_sec_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_image_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_image_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_image_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_image_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_configuration_base.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_configuration_base.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_configuration_from_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_configuration_from_instance_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_configuration_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_configuration_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_console_connection_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_console_connection_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_console_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_console_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_pool_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_pool_placement_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_pool_placement_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_internet_gateway_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_internet_gateway_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_internet_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_internet_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ip_sec_connection_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ip_sec_connection_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ip_sec_connection_tunnel_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ip_sec_connection_tunnel_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ip_sec_tunnel_bgp_session_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ip_sec_tunnel_bgp_session_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ip_sec_tunnel_encryption_domain_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ip_sec_tunnel_encryption_domain_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ipv6_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ipv6_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ipv6_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_ipv6_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_local_peering_gateway_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_local_peering_gateway_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_local_peering_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_local_peering_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_macsec_key.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_macsec_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_macsec_properties.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_macsec_properties.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_nat_gateway_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_nat_gateway_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_nat_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_nat_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_network_security_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_network_security_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_network_security_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_network_security_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_private_ip_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_private_ip_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_private_ip_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_private_ip_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_public_ip_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_public_ip_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_public_ip_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_public_ip_pool_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_public_ip_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_public_ip_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_public_ip_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_public_ip_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_remote_peering_connection_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_remote_peering_connection_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_remote_peering_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_remote_peering_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_route_table_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_route_table_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_route_table_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_route_table_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_security_list_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_security_list_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_security_list_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_security_list_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_service_gateway_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_service_gateway_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_service_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_service_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_subnet_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_subnet_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_subnet_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_subnet_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vcn_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vcn_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vcn_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vcn_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_virtual_circuit_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_virtual_circuit_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_virtual_circuit_public_prefix_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_virtual_circuit_public_prefix_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_virtual_circuit_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_virtual_circuit_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vlan_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vlan_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vlan_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vlan_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vnic_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vnic_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_policy_assignment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_policy_assignment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_policy_assignment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_policy_assignment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_group_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_group_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_group_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_group_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vtap_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vtap_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vtap_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/create_vtap_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_group.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_group.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_location.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_location.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_mapping.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_mapping.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_mapping_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_mapping_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_mapping_details_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_mapping_details_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_port_speed_shape.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_port_speed_shape.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/cross_connect_status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_capacity_source.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_capacity_source.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// DedicatedCapacitySource A capacity source of bare metal hosts that is dedicated to a user.
+type DedicatedCapacitySource struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment of this capacity source.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+}
+
+func (m DedicatedCapacitySource) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m DedicatedCapacitySource) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m DedicatedCapacitySource) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeDedicatedCapacitySource DedicatedCapacitySource
+	s := struct {
+		DiscriminatorParam string `json:"capacityType"`
+		MarshalTypeDedicatedCapacitySource
+	}{
+		"DEDICATED",
+		(MarshalTypeDedicatedCapacitySource)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host_instance_shape_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host_instance_shape_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host_instance_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host_instance_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host_shape_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host_shape_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dedicated_vm_host_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/default_drg_route_tables.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/default_drg_route_tables.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/default_phase_one_parameters.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/default_phase_one_parameters.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/default_phase_two_parameters.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/default_phase_two_parameters.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_app_catalog_subscription_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_app_catalog_subscription_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_boot_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_boot_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_boot_volume_kms_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_boot_volume_kms_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_boot_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_boot_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_byoip_range_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_byoip_range_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_capture_filter_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_capture_filter_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_compute_capacity_reservation_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_compute_capacity_reservation_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_compute_capacity_topology_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_compute_capacity_topology_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteComputeCapacityTopologyRequest wrapper for the DeleteComputeCapacityTopology operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/DeleteComputeCapacityTopology.go.html to see an example of how to use DeleteComputeCapacityTopologyRequest.
+type DeleteComputeCapacityTopologyRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" contributesTo:"path" name:"computeCapacityTopologyId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteComputeCapacityTopologyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteComputeCapacityTopologyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteComputeCapacityTopologyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteComputeCapacityTopologyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteComputeCapacityTopologyRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteComputeCapacityTopologyResponse wrapper for the DeleteComputeCapacityTopology operation
+type DeleteComputeCapacityTopologyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
+	// Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/latest/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response DeleteComputeCapacityTopologyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteComputeCapacityTopologyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_compute_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_compute_cluster_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_compute_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_compute_image_capability_schema_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_console_history_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_console_history_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_cpe_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_cpe_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_cross_connect_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_cross_connect_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_cross_connect_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_cross_connect_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_dedicated_vm_host_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_dedicated_vm_host_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_dhcp_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_dhcp_options_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_drg_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_drg_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_drg_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_drg_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_drg_route_distribution_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_drg_route_distribution_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_drg_route_table_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_drg_route_table_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_i_p_sec_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_i_p_sec_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_image_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_image_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_instance_configuration_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_instance_configuration_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_instance_console_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_instance_console_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_internet_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_internet_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_ipv6_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_ipv6_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_local_peering_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_local_peering_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_nat_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_nat_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_network_security_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_network_security_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_private_ip_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_private_ip_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_public_ip_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_public_ip_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_public_ip_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_public_ip_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_remote_peering_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_remote_peering_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_route_table_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_route_table_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_security_list_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_security_list_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_service_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_service_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_subnet_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_subnet_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_vcn_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_vcn_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_virtual_circuit_public_prefix_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_virtual_circuit_public_prefix_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_virtual_circuit_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_virtual_circuit_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_vlan_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_vlan_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_backup_policy_assignment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_backup_policy_assignment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_backup_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_backup_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_group_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_group_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_kms_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_kms_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_vtap_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/delete_vtap_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_boot_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_boot_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_instance_pool_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_instance_pool_instance_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_instance_pool_instance_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_instance_pool_instance_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_load_balancer_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_load_balancer_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_service_id_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_service_id_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_vnic_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_vnic_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detach_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/detached_volume_autotune_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/detached_volume_autotune_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/device.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/device.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dhcp_dns_option.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dhcp_dns_option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dhcp_option.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dhcp_option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dhcp_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dhcp_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dhcp_search_domain_option.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dhcp_search_domain_option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/dpd_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/dpd_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_id_drg_route_distribution_match_criteria.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_id_drg_route_distribution_match_criteria.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_info.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_match_all_drg_route_distribution_match_criteria.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_match_all_drg_route_distribution_match_criteria.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_network_create_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_network_create_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_network_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_network_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_network_update_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_network_update_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_type_drg_route_distribution_match_criteria.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_attachment_type_drg_route_distribution_match_criteria.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_redundancy_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_redundancy_status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_distribution.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_distribution.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_distribution_match_criteria.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_distribution_match_criteria.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_distribution_statement.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_distribution_statement.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_table.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/drg_route_table.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/egress_security_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/egress_security_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/emulated_volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/emulated_volume_attachment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/encryption_domain_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/encryption_domain_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/encryption_in_transit_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/encryption_in_transit_type.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/enum_integer_image_capability_descriptor.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/enum_integer_image_capability_descriptor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/enum_string_image_capability_schema_descriptor.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/enum_string_image_capability_schema_descriptor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/export_image_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/export_image_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/export_image_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/export_image_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/export_image_via_object_storage_tuple_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/export_image_via_object_storage_tuple_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/export_image_via_object_storage_uri_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/export_image_via_object_storage_uri_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/fast_connect_provider_service.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/fast_connect_provider_service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/fast_connect_provider_service_key.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/fast_connect_provider_service_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/flow_log_capture_filter_rule_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/flow_log_capture_filter_rule_details.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// FlowLogCaptureFilterRuleDetails The set of rules governing what traffic the VCN flow log collects.
+type FlowLogCaptureFilterRuleDetails struct {
+
+	// Indicates whether a VCN flow log capture filter rule is enabled.
+	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
+
+	// A lower number indicates a higher priority, range 0-9. Each rule must have a distinct priority.
+	Priority *int `mandatory:"false" json:"priority"`
+
+	// Sampling interval as `1` of `X`, where `X` is an integer not greater than `100000`.
+	SamplingRate *int `mandatory:"false" json:"samplingRate"`
+
+	// Traffic from this CIDR will be captured in the VCN flow log.
+	SourceCidr *string `mandatory:"false" json:"sourceCidr"`
+
+	// Traffic to this CIDR will be captured in the VCN flow log.
+	DestinationCidr *string `mandatory:"false" json:"destinationCidr"`
+
+	// The transport protocol the filter uses.
+	Protocol *string `mandatory:"false" json:"protocol"`
+
+	IcmpOptions *IcmpOptions `mandatory:"false" json:"icmpOptions"`
+
+	TcpOptions *TcpOptions `mandatory:"false" json:"tcpOptions"`
+
+	UdpOptions *UdpOptions `mandatory:"false" json:"udpOptions"`
+
+	// Type or types of VCN flow logs to store. `ALL` includes records for both accepted traffic and
+	// rejected traffic.
+	FlowLogType FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum `mandatory:"false" json:"flowLogType,omitempty"`
+
+	// Include or exclude a `ruleAction` object.
+	RuleAction FlowLogCaptureFilterRuleDetailsRuleActionEnum `mandatory:"false" json:"ruleAction,omitempty"`
+}
+
+func (m FlowLogCaptureFilterRuleDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m FlowLogCaptureFilterRuleDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingFlowLogCaptureFilterRuleDetailsFlowLogTypeEnum(string(m.FlowLogType)); !ok && m.FlowLogType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for FlowLogType: %s. Supported values are: %s.", m.FlowLogType, strings.Join(GetFlowLogCaptureFilterRuleDetailsFlowLogTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingFlowLogCaptureFilterRuleDetailsRuleActionEnum(string(m.RuleAction)); !ok && m.RuleAction != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for RuleAction: %s. Supported values are: %s.", m.RuleAction, strings.Join(GetFlowLogCaptureFilterRuleDetailsRuleActionEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum Enum with underlying type: string
+type FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum string
+
+// Set of constants representing the allowable values for FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum
+const (
+	FlowLogCaptureFilterRuleDetailsFlowLogTypeAll    FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum = "ALL"
+	FlowLogCaptureFilterRuleDetailsFlowLogTypeReject FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum = "REJECT"
+	FlowLogCaptureFilterRuleDetailsFlowLogTypeAccept FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum = "ACCEPT"
+)
+
+var mappingFlowLogCaptureFilterRuleDetailsFlowLogTypeEnum = map[string]FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum{
+	"ALL":    FlowLogCaptureFilterRuleDetailsFlowLogTypeAll,
+	"REJECT": FlowLogCaptureFilterRuleDetailsFlowLogTypeReject,
+	"ACCEPT": FlowLogCaptureFilterRuleDetailsFlowLogTypeAccept,
+}
+
+var mappingFlowLogCaptureFilterRuleDetailsFlowLogTypeEnumLowerCase = map[string]FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum{
+	"all":    FlowLogCaptureFilterRuleDetailsFlowLogTypeAll,
+	"reject": FlowLogCaptureFilterRuleDetailsFlowLogTypeReject,
+	"accept": FlowLogCaptureFilterRuleDetailsFlowLogTypeAccept,
+}
+
+// GetFlowLogCaptureFilterRuleDetailsFlowLogTypeEnumValues Enumerates the set of values for FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum
+func GetFlowLogCaptureFilterRuleDetailsFlowLogTypeEnumValues() []FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum {
+	values := make([]FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum, 0)
+	for _, v := range mappingFlowLogCaptureFilterRuleDetailsFlowLogTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetFlowLogCaptureFilterRuleDetailsFlowLogTypeEnumStringValues Enumerates the set of values in String for FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum
+func GetFlowLogCaptureFilterRuleDetailsFlowLogTypeEnumStringValues() []string {
+	return []string{
+		"ALL",
+		"REJECT",
+		"ACCEPT",
+	}
+}
+
+// GetMappingFlowLogCaptureFilterRuleDetailsFlowLogTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingFlowLogCaptureFilterRuleDetailsFlowLogTypeEnum(val string) (FlowLogCaptureFilterRuleDetailsFlowLogTypeEnum, bool) {
+	enum, ok := mappingFlowLogCaptureFilterRuleDetailsFlowLogTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// FlowLogCaptureFilterRuleDetailsRuleActionEnum Enum with underlying type: string
+type FlowLogCaptureFilterRuleDetailsRuleActionEnum string
+
+// Set of constants representing the allowable values for FlowLogCaptureFilterRuleDetailsRuleActionEnum
+const (
+	FlowLogCaptureFilterRuleDetailsRuleActionInclude FlowLogCaptureFilterRuleDetailsRuleActionEnum = "INCLUDE"
+	FlowLogCaptureFilterRuleDetailsRuleActionExclude FlowLogCaptureFilterRuleDetailsRuleActionEnum = "EXCLUDE"
+)
+
+var mappingFlowLogCaptureFilterRuleDetailsRuleActionEnum = map[string]FlowLogCaptureFilterRuleDetailsRuleActionEnum{
+	"INCLUDE": FlowLogCaptureFilterRuleDetailsRuleActionInclude,
+	"EXCLUDE": FlowLogCaptureFilterRuleDetailsRuleActionExclude,
+}
+
+var mappingFlowLogCaptureFilterRuleDetailsRuleActionEnumLowerCase = map[string]FlowLogCaptureFilterRuleDetailsRuleActionEnum{
+	"include": FlowLogCaptureFilterRuleDetailsRuleActionInclude,
+	"exclude": FlowLogCaptureFilterRuleDetailsRuleActionExclude,
+}
+
+// GetFlowLogCaptureFilterRuleDetailsRuleActionEnumValues Enumerates the set of values for FlowLogCaptureFilterRuleDetailsRuleActionEnum
+func GetFlowLogCaptureFilterRuleDetailsRuleActionEnumValues() []FlowLogCaptureFilterRuleDetailsRuleActionEnum {
+	values := make([]FlowLogCaptureFilterRuleDetailsRuleActionEnum, 0)
+	for _, v := range mappingFlowLogCaptureFilterRuleDetailsRuleActionEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetFlowLogCaptureFilterRuleDetailsRuleActionEnumStringValues Enumerates the set of values in String for FlowLogCaptureFilterRuleDetailsRuleActionEnum
+func GetFlowLogCaptureFilterRuleDetailsRuleActionEnumStringValues() []string {
+	return []string{
+		"INCLUDE",
+		"EXCLUDE",
+	}
+}
+
+// GetMappingFlowLogCaptureFilterRuleDetailsRuleActionEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingFlowLogCaptureFilterRuleDetailsRuleActionEnum(val string) (FlowLogCaptureFilterRuleDetailsRuleActionEnum, bool) {
+	enum, ok := mappingFlowLogCaptureFilterRuleDetailsRuleActionEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/generic_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/generic_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/generic_bm_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/generic_bm_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_all_drg_attachments_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_all_drg_attachments_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_allowed_ike_i_p_sec_parameters_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_allowed_ike_i_p_sec_parameters_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_app_catalog_listing_agreements_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_app_catalog_listing_agreements_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_app_catalog_listing_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_app_catalog_listing_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_app_catalog_listing_resource_version_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_app_catalog_listing_resource_version_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_block_volume_replica_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_block_volume_replica_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_kms_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_kms_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_replica_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_replica_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_boot_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_byoip_range_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_byoip_range_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_capture_filter_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_capture_filter_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cluster_network_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cluster_network_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_capacity_reservation_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_capacity_reservation_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_capacity_topology_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_capacity_topology_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetComputeCapacityTopologyRequest wrapper for the GetComputeCapacityTopology operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/GetComputeCapacityTopology.go.html to see an example of how to use GetComputeCapacityTopologyRequest.
+type GetComputeCapacityTopologyRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" contributesTo:"path" name:"computeCapacityTopologyId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetComputeCapacityTopologyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetComputeCapacityTopologyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetComputeCapacityTopologyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetComputeCapacityTopologyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetComputeCapacityTopologyRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetComputeCapacityTopologyResponse wrapper for the GetComputeCapacityTopology operation
+type GetComputeCapacityTopologyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeCapacityTopology instance
+	ComputeCapacityTopology `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetComputeCapacityTopologyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetComputeCapacityTopologyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_cluster_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_global_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_global_image_capability_schema_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_global_image_capability_schema_version_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_global_image_capability_schema_version_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_compute_image_capability_schema_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_console_history_content_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_console_history_content_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_console_history_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_console_history_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cpe_device_config_content_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cpe_device_config_content_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cpe_device_shape_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cpe_device_shape_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cpe_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cpe_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cross_connect_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cross_connect_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cross_connect_letter_of_authority_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cross_connect_letter_of_authority_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cross_connect_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cross_connect_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cross_connect_status_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_cross_connect_status_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_dedicated_vm_host_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_dedicated_vm_host_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_dhcp_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_dhcp_options_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_redundancy_status_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_redundancy_status_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_route_distribution_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_route_distribution_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_route_table_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_drg_route_table_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_fast_connect_provider_service_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_fast_connect_provider_service_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_fast_connect_provider_service_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_fast_connect_provider_service_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_device_config_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_device_config_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_device_status_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_device_status_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_tunnel_error_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_tunnel_error_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_tunnel_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_tunnel_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_tunnel_shared_secret_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_i_p_sec_connection_tunnel_shared_secret_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_image_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_image_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_image_shape_compatibility_entry_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_image_shape_compatibility_entry_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_configuration_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_configuration_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_console_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_console_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_maintenance_reboot_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_maintenance_reboot_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_pool_instance_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_pool_instance_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_pool_load_balancer_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_pool_load_balancer_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_instance_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_internet_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_internet_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_ipsec_cpe_device_config_content_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_ipsec_cpe_device_config_content_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_ipv6_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_ipv6_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_local_peering_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_local_peering_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_measured_boot_report_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_measured_boot_report_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_nat_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_nat_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_network_security_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_network_security_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_networking_topology_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_networking_topology_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_private_ip_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_private_ip_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_by_ip_address_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_by_ip_address_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_by_ip_address_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_by_ip_address_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_by_private_ip_id_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_by_private_ip_id_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_by_private_ip_id_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_by_private_ip_id_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_public_ip_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_remote_peering_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_remote_peering_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_route_table_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_route_table_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_security_list_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_security_list_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_service_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_service_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_service_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_service_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_subnet_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_subnet_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_subnet_topology_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_subnet_topology_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_tunnel_cpe_device_config_content_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_tunnel_cpe_device_config_content_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_tunnel_cpe_device_config_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_tunnel_cpe_device_config_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_upgrade_status_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_upgrade_status_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vcn_dns_resolver_association_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vcn_dns_resolver_association_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vcn_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vcn_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vcn_topology_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vcn_topology_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_virtual_circuit_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_virtual_circuit_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vlan_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vlan_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vnic_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vnic_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vnic_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vnic_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_backup_policy_asset_assignment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_backup_policy_asset_assignment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_backup_policy_assignment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_backup_policy_assignment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_backup_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_backup_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_group_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_group_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_group_replica_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_group_replica_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_kms_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_kms_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vtap_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_vtap_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/get_windows_instance_initial_credentials_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/get_windows_instance_initial_credentials_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/i_scsi_volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/i_scsi_volume_attachment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/icmp_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/icmp_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image_capability_schema_descriptor.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image_capability_schema_descriptor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image_memory_constraints.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image_memory_constraints.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image_ocpu_constraints.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image_ocpu_constraints.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image_shape_compatibility_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image_shape_compatibility_entry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image_shape_compatibility_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image_shape_compatibility_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image_source_via_object_storage_tuple_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image_source_via_object_storage_tuple_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/image_source_via_object_storage_uri_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/image_source_via_object_storage_uri_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ingress_security_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ingress_security_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_action_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_action_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_agent_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_agent_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_agent_features.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_agent_features.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_agent_plugin_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_agent_plugin_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_availability_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_availability_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_milan_bm_gpu_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_milan_bm_gpu_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_milan_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_milan_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_rome_bm_gpu_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_rome_bm_gpu_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_rome_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_rome_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_vm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_amd_vm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_attach_vnic_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_attach_vnic_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_attach_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_attach_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_autotune_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_autotune_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_availability_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_availability_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_block_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_block_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_block_volume_replica_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_block_volume_replica_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_create_vnic_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_create_vnic_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_create_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_create_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_detached_volume_autotune_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_detached_volume_autotune_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_generic_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_generic_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_source_image_filter_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_source_image_filter_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_source_via_boot_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_source_via_boot_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_source_via_image_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_instance_source_via_image_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_intel_icelake_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_intel_icelake_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_intel_skylake_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_intel_skylake_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_intel_vm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_intel_vm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_ipv6_address_ipv6_subnet_cidr_pair_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_ipv6_address_ipv6_subnet_cidr_pair_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_iscsi_attach_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_iscsi_attach_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_instance_agent_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_instance_agent_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_instance_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_instance_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_instance_shape_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_launch_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_paravirtualized_attach_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_paravirtualized_attach_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_performance_based_autotune_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_performance_based_autotune_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_volume_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_volume_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_volume_source_from_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_volume_source_from_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_volume_source_from_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_configuration_volume_source_from_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_console_connection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_console_connection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_credentials.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_credentials.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_maintenance_reboot.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_maintenance_reboot.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_instance.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_instance.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_instance_load_balancer_backend.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_instance_load_balancer_backend.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_load_balancer_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_load_balancer_attachment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_configuration.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_ipv6_address_ipv6_subnet_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_ipv6_address_ipv6_subnet_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_primary_subnet.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_primary_subnet.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_secondary_vnic_subnet.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_secondary_vnic_subnet.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_subnet_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_placement_subnet_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_pool_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_power_action_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_power_action_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_reservation_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_reservation_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_reservation_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_reservation_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_reservation_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_reservation_shape_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_shape_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_shape_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_source_image_filter_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_source_image_filter_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_source_via_boot_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_source_via_boot_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_source_via_image_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_source_via_image_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/instance_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_icelake_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_icelake_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_icelake_bm_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_icelake_bm_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_skylake_bm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_skylake_bm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_skylake_bm_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_skylake_bm_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_vm_launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_vm_launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_vm_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/intel_vm_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/internet_gateway.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/internet_gateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_device_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_device_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_device_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_device_status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_tunnel.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_tunnel.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_tunnel_error_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_tunnel_error_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_tunnel_shared_secret.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ip_sec_connection_tunnel_shared_secret.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ipsec_tunnel_drg_attachment_network_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ipsec_tunnel_drg_attachment_network_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ipv6.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ipv6.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/ipv6_address_ipv6_subnet_cidr_pair_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/ipv6_address_ipv6_subnet_cidr_pair_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_agent_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_agent_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_availability_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_availability_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_configuration_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_configuration_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_instance_shape_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/launch_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/letter_of_authority.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/letter_of_authority.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_allowed_peer_regions_for_remote_peering_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_allowed_peer_regions_for_remote_peering_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_app_catalog_listing_resource_versions_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_app_catalog_listing_resource_versions_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_app_catalog_listings_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_app_catalog_listings_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_app_catalog_subscriptions_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_app_catalog_subscriptions_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_block_volume_replicas_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_block_volume_replicas_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_boot_volume_attachments_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_boot_volume_attachments_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_boot_volume_backups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_boot_volume_backups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_boot_volume_replicas_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_boot_volume_replicas_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_boot_volumes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_boot_volumes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_byoip_allocated_ranges_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_byoip_allocated_ranges_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_byoip_ranges_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_byoip_ranges_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_capture_filters_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_capture_filters_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -56,6 +56,9 @@ type ListCaptureFiltersRequest struct {
 	// The state value is case-insensitive.
 	LifecycleState CaptureFilterLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
 
+	// A filter to only return resources that match the given capture `filterType`. The `filterType` value is the string representation of enum - `VTAP`, `FLOWLOG`.
+	FilterType CaptureFilterFilterTypeEnum `mandatory:"false" contributesTo:"query" name:"filterType" omitEmpty:"true"`
+
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
 	RequestMetadata common.RequestMetadata
@@ -100,6 +103,9 @@ func (request ListCaptureFiltersRequest) ValidateEnumValue() (bool, error) {
 	}
 	if _, ok := GetMappingCaptureFilterLifecycleStateEnum(string(request.LifecycleState)); !ok && request.LifecycleState != "" {
 		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", request.LifecycleState, strings.Join(GetCaptureFilterLifecycleStateEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingCaptureFilterFilterTypeEnum(string(request.FilterType)); !ok && request.FilterType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for FilterType: %s. Supported values are: %s.", request.FilterType, strings.Join(GetCaptureFilterFilterTypeEnumStringValues(), ",")))
 	}
 	if len(errMessage) > 0 {
 		return true, fmt.Errorf(strings.Join(errMessage, "\n"))

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cluster_network_instances_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cluster_network_instances_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cluster_networks_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cluster_networks_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_reservation_instance_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_reservation_instance_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_reservation_instances_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_reservation_instances_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_reservations_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_reservations_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_topologies_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_topologies_request_response.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListComputeCapacityTopologiesRequest wrapper for the ListComputeCapacityTopologies operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListComputeCapacityTopologies.go.html to see an example of how to use ListComputeCapacityTopologiesRequest.
+type ListComputeCapacityTopologiesRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The name of the availability domain.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"false" contributesTo:"query" name:"availabilityDomain"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeCapacityTopologiesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeCapacityTopologiesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeCapacityTopologiesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeCapacityTopologiesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListComputeCapacityTopologiesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeCapacityTopologiesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListComputeCapacityTopologiesRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListComputeCapacityTopologiesSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListComputeCapacityTopologiesSortByEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListComputeCapacityTopologiesSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListComputeCapacityTopologiesSortOrderEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListComputeCapacityTopologiesResponse wrapper for the ListComputeCapacityTopologies operation
+type ListComputeCapacityTopologiesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ComputeCapacityTopologyCollection instances
+	ComputeCapacityTopologyCollection `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeCapacityTopologiesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeCapacityTopologiesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeCapacityTopologiesSortByEnum Enum with underlying type: string
+type ListComputeCapacityTopologiesSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeCapacityTopologiesSortByEnum
+const (
+	ListComputeCapacityTopologiesSortByTimecreated ListComputeCapacityTopologiesSortByEnum = "TIMECREATED"
+	ListComputeCapacityTopologiesSortByDisplayname ListComputeCapacityTopologiesSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeCapacityTopologiesSortByEnum = map[string]ListComputeCapacityTopologiesSortByEnum{
+	"TIMECREATED": ListComputeCapacityTopologiesSortByTimecreated,
+	"DISPLAYNAME": ListComputeCapacityTopologiesSortByDisplayname,
+}
+
+var mappingListComputeCapacityTopologiesSortByEnumLowerCase = map[string]ListComputeCapacityTopologiesSortByEnum{
+	"timecreated": ListComputeCapacityTopologiesSortByTimecreated,
+	"displayname": ListComputeCapacityTopologiesSortByDisplayname,
+}
+
+// GetListComputeCapacityTopologiesSortByEnumValues Enumerates the set of values for ListComputeCapacityTopologiesSortByEnum
+func GetListComputeCapacityTopologiesSortByEnumValues() []ListComputeCapacityTopologiesSortByEnum {
+	values := make([]ListComputeCapacityTopologiesSortByEnum, 0)
+	for _, v := range mappingListComputeCapacityTopologiesSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListComputeCapacityTopologiesSortByEnumStringValues Enumerates the set of values in String for ListComputeCapacityTopologiesSortByEnum
+func GetListComputeCapacityTopologiesSortByEnumStringValues() []string {
+	return []string{
+		"TIMECREATED",
+		"DISPLAYNAME",
+	}
+}
+
+// GetMappingListComputeCapacityTopologiesSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListComputeCapacityTopologiesSortByEnum(val string) (ListComputeCapacityTopologiesSortByEnum, bool) {
+	enum, ok := mappingListComputeCapacityTopologiesSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListComputeCapacityTopologiesSortOrderEnum Enum with underlying type: string
+type ListComputeCapacityTopologiesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeCapacityTopologiesSortOrderEnum
+const (
+	ListComputeCapacityTopologiesSortOrderAsc  ListComputeCapacityTopologiesSortOrderEnum = "ASC"
+	ListComputeCapacityTopologiesSortOrderDesc ListComputeCapacityTopologiesSortOrderEnum = "DESC"
+)
+
+var mappingListComputeCapacityTopologiesSortOrderEnum = map[string]ListComputeCapacityTopologiesSortOrderEnum{
+	"ASC":  ListComputeCapacityTopologiesSortOrderAsc,
+	"DESC": ListComputeCapacityTopologiesSortOrderDesc,
+}
+
+var mappingListComputeCapacityTopologiesSortOrderEnumLowerCase = map[string]ListComputeCapacityTopologiesSortOrderEnum{
+	"asc":  ListComputeCapacityTopologiesSortOrderAsc,
+	"desc": ListComputeCapacityTopologiesSortOrderDesc,
+}
+
+// GetListComputeCapacityTopologiesSortOrderEnumValues Enumerates the set of values for ListComputeCapacityTopologiesSortOrderEnum
+func GetListComputeCapacityTopologiesSortOrderEnumValues() []ListComputeCapacityTopologiesSortOrderEnum {
+	values := make([]ListComputeCapacityTopologiesSortOrderEnum, 0)
+	for _, v := range mappingListComputeCapacityTopologiesSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListComputeCapacityTopologiesSortOrderEnumStringValues Enumerates the set of values in String for ListComputeCapacityTopologiesSortOrderEnum
+func GetListComputeCapacityTopologiesSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListComputeCapacityTopologiesSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListComputeCapacityTopologiesSortOrderEnum(val string) (ListComputeCapacityTopologiesSortOrderEnum, bool) {
+	enum, ok := mappingListComputeCapacityTopologiesSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_topology_compute_bare_metal_hosts_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_topology_compute_bare_metal_hosts_request_response.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListComputeCapacityTopologyComputeBareMetalHostsRequest wrapper for the ListComputeCapacityTopologyComputeBareMetalHosts operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListComputeCapacityTopologyComputeBareMetalHosts.go.html to see an example of how to use ListComputeCapacityTopologyComputeBareMetalHostsRequest.
+type ListComputeCapacityTopologyComputeBareMetalHostsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" contributesTo:"path" name:"computeCapacityTopologyId"`
+
+	// The name of the availability domain.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"false" contributesTo:"query" name:"availabilityDomain"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute HPC island.
+	ComputeHpcIslandId *string `mandatory:"false" contributesTo:"query" name:"computeHpcIslandId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute network block.
+	ComputeNetworkBlockId *string `mandatory:"false" contributesTo:"query" name:"computeNetworkBlockId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute local block.
+	ComputeLocalBlockId *string `mandatory:"false" contributesTo:"query" name:"computeLocalBlockId"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeCapacityTopologyComputeBareMetalHostsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeCapacityTopologyComputeBareMetalHostsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListComputeCapacityTopologyComputeBareMetalHostsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeCapacityTopologyComputeBareMetalHostsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListComputeCapacityTopologyComputeBareMetalHostsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListComputeCapacityTopologyComputeBareMetalHostsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListComputeCapacityTopologyComputeBareMetalHostsSortByEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListComputeCapacityTopologyComputeBareMetalHostsResponse wrapper for the ListComputeCapacityTopologyComputeBareMetalHosts operation
+type ListComputeCapacityTopologyComputeBareMetalHostsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ComputeBareMetalHostCollection instances
+	ComputeBareMetalHostCollection `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeCapacityTopologyComputeBareMetalHostsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeCapacityTopologyComputeBareMetalHostsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum Enum with underlying type: string
+type ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum
+const (
+	ListComputeCapacityTopologyComputeBareMetalHostsSortByTimecreated ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum = "TIMECREATED"
+	ListComputeCapacityTopologyComputeBareMetalHostsSortByDisplayname ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeCapacityTopologyComputeBareMetalHostsSortByEnum = map[string]ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum{
+	"TIMECREATED": ListComputeCapacityTopologyComputeBareMetalHostsSortByTimecreated,
+	"DISPLAYNAME": ListComputeCapacityTopologyComputeBareMetalHostsSortByDisplayname,
+}
+
+var mappingListComputeCapacityTopologyComputeBareMetalHostsSortByEnumLowerCase = map[string]ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum{
+	"timecreated": ListComputeCapacityTopologyComputeBareMetalHostsSortByTimecreated,
+	"displayname": ListComputeCapacityTopologyComputeBareMetalHostsSortByDisplayname,
+}
+
+// GetListComputeCapacityTopologyComputeBareMetalHostsSortByEnumValues Enumerates the set of values for ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum
+func GetListComputeCapacityTopologyComputeBareMetalHostsSortByEnumValues() []ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum {
+	values := make([]ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum, 0)
+	for _, v := range mappingListComputeCapacityTopologyComputeBareMetalHostsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListComputeCapacityTopologyComputeBareMetalHostsSortByEnumStringValues Enumerates the set of values in String for ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum
+func GetListComputeCapacityTopologyComputeBareMetalHostsSortByEnumStringValues() []string {
+	return []string{
+		"TIMECREATED",
+		"DISPLAYNAME",
+	}
+}
+
+// GetMappingListComputeCapacityTopologyComputeBareMetalHostsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListComputeCapacityTopologyComputeBareMetalHostsSortByEnum(val string) (ListComputeCapacityTopologyComputeBareMetalHostsSortByEnum, bool) {
+	enum, ok := mappingListComputeCapacityTopologyComputeBareMetalHostsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum Enum with underlying type: string
+type ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum
+const (
+	ListComputeCapacityTopologyComputeBareMetalHostsSortOrderAsc  ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum = "ASC"
+	ListComputeCapacityTopologyComputeBareMetalHostsSortOrderDesc ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum = "DESC"
+)
+
+var mappingListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum = map[string]ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum{
+	"ASC":  ListComputeCapacityTopologyComputeBareMetalHostsSortOrderAsc,
+	"DESC": ListComputeCapacityTopologyComputeBareMetalHostsSortOrderDesc,
+}
+
+var mappingListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnumLowerCase = map[string]ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum{
+	"asc":  ListComputeCapacityTopologyComputeBareMetalHostsSortOrderAsc,
+	"desc": ListComputeCapacityTopologyComputeBareMetalHostsSortOrderDesc,
+}
+
+// GetListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnumValues Enumerates the set of values for ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum
+func GetListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnumValues() []ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum {
+	values := make([]ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum, 0)
+	for _, v := range mappingListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnumStringValues Enumerates the set of values in String for ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum
+func GetListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum(val string) (ListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnum, bool) {
+	enum, ok := mappingListComputeCapacityTopologyComputeBareMetalHostsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_topology_compute_hpc_islands_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_topology_compute_hpc_islands_request_response.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListComputeCapacityTopologyComputeHpcIslandsRequest wrapper for the ListComputeCapacityTopologyComputeHpcIslands operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListComputeCapacityTopologyComputeHpcIslands.go.html to see an example of how to use ListComputeCapacityTopologyComputeHpcIslandsRequest.
+type ListComputeCapacityTopologyComputeHpcIslandsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" contributesTo:"path" name:"computeCapacityTopologyId"`
+
+	// The name of the availability domain.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"false" contributesTo:"query" name:"availabilityDomain"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeCapacityTopologyComputeHpcIslandsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeCapacityTopologyComputeHpcIslandsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeCapacityTopologyComputeHpcIslandsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListComputeCapacityTopologyComputeHpcIslandsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeCapacityTopologyComputeHpcIslandsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListComputeCapacityTopologyComputeHpcIslandsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListComputeCapacityTopologyComputeHpcIslandsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListComputeCapacityTopologyComputeHpcIslandsSortByEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListComputeCapacityTopologyComputeHpcIslandsSortOrderEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListComputeCapacityTopologyComputeHpcIslandsResponse wrapper for the ListComputeCapacityTopologyComputeHpcIslands operation
+type ListComputeCapacityTopologyComputeHpcIslandsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ComputeHpcIslandCollection instances
+	ComputeHpcIslandCollection `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeCapacityTopologyComputeHpcIslandsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeCapacityTopologyComputeHpcIslandsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeCapacityTopologyComputeHpcIslandsSortByEnum Enum with underlying type: string
+type ListComputeCapacityTopologyComputeHpcIslandsSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeCapacityTopologyComputeHpcIslandsSortByEnum
+const (
+	ListComputeCapacityTopologyComputeHpcIslandsSortByTimecreated ListComputeCapacityTopologyComputeHpcIslandsSortByEnum = "TIMECREATED"
+	ListComputeCapacityTopologyComputeHpcIslandsSortByDisplayname ListComputeCapacityTopologyComputeHpcIslandsSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeCapacityTopologyComputeHpcIslandsSortByEnum = map[string]ListComputeCapacityTopologyComputeHpcIslandsSortByEnum{
+	"TIMECREATED": ListComputeCapacityTopologyComputeHpcIslandsSortByTimecreated,
+	"DISPLAYNAME": ListComputeCapacityTopologyComputeHpcIslandsSortByDisplayname,
+}
+
+var mappingListComputeCapacityTopologyComputeHpcIslandsSortByEnumLowerCase = map[string]ListComputeCapacityTopologyComputeHpcIslandsSortByEnum{
+	"timecreated": ListComputeCapacityTopologyComputeHpcIslandsSortByTimecreated,
+	"displayname": ListComputeCapacityTopologyComputeHpcIslandsSortByDisplayname,
+}
+
+// GetListComputeCapacityTopologyComputeHpcIslandsSortByEnumValues Enumerates the set of values for ListComputeCapacityTopologyComputeHpcIslandsSortByEnum
+func GetListComputeCapacityTopologyComputeHpcIslandsSortByEnumValues() []ListComputeCapacityTopologyComputeHpcIslandsSortByEnum {
+	values := make([]ListComputeCapacityTopologyComputeHpcIslandsSortByEnum, 0)
+	for _, v := range mappingListComputeCapacityTopologyComputeHpcIslandsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListComputeCapacityTopologyComputeHpcIslandsSortByEnumStringValues Enumerates the set of values in String for ListComputeCapacityTopologyComputeHpcIslandsSortByEnum
+func GetListComputeCapacityTopologyComputeHpcIslandsSortByEnumStringValues() []string {
+	return []string{
+		"TIMECREATED",
+		"DISPLAYNAME",
+	}
+}
+
+// GetMappingListComputeCapacityTopologyComputeHpcIslandsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListComputeCapacityTopologyComputeHpcIslandsSortByEnum(val string) (ListComputeCapacityTopologyComputeHpcIslandsSortByEnum, bool) {
+	enum, ok := mappingListComputeCapacityTopologyComputeHpcIslandsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum Enum with underlying type: string
+type ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum
+const (
+	ListComputeCapacityTopologyComputeHpcIslandsSortOrderAsc  ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum = "ASC"
+	ListComputeCapacityTopologyComputeHpcIslandsSortOrderDesc ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum = "DESC"
+)
+
+var mappingListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum = map[string]ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum{
+	"ASC":  ListComputeCapacityTopologyComputeHpcIslandsSortOrderAsc,
+	"DESC": ListComputeCapacityTopologyComputeHpcIslandsSortOrderDesc,
+}
+
+var mappingListComputeCapacityTopologyComputeHpcIslandsSortOrderEnumLowerCase = map[string]ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum{
+	"asc":  ListComputeCapacityTopologyComputeHpcIslandsSortOrderAsc,
+	"desc": ListComputeCapacityTopologyComputeHpcIslandsSortOrderDesc,
+}
+
+// GetListComputeCapacityTopologyComputeHpcIslandsSortOrderEnumValues Enumerates the set of values for ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum
+func GetListComputeCapacityTopologyComputeHpcIslandsSortOrderEnumValues() []ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum {
+	values := make([]ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum, 0)
+	for _, v := range mappingListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListComputeCapacityTopologyComputeHpcIslandsSortOrderEnumStringValues Enumerates the set of values in String for ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum
+func GetListComputeCapacityTopologyComputeHpcIslandsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum(val string) (ListComputeCapacityTopologyComputeHpcIslandsSortOrderEnum, bool) {
+	enum, ok := mappingListComputeCapacityTopologyComputeHpcIslandsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_topology_compute_network_blocks_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_capacity_topology_compute_network_blocks_request_response.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListComputeCapacityTopologyComputeNetworkBlocksRequest wrapper for the ListComputeCapacityTopologyComputeNetworkBlocks operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/ListComputeCapacityTopologyComputeNetworkBlocks.go.html to see an example of how to use ListComputeCapacityTopologyComputeNetworkBlocksRequest.
+type ListComputeCapacityTopologyComputeNetworkBlocksRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" contributesTo:"path" name:"computeCapacityTopologyId"`
+
+	// The name of the availability domain.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"false" contributesTo:"query" name:"availabilityDomain"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute HPC island.
+	ComputeHpcIslandId *string `mandatory:"false" contributesTo:"query" name:"computeHpcIslandId"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeCapacityTopologyComputeNetworkBlocksRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeCapacityTopologyComputeNetworkBlocksRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListComputeCapacityTopologyComputeNetworkBlocksRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeCapacityTopologyComputeNetworkBlocksRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListComputeCapacityTopologyComputeNetworkBlocksRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListComputeCapacityTopologyComputeNetworkBlocksSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListComputeCapacityTopologyComputeNetworkBlocksSortByEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListComputeCapacityTopologyComputeNetworkBlocksResponse wrapper for the ListComputeCapacityTopologyComputeNetworkBlocks operation
+type ListComputeCapacityTopologyComputeNetworkBlocksResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of ComputeNetworkBlockCollection instances
+	ComputeNetworkBlockCollection `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeCapacityTopologyComputeNetworkBlocksResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeCapacityTopologyComputeNetworkBlocksResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum Enum with underlying type: string
+type ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum
+const (
+	ListComputeCapacityTopologyComputeNetworkBlocksSortByTimecreated ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum = "TIMECREATED"
+	ListComputeCapacityTopologyComputeNetworkBlocksSortByDisplayname ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeCapacityTopologyComputeNetworkBlocksSortByEnum = map[string]ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum{
+	"TIMECREATED": ListComputeCapacityTopologyComputeNetworkBlocksSortByTimecreated,
+	"DISPLAYNAME": ListComputeCapacityTopologyComputeNetworkBlocksSortByDisplayname,
+}
+
+var mappingListComputeCapacityTopologyComputeNetworkBlocksSortByEnumLowerCase = map[string]ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum{
+	"timecreated": ListComputeCapacityTopologyComputeNetworkBlocksSortByTimecreated,
+	"displayname": ListComputeCapacityTopologyComputeNetworkBlocksSortByDisplayname,
+}
+
+// GetListComputeCapacityTopologyComputeNetworkBlocksSortByEnumValues Enumerates the set of values for ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum
+func GetListComputeCapacityTopologyComputeNetworkBlocksSortByEnumValues() []ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum {
+	values := make([]ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum, 0)
+	for _, v := range mappingListComputeCapacityTopologyComputeNetworkBlocksSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListComputeCapacityTopologyComputeNetworkBlocksSortByEnumStringValues Enumerates the set of values in String for ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum
+func GetListComputeCapacityTopologyComputeNetworkBlocksSortByEnumStringValues() []string {
+	return []string{
+		"TIMECREATED",
+		"DISPLAYNAME",
+	}
+}
+
+// GetMappingListComputeCapacityTopologyComputeNetworkBlocksSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListComputeCapacityTopologyComputeNetworkBlocksSortByEnum(val string) (ListComputeCapacityTopologyComputeNetworkBlocksSortByEnum, bool) {
+	enum, ok := mappingListComputeCapacityTopologyComputeNetworkBlocksSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum Enum with underlying type: string
+type ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum
+const (
+	ListComputeCapacityTopologyComputeNetworkBlocksSortOrderAsc  ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum = "ASC"
+	ListComputeCapacityTopologyComputeNetworkBlocksSortOrderDesc ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum = "DESC"
+)
+
+var mappingListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum = map[string]ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum{
+	"ASC":  ListComputeCapacityTopologyComputeNetworkBlocksSortOrderAsc,
+	"DESC": ListComputeCapacityTopologyComputeNetworkBlocksSortOrderDesc,
+}
+
+var mappingListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnumLowerCase = map[string]ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum{
+	"asc":  ListComputeCapacityTopologyComputeNetworkBlocksSortOrderAsc,
+	"desc": ListComputeCapacityTopologyComputeNetworkBlocksSortOrderDesc,
+}
+
+// GetListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnumValues Enumerates the set of values for ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum
+func GetListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnumValues() []ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum {
+	values := make([]ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum, 0)
+	for _, v := range mappingListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnumStringValues Enumerates the set of values in String for ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum
+func GetListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum(val string) (ListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnum, bool) {
+	enum, ok := mappingListComputeCapacityTopologyComputeNetworkBlocksSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_clusters_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_clusters_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_global_image_capability_schema_versions_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_global_image_capability_schema_versions_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_global_image_capability_schemas_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_global_image_capability_schemas_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_image_capability_schemas_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_compute_image_capability_schemas_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_console_histories_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_console_histories_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cpe_device_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cpe_device_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cpes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cpes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cross_connect_groups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cross_connect_groups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cross_connect_locations_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cross_connect_locations_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cross_connect_mappings_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cross_connect_mappings_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cross_connects_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_cross_connects_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_crossconnect_port_speed_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_crossconnect_port_speed_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dedicated_vm_host_instance_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dedicated_vm_host_instance_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dedicated_vm_host_instances_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dedicated_vm_host_instances_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dedicated_vm_host_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dedicated_vm_host_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dedicated_vm_hosts_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dedicated_vm_hosts_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dhcp_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_dhcp_options_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_attachments_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_attachments_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_route_distribution_statements_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_route_distribution_statements_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_route_distributions_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_route_distributions_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_route_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_route_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_route_tables_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drg_route_tables_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drgs_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_drgs_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_fast_connect_provider_services_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_fast_connect_provider_services_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_fast_connect_provider_virtual_circuit_bandwidth_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_fast_connect_provider_virtual_circuit_bandwidth_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_i_p_sec_connection_tunnel_routes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_i_p_sec_connection_tunnel_routes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_i_p_sec_connection_tunnel_security_associations_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_i_p_sec_connection_tunnel_security_associations_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_i_p_sec_connection_tunnels_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_i_p_sec_connection_tunnels_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_i_p_sec_connections_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_i_p_sec_connections_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_image_shape_compatibility_entries_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_image_shape_compatibility_entries_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_images_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_images_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_configurations_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_configurations_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_console_connections_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_console_connections_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_devices_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_devices_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_pool_instances_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_pool_instances_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_pools_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instance_pools_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instances_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_instances_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_internet_gateways_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_internet_gateways_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_ipv6s_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_ipv6s_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_local_peering_gateways_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_local_peering_gateways_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_nat_gateways_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_nat_gateways_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_network_security_group_security_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_network_security_group_security_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_network_security_group_vnics_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_network_security_group_vnics_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_network_security_groups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_network_security_groups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_private_ips_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_private_ips_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_public_ip_pools_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_public_ip_pools_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_public_ips_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_public_ips_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_remote_peering_connections_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_remote_peering_connections_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_route_tables_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_route_tables_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_security_lists_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_security_lists_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_service_gateways_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_service_gateways_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_services_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_services_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_subnets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_subnets_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_vcns_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_vcns_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_virtual_circuit_associated_tunnels_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_virtual_circuit_associated_tunnels_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_virtual_circuit_bandwidth_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_virtual_circuit_bandwidth_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_virtual_circuit_public_prefixes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_virtual_circuit_public_prefixes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_virtual_circuits_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_virtual_circuits_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_vlans_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_vlans_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_vnic_attachments_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_vnic_attachments_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_attachments_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_attachments_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_backup_policies_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_backup_policies_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_backups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_backups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_group_backups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_group_backups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_group_replicas_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_group_replicas_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_groups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volume_groups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volumes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_volumes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/list_vtaps_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/list_vtaps_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/local_peering_gateway.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/local_peering_gateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/loop_back_drg_attachment_network_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/loop_back_drg_attachment_network_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/macsec_encryption_cipher.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/macsec_encryption_cipher.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/macsec_key.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/macsec_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/macsec_properties.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/macsec_properties.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/macsec_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/macsec_state.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/measured_boot_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/measured_boot_entry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/measured_boot_report.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/measured_boot_report.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/measured_boot_report_measurements.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/measured_boot_report_measurements.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/member_replica.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/member_replica.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/modify_vcn_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/modify_vcn_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/modify_vcn_cidr_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/modify_vcn_cidr_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/multipath_device.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/multipath_device.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/nat_gateway.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/nat_gateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/network_security_group.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/network_security_group.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/network_security_group_vnic.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/network_security_group_vnic.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/networking_topology.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/networking_topology.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/paravirtualized_volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/paravirtualized_volume_attachment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/peer_region_for_remote_peering.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/peer_region_for_remote_peering.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/percentage_of_cores_enabled_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/percentage_of_cores_enabled_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/performance_based_autotune_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/performance_based_autotune_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/phase_one_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/phase_one_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/phase_two_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/phase_two_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/platform_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/platform_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/port_range.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/port_range.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/preemptible_instance_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/preemptible_instance_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/preemption_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/preemption_action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/private_ip.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/private_ip.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/public_ip.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/public_ip.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/public_ip_pool.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/public_ip_pool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/public_ip_pool_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/public_ip_pool_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/public_ip_pool_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/public_ip_pool_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/reboot_migrate_action_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/reboot_migrate_action_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remote_peering_connection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remote_peering_connection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remote_peering_connection_drg_attachment_network_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remote_peering_connection_drg_attachment_network_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_drg_route_distribution_statements_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_drg_route_distribution_statements_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_drg_route_distribution_statements_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_drg_route_distribution_statements_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_drg_route_rules_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_drg_route_rules_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_drg_route_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_drg_route_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_export_drg_route_distribution_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_export_drg_route_distribution_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_image_shape_compatibility_entry_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_image_shape_compatibility_entry_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_import_drg_route_distribution_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_import_drg_route_distribution_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_ipv6_subnet_cidr_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_ipv6_subnet_cidr_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_ipv6_vcn_cidr_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_ipv6_vcn_cidr_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_network_security_group_security_rules_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_network_security_group_security_rules_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_network_security_group_security_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_network_security_group_security_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_public_ip_pool_capacity_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_public_ip_pool_capacity_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_public_ip_pool_capacity_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_public_ip_pool_capacity_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_subnet_ipv6_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_subnet_ipv6_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_vcn_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_vcn_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_vcn_cidr_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_vcn_cidr_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_vcn_ipv6_cidr_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/remove_vcn_ipv6_cidr_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/reset_action_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/reset_action_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/reset_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/reset_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/route_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/route_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/route_table.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/route_table.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/security_list.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/security_list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/security_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/security_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/service.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/service_gateway.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/service_gateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/service_id_request_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/service_id_request_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/service_id_response_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/service_id_response_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_access_control_service_enabled_platform_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_access_control_service_enabled_platform_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_alternative_object.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_alternative_object.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_input_output_memory_management_unit_enabled_platform_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_input_output_memory_management_unit_enabled_platform_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_max_vnic_attachment_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_max_vnic_attachment_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_measured_boot_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_measured_boot_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_memory_encryption_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_memory_encryption_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_memory_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_memory_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_networking_bandwidth_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_networking_bandwidth_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_numa_nodes_per_socket_platform_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_numa_nodes_per_socket_platform_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_ocpu_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_ocpu_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_platform_config_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_platform_config_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_secure_boot_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_secure_boot_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_symmetric_multi_threading_enabled_platform_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_symmetric_multi_threading_enabled_platform_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_trusted_platform_module_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_trusted_platform_module_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_virtual_instructions_enabled_platform_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/shape_virtual_instructions_enabled_platform_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/soft_reset_action_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/soft_reset_action_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/softreset_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/softreset_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/softstop_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/softstop_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/start_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/start_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/stop_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/stop_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/subnet.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/subnet.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/subnet_topology.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/subnet_topology.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/tcp_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/tcp_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/terminate_cluster_network_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/terminate_cluster_network_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/terminate_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/terminate_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/terminate_instance_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/terminate_instance_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/terminate_preemption_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/terminate_preemption_action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/topology.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/topology.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_associated_with_entity_relationship.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_associated_with_entity_relationship.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_associated_with_relationship_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_associated_with_relationship_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_contains_entity_relationship.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_contains_entity_relationship.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_entity_relationship.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_entity_relationship.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_routes_to_entity_relationship.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_routes_to_entity_relationship.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_routes_to_relationship_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/topology_routes_to_relationship_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_cpe_device_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_cpe_device_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_phase_one_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_phase_one_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_phase_two_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_phase_two_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_route_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_route_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_security_association_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_security_association_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/tunnel_status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/udp_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/udp_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_kms_key_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_kms_key_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_kms_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_kms_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_boot_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_byoip_range_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_byoip_range_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_byoip_range_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_byoip_range_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_capacity_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_capacity_source_details.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateCapacitySourceDetails A capacity source of bare metal hosts.
+type UpdateCapacitySourceDetails interface {
+}
+
+type updatecapacitysourcedetails struct {
+	JsonData     []byte
+	CapacityType string `json:"capacityType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *updatecapacitysourcedetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerupdatecapacitysourcedetails updatecapacitysourcedetails
+	s := struct {
+		Model Unmarshalerupdatecapacitysourcedetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CapacityType = s.Model.CapacityType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *updatecapacitysourcedetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.CapacityType {
+	case "DEDICATED":
+		mm := UpdateDedicatedCapacitySourceDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for UpdateCapacitySourceDetails: %s.", m.CapacityType)
+		return *m, nil
+	}
+}
+
+func (m updatecapacitysourcedetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m updatecapacitysourcedetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_capture_filter_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_capture_filter_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -35,6 +35,9 @@ type UpdateCaptureFilterDetails struct {
 
 	// The set of rules governing what traffic a VTAP mirrors.
 	VtapCaptureFilterRules []VtapCaptureFilterRuleDetails `mandatory:"false" json:"vtapCaptureFilterRules"`
+
+	// The set of rules governing what traffic the VCN flow log collects.
+	FlowLogCaptureFilterRules []FlowLogCaptureFilterRuleDetails `mandatory:"false" json:"flowLogCaptureFilterRules"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
 	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_capture_filter_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_capture_filter_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cluster_network_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cluster_network_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cluster_network_instance_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cluster_network_instance_pool_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cluster_network_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cluster_network_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_capacity_reservation_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_capacity_reservation_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_capacity_reservation_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_capacity_reservation_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_capacity_topology_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_capacity_topology_details.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateComputeCapacityTopologyDetails The details for updating the compute capacity topology.
+type UpdateComputeCapacityTopologyDetails struct {
+	CapacitySource UpdateCapacitySourceDetails `mandatory:"false" json:"capacitySource"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m UpdateComputeCapacityTopologyDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateComputeCapacityTopologyDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateComputeCapacityTopologyDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		CapacitySource updatecapacitysourcedetails       `json:"capacitySource"`
+		DefinedTags    map[string]map[string]interface{} `json:"definedTags"`
+		DisplayName    *string                           `json:"displayName"`
+		FreeformTags   map[string]string                 `json:"freeformTags"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	nn, e = model.CapacitySource.UnmarshalPolymorphicJSON(model.CapacitySource.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.CapacitySource = nn.(UpdateCapacitySourceDetails)
+	} else {
+		m.CapacitySource = nil
+	}
+
+	m.DefinedTags = model.DefinedTags
+
+	m.DisplayName = model.DisplayName
+
+	m.FreeformTags = model.FreeformTags
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_capacity_topology_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_capacity_topology_request_response.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateComputeCapacityTopologyRequest wrapper for the UpdateComputeCapacityTopology operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/core/UpdateComputeCapacityTopology.go.html to see an example of how to use UpdateComputeCapacityTopologyRequest.
+type UpdateComputeCapacityTopologyRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute capacity topology.
+	ComputeCapacityTopologyId *string `mandatory:"true" contributesTo:"path" name:"computeCapacityTopologyId"`
+
+	// Update compute capacity topology details.
+	UpdateComputeCapacityTopologyDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateComputeCapacityTopologyRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateComputeCapacityTopologyRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateComputeCapacityTopologyRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateComputeCapacityTopologyRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateComputeCapacityTopologyRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateComputeCapacityTopologyResponse wrapper for the UpdateComputeCapacityTopology operation
+type UpdateComputeCapacityTopologyResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
+	// Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/latest/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response UpdateComputeCapacityTopologyResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateComputeCapacityTopologyResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_cluster_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_cluster_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_cluster_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_image_capability_schema_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_image_capability_schema_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_compute_image_capability_schema_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_console_history_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_console_history_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_console_history_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_console_history_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cpe_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cpe_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cpe_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cpe_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cross_connect_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cross_connect_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cross_connect_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cross_connect_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cross_connect_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cross_connect_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cross_connect_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_cross_connect_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dedicated_capacity_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dedicated_capacity_source_details.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// Use the Core Services API to manage resources such as virtual cloud networks (VCNs),
+// compute instances, and block storage volumes. For more information, see the console
+// documentation for the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services.
+// The required permissions are documented in the
+// Details for the Core Services (https://docs.cloud.oracle.com/iaas/Content/Identity/Reference/corepolicyreference.htm) article.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateDedicatedCapacitySourceDetails A capacity source of bare metal hosts that is dedicated to a user.
+type UpdateDedicatedCapacitySourceDetails struct {
+}
+
+func (m UpdateDedicatedCapacitySourceDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateDedicatedCapacitySourceDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m UpdateDedicatedCapacitySourceDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeUpdateDedicatedCapacitySourceDetails UpdateDedicatedCapacitySourceDetails
+	s := struct {
+		DiscriminatorParam string `json:"capacityType"`
+		MarshalTypeUpdateDedicatedCapacitySourceDetails
+	}{
+		"DEDICATED",
+		(MarshalTypeUpdateDedicatedCapacitySourceDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dedicated_vm_host_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dedicated_vm_host_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dedicated_vm_host_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dedicated_vm_host_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dhcp_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dhcp_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dhcp_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_dhcp_options_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_attachment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_attachment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_statement_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_statement_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_statements_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_statements_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_statements_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_distribution_statements_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_rule_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_rule_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_rules_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_rules_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_table_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_table_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_table_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_drg_route_table_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_i_p_sec_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_i_p_sec_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_i_p_sec_connection_tunnel_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_i_p_sec_connection_tunnel_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_i_p_sec_connection_tunnel_shared_secret_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_i_p_sec_connection_tunnel_shared_secret_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_image_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_image_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_image_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_image_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_agent_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_agent_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_availability_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_availability_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_configuration_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_configuration_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_console_connection_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_console_connection_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_console_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_console_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -124,6 +124,12 @@ type UpdateInstanceDetails struct {
 	// Infrastructure Maintenance (https://docs.cloud.oracle.com/iaas/Content/Compute/References/infrastructure-maintenance.htm).
 	// Example: `2018-05-25T21:10:29.600Z`
 	TimeMaintenanceRebootDue *common.SDKTime `mandatory:"false" json:"timeMaintenanceRebootDue"`
+
+	// The OCID of the dedicated virtual machine host to place the instance on.
+	// Supported only if this VM instance was already placed on a dedicated virtual machine host
+	// - that is, you can't move an instance from on-demand capacity to dedicated capacity,
+	// nor can you move an instance from dedicated capacity to on-demand capacity.
+	DedicatedVmHostId *string `mandatory:"false" json:"dedicatedVmHostId"`
 }
 
 func (m UpdateInstanceDetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_pool_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_pool_placement_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_pool_placement_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_instance_shape_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_internet_gateway_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_internet_gateway_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_internet_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_internet_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_connection_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_connection_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_connection_tunnel_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_connection_tunnel_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_connection_tunnel_shared_secret_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_connection_tunnel_shared_secret_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_tunnel_bgp_session_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_tunnel_bgp_session_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_tunnel_encryption_domain_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ip_sec_tunnel_encryption_domain_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ipv6_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ipv6_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ipv6_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_ipv6_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_launch_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_launch_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_local_peering_gateway_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_local_peering_gateway_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_local_peering_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_local_peering_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_macsec_key.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_macsec_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_macsec_properties.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_macsec_properties.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_nat_gateway_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_nat_gateway_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_nat_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_nat_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_network_security_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_network_security_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_network_security_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_network_security_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_network_security_group_security_rules_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_network_security_group_security_rules_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_network_security_group_security_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_network_security_group_security_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_private_ip_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_private_ip_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_private_ip_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_private_ip_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_public_ip_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_public_ip_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_public_ip_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_public_ip_pool_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_public_ip_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_public_ip_pool_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_public_ip_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_public_ip_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_remote_peering_connection_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_remote_peering_connection_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_remote_peering_connection_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_remote_peering_connection_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_route_table_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_route_table_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_route_table_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_route_table_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_security_list_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_security_list_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_security_list_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_security_list_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_security_rule_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_security_rule_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_service_gateway_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_service_gateway_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_service_gateway_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_service_gateway_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_subnet_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_subnet_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_subnet_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_subnet_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_tunnel_cpe_device_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_tunnel_cpe_device_config_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_tunnel_cpe_device_config_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_tunnel_cpe_device_config_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vcn_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vcn_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vcn_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vcn_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_virtual_circuit_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_virtual_circuit_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_virtual_circuit_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_virtual_circuit_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vlan_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vlan_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vlan_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vlan_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vnic_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vnic_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vnic_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vnic_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_attachment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_attachment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_attachment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_attachment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_backup_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_backup_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_backup_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_backup_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_group_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_group_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_group_backup_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_group_backup_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_kms_key_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_kms_key_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_kms_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_kms_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_volume_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vtap_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vtap_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vtap_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/update_vtap_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/updated_network_security_group_security_rules.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/updated_network_security_group_security_rules.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/upgrade_drg_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/upgrade_drg_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/upgrade_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/upgrade_status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/validate_byoip_range_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/validate_byoip_range_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_dns_resolver_association.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_dns_resolver_association.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_drg_attachment_network_create_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_drg_attachment_network_create_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_drg_attachment_network_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_drg_attachment_network_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_drg_attachment_network_update_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_drg_attachment_network_update_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_topology.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vcn_topology.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_associated_tunnel_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_associated_tunnel_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_bandwidth_shape.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_bandwidth_shape.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_drg_attachment_network_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_drg_attachment_network_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_ip_mtu.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_ip_mtu.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_public_prefix.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/virtual_circuit_public_prefix.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vlan.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vlan.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vnic.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vnic.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vnic_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vnic_attachment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_attachment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_backup.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_backup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_backup_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_backup_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_backup_policy_assignment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_backup_policy_assignment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_backup_schedule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_backup_schedule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_backup.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_backup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_replica.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_replica.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_replica_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_replica_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_replica_info.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_replica_info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_from_volume_group_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_from_volume_group_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_from_volume_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_from_volume_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_from_volume_group_replica_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_from_volume_group_replica_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_from_volumes_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_group_source_from_volumes_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_kms_key.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_kms_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_source_from_block_volume_replica_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_source_from_block_volume_replica_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_source_from_volume_backup_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_source_from_volume_backup_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_source_from_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/volume_source_from_volume_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vtap.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vtap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/vtap_capture_filter_rule_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/vtap_capture_filter_rule_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/core/withdraw_byoip_range_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/core/withdraw_byoip_range_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_file_system_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_file_system_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_file_system_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_file_system_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_filesystem_snapshot_policy_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_filesystem_snapshot_policy_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_filesystem_snapshot_policy_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_filesystem_snapshot_policy_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_mount_target_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_mount_target_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_mount_target_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_mount_target_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_outbound_connector_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_outbound_connector_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_outbound_connector_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_outbound_connector_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_replication_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_replication_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_replication_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/change_replication_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/client_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/client_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_export_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_export_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_export_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_export_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_file_system_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_file_system_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_file_system_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_file_system_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_filesystem_snapshot_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_filesystem_snapshot_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_filesystem_snapshot_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_filesystem_snapshot_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_kerberos_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_kerberos_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_ldap_bind_account_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_ldap_bind_account_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_ldap_idmap_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_ldap_idmap_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_mount_target_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_mount_target_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_mount_target_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_mount_target_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_outbound_connector_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_outbound_connector_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_outbound_connector_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_outbound_connector_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_replication_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_replication_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_replication_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_replication_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_snapshot_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_snapshot_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_snapshot_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/create_snapshot_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_export_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_export_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_file_system_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_file_system_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_filesystem_snapshot_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_filesystem_snapshot_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_mount_target_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_mount_target_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_outbound_connector_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_outbound_connector_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_replication_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_replication_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_replication_target_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_replication_target_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_snapshot_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/delete_snapshot_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/endpoint.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/estimate_replication_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/estimate_replication_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/export.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/export.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/export_set.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/export_set.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/export_set_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/export_set_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/export_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/export_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/file_system.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/file_system.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/file_system_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/file_system_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/filestorage_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/filestorage_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -28,7 +28,7 @@ type FileStorageClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewFileStorageClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client FileStorageClient, err error) {
 	if enabled := common.CheckForEnabledServices("filestorage"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/filesystem_snapshot_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/filesystem_snapshot_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/filesystem_snapshot_policy_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/filesystem_snapshot_policy_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_export_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_export_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_export_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_export_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_file_system_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_file_system_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_filesystem_snapshot_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_filesystem_snapshot_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_mount_target_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_mount_target_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_outbound_connector_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_outbound_connector_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_replication_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_replication_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_replication_target_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_replication_target_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_snapshot_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/get_snapshot_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/kerberos.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/kerberos.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/kerberos_keytab_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/kerberos_keytab_entry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/key_tab_secret_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/key_tab_secret_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/ldap_bind_account.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/ldap_bind_account.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/ldap_bind_account_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/ldap_bind_account_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/ldap_idmap.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/ldap_idmap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_export_sets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_export_sets_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_exports_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_exports_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_file_systems_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_file_systems_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_filesystem_snapshot_policies_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_filesystem_snapshot_policies_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_mount_targets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_mount_targets_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_outbound_connectors_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_outbound_connectors_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_replication_targets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_replication_targets_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_replications_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_replications_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_snapshots_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/list_snapshots_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/mount_target.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/mount_target.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/mount_target_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/mount_target_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/outbound_connector.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/outbound_connector.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/outbound_connector_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/outbound_connector_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/pause_filesystem_snapshot_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/pause_filesystem_snapshot_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication_estimate.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication_estimate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication_target.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication_target.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication_target_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/replication_target_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/snapshot.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/snapshot.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/snapshot_schedule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/snapshot_schedule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/snapshot_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/snapshot_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/unpause_filesystem_snapshot_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/unpause_filesystem_snapshot_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_export_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_export_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_export_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_export_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_export_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_export_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_export_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_export_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_file_system_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_file_system_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_file_system_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_file_system_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_filesystem_snapshot_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_filesystem_snapshot_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_filesystem_snapshot_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_filesystem_snapshot_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_kerberos_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_kerberos_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_ldap_idmap_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_ldap_idmap_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_mount_target_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_mount_target_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_mount_target_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_mount_target_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_outbound_connector_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_outbound_connector_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_outbound_connector_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_outbound_connector_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_replication_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_replication_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_replication_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_replication_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_snapshot_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_snapshot_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_snapshot_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/update_snapshot_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/validate_key_tabs_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/validate_key_tabs_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/validate_key_tabs_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/validate_key_tabs_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/validate_key_tabs_response_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/filestorage/validate_key_tabs_response_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/activate_domain_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/activate_domain_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/activate_mfa_totp_device_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/activate_mfa_totp_device_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_lock_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_lock_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_tag_default_lock_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_tag_default_lock_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_tag_namespace_lock_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_tag_namespace_lock_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_user_to_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_user_to_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_user_to_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/add_user_to_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/allowed_domain_license_type_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/allowed_domain_license_type_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/api_key.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/api_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/assemble_effective_tag_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/assemble_effective_tag_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/auth_token.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/auth_token.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/authentication_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/authentication_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/availability_domain.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/availability_domain.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/base_tag_definition_validator.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/base_tag_definition_validator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_action_resource.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_action_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_action_resource_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_action_resource_type.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_action_resource_type_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_action_resource_type_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_delete_resources_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_delete_resources_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_delete_resources_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_delete_resources_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_delete_tags_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_delete_tags_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_delete_tags_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_delete_tags_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_operation_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_operation_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_resource.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_tags_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_tags_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_tags_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_tags_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_tags_resource_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_tags_resource_type.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_tags_resource_type_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_edit_tags_resource_type_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_move_resources_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_move_resources_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_move_resources_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/bulk_move_resources_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/cascade_delete_tag_namespace_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/cascade_delete_tag_namespace_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_domain_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_domain_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_domain_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_domain_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_domain_license_type_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_domain_license_type_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_domain_license_type_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_domain_license_type_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_tag_namespace_compartment_detail.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_tag_namespace_compartment_detail.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_tag_namespace_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_tag_namespace_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_tas_domain_license_type_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/change_tas_domain_license_type_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/compartment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/compartment.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_api_key_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_api_key_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_auth_token_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_auth_token_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_auth_token_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_auth_token_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_customer_secret_key_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_customer_secret_key_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_customer_secret_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_customer_secret_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_db_credential_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_db_credential_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_db_credential_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_db_credential_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_domain_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_domain_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_domain_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_domain_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_dynamic_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_dynamic_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_dynamic_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_dynamic_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_identity_provider_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_identity_provider_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_identity_provider_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_identity_provider_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_idp_group_mapping_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_idp_group_mapping_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_idp_group_mapping_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_idp_group_mapping_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_mfa_totp_device_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_mfa_totp_device_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_network_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_network_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_network_source_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_network_source_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_o_auth2_client_credential_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_o_auth2_client_credential_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_o_auth_client_credential_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_o_auth_client_credential_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_or_reset_u_i_password_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_or_reset_u_i_password_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_region_subscription_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_region_subscription_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_region_subscription_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_region_subscription_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_saml2_identity_provider_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_saml2_identity_provider_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_smtp_credential_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_smtp_credential_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_smtp_credential_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_smtp_credential_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_swift_password_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_swift_password_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_swift_password_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_swift_password_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_default_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_default_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_default_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_default_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_namespace_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_namespace_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_namespace_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_namespace_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_tag_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_user_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_user_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_user_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/create_user_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/customer_secret_key.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/customer_secret_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/customer_secret_key_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/customer_secret_key_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/db_credential.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/db_credential.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/db_credential_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/db_credential_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/deactivate_domain_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/deactivate_domain_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/default_tag_definition_validator.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/default_tag_definition_validator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_api_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_api_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_auth_token_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_auth_token_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_customer_secret_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_customer_secret_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_db_credential_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_db_credential_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_domain_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_domain_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_dynamic_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_dynamic_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_identity_provider_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_identity_provider_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_idp_group_mapping_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_idp_group_mapping_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_mfa_totp_device_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_mfa_totp_device_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_network_source_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_network_source_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_o_auth_client_credential_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_o_auth_client_credential_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_smtp_credential_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_smtp_credential_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_swift_password_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_swift_password_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_tag_default_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_tag_default_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_tag_namespace_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_tag_namespace_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_tag_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_tag_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_user_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/delete_user_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/domain.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/domain.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/domain_replication.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/domain_replication.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/domain_replication_states.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/domain_replication_states.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/domain_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/domain_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/dynamic_group.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/dynamic_group.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/enable_replication_to_region_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/enable_replication_to_region_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/enable_replication_to_region_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/enable_replication_to_region_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/enum_tag_definition_validator.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/enum_tag_definition_validator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/fault_domain.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/fault_domain.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/fully_qualified_scope.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/fully_qualified_scope.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/generate_totp_seed_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/generate_totp_seed_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_authentication_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_authentication_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_domain_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_domain_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_dynamic_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_dynamic_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_iam_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_iam_work_request_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_identity_provider_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_identity_provider_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_idp_group_mapping_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_idp_group_mapping_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_mfa_totp_device_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_mfa_totp_device_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_network_source_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_network_source_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_standard_tag_template_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_standard_tag_template_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tag_default_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tag_default_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tag_namespace_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tag_namespace_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tag_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tag_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tagging_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tagging_work_request_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tenancy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_tenancy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_user_group_membership_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_user_group_membership_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_user_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_user_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_user_u_i_password_information_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_user_u_i_password_information_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/get_work_request_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/group.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/group.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request_error_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request_error_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request_log_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request_log_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request_resource.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/iam_work_request_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/identity_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/identity_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -28,7 +28,7 @@ type IdentityClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewIdentityClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client IdentityClient, err error) {
 	if enabled := common.CheckForEnabledServices("identity"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/identity_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/identity_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/identity_provider_group_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/identity_provider_group_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/idp_group_mapping.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/idp_group_mapping.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/import_standard_tags_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/import_standard_tags_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/import_standard_tags_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/import_standard_tags_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_allowed_domain_license_types_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_allowed_domain_license_types_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_api_keys_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_api_keys_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_auth_tokens_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_auth_tokens_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_availability_domains_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_availability_domains_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_bulk_action_resource_types_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_bulk_action_resource_types_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_bulk_edit_tags_resource_types_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_bulk_edit_tags_resource_types_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_compartments_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_compartments_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_cost_tracking_tags_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_cost_tracking_tags_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_customer_secret_keys_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_customer_secret_keys_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_db_credentials_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_db_credentials_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_domains_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_domains_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_dynamic_groups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_dynamic_groups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_fault_domains_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_fault_domains_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_groups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_groups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_iam_work_request_errors_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_iam_work_request_errors_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_iam_work_request_logs_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_iam_work_request_logs_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_iam_work_requests_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_iam_work_requests_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_identity_provider_groups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_identity_provider_groups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_identity_providers_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_identity_providers_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_idp_group_mappings_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_idp_group_mappings_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_mfa_totp_devices_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_mfa_totp_devices_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_network_sources_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_network_sources_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_o_auth_client_credentials_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_o_auth_client_credentials_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_policies_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_policies_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_region_subscriptions_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_region_subscriptions_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_regions_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_regions_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_smtp_credentials_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_smtp_credentials_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_standard_tag_namespaces_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_standard_tag_namespaces_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_swift_passwords_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_swift_passwords_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tag_defaults_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tag_defaults_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tag_namespaces_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tag_namespaces_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tagging_work_request_errors_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tagging_work_request_errors_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tagging_work_request_logs_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tagging_work_request_logs_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tagging_work_requests_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tagging_work_requests_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tags_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_tags_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_user_group_memberships_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_user_group_memberships_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_users_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_users_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_work_requests_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/list_work_requests_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/mfa_totp_device.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/mfa_totp_device.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/mfa_totp_device_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/mfa_totp_device_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/mfa_totp_token.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/mfa_totp_token.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/move_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/move_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/move_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/move_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/network_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/network_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/network_sources.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/network_sources.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/network_sources_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/network_sources_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/network_sources_virtual_source_list.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/network_sources_virtual_source_list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/o_auth2_client_credential.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/o_auth2_client_credential.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/o_auth2_client_credential_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/o_auth2_client_credential_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/password_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/password_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/recover_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/recover_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/region.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/region.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/region_subscription.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/region_subscription.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/remove_lock_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/remove_lock_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/remove_tag_default_lock_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/remove_tag_default_lock_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/remove_tag_namespace_lock_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/remove_tag_namespace_lock_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/remove_user_from_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/remove_user_from_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/replicated_region_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/replicated_region_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/reset_idp_scim_client_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/reset_idp_scim_client_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/resource_lock.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/resource_lock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/saml2_identity_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/saml2_identity_provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/scim_client_credentials.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/scim_client_credentials.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/smtp_credential.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/smtp_credential.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/smtp_credential_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/smtp_credential_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/standard_tag_definition_template.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/standard_tag_definition_template.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/standard_tag_namespace_template.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/standard_tag_namespace_template.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/standard_tag_namespace_template_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/standard_tag_namespace_template_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/swift_password.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/swift_password.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_default.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_default.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_default_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_default_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_namespace.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_namespace.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_namespace_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_namespace_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tag_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tagging_work_request.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tagging_work_request.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tagging_work_request_error_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tagging_work_request_error_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tagging_work_request_log_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tagging_work_request_log_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tagging_work_request_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tagging_work_request_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/tenancy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/tenancy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/ui_password.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/ui_password.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/ui_password_information.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/ui_password_information.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_auth_token_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_auth_token_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_auth_token_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_auth_token_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_authentication_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_authentication_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_authentication_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_authentication_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_customer_secret_key_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_customer_secret_key_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_customer_secret_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_customer_secret_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_domain_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_domain_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_domain_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_domain_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_dynamic_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_dynamic_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_dynamic_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_dynamic_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_group_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_group_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_group_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_identity_provider_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_identity_provider_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_identity_provider_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_identity_provider_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_idp_group_mapping_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_idp_group_mapping_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_idp_group_mapping_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_idp_group_mapping_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_network_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_network_source_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_network_source_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_network_source_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_o_auth2_client_credential_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_o_auth2_client_credential_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_o_auth_client_credential_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_o_auth_client_credential_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_saml2_identity_provider_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_saml2_identity_provider_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_smtp_credential_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_smtp_credential_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_smtp_credential_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_smtp_credential_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_state_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_state_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_swift_password_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_swift_password_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_swift_password_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_swift_password_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_default_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_default_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_default_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_default_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_namespace_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_namespace_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_namespace_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_namespace_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_tag_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_capabilities_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_capabilities_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_capabilities_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_capabilities_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_state_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/update_user_state_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/upload_api_key_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/upload_api_key_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/user.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/user.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/user_capabilities.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/user_capabilities.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/user_group_membership.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/user_group_membership.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request_error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request_log_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request_log_entry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request_resource.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/identity/work_request_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/add_http_request_header_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/add_http_request_header_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/add_http_response_header_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/add_http_response_header_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/allow_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/allow_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_health.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_set.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_set.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_set_health.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/backend_set_health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/certificate.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/certificate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/certificate_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/certificate_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/change_load_balancer_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/change_load_balancer_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/change_load_balancer_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/change_load_balancer_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/connection_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/connection_configuration.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/control_access_using_http_methods_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/control_access_using_http_methods_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_backend_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_backend_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_backend_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_backend_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_backend_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_backend_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_backend_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_backend_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_certificate_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_certificate_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_certificate_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_certificate_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_hostname_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_hostname_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_hostname_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_hostname_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_listener_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_listener_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_listener_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_listener_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_load_balancer_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_load_balancer_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_path_route_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_path_route_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_path_route_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_path_route_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_routing_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_routing_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_routing_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_routing_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_rule_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_rule_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_rule_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_rule_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_s_s_l_cipher_suite_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_s_s_l_cipher_suite_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_ssl_cipher_suite_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/create_ssl_cipher_suite_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_backend_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_backend_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_backend_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_backend_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_certificate_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_certificate_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_hostname_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_hostname_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_listener_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_listener_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_path_route_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_path_route_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_routing_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_routing_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_rule_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_rule_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_s_s_l_cipher_suite_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/delete_s_s_l_cipher_suite_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/extend_http_request_header_value_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/extend_http_request_header_value_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/extend_http_response_header_value_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/extend_http_response_header_value_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/forward_to_backend_set.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/forward_to_backend_set.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_backend_health_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_backend_health_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_backend_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_backend_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_backend_set_health_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_backend_set_health_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_backend_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_backend_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_health_checker_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_health_checker_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_hostname_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_hostname_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_load_balancer_health_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_load_balancer_health_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_path_route_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_path_route_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_routing_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_routing_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_rule_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_rule_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_s_s_l_cipher_suite_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_s_s_l_cipher_suite_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/get_work_request_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/health_check_result.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/health_check_result.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/health_checker.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/health_checker.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/health_checker_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/health_checker_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/hostname.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/hostname.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/hostname_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/hostname_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/http_header_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/http_header_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ip_address.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ip_address.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/lb_cookie_session_persistence_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/lb_cookie_session_persistence_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_backend_sets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_backend_sets_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_backends_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_backends_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_certificates_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_certificates_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_hostnames_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_hostnames_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_listener_rules_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_listener_rules_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_load_balancer_healths_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_load_balancer_healths_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_load_balancers_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_load_balancers_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_path_route_sets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_path_route_sets_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_policies_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_policies_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_protocols_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_protocols_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_routing_policies_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_routing_policies_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_rule_sets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_rule_sets_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_s_s_l_cipher_suites_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_s_s_l_cipher_suites_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_shapes_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_work_requests_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/list_work_requests_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/listener.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/listener.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/listener_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/listener_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/listener_rule_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/listener_rule_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_health.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_health_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_health_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_protocol.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_protocol.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_shape.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/load_balancer_shape.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/loadbalancer_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/loadbalancer_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -28,7 +28,7 @@ type LoadBalancerClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewLoadBalancerClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client LoadBalancerClient, err error) {
 	if enabled := common.CheckForEnabledServices("loadbalancer"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_match_condition.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_match_condition.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_match_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_match_type.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_route.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_route.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_route_set.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_route_set.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_route_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/path_route_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/redirect_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/redirect_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/redirect_uri.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/redirect_uri.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/remove_http_request_header_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/remove_http_request_header_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/remove_http_response_header_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/remove_http_response_header_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/reserved_ip.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/reserved_ip.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/routing_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/routing_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/routing_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/routing_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/routing_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/routing_rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/rule.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/rule_condition.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/rule_condition.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/rule_set.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/rule_set.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/rule_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/rule_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/session_persistence_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/session_persistence_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/shape_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/shape_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/source_ip_address_condition.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/source_ip_address_condition.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/source_vcn_id_condition.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/source_vcn_id_condition.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/source_vcn_ip_address_condition.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/source_vcn_ip_address_condition.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ssl_cipher_suite.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ssl_cipher_suite.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ssl_cipher_suite_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ssl_cipher_suite_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ssl_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ssl_configuration.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ssl_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/ssl_configuration_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_backend_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_backend_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_backend_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_backend_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_backend_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_backend_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_backend_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_backend_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_health_checker_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_health_checker_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_health_checker_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_health_checker_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_hostname_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_hostname_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_hostname_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_hostname_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_listener_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_listener_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_listener_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_listener_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_load_balancer_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_load_balancer_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_load_balancer_shape_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_load_balancer_shape_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_load_balancer_shape_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_load_balancer_shape_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_network_security_groups_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_network_security_groups_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_network_security_groups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_network_security_groups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_path_route_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_path_route_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_path_route_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_path_route_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_routing_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_routing_policy_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_routing_policy_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_routing_policy_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_rule_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_rule_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_rule_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_rule_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_s_s_l_cipher_suite_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_s_s_l_cipher_suite_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_ssl_cipher_suite_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/update_ssl_cipher_suite_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/work_request.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/work_request.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/work_request_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/loadbalancer/work_request_error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/aggregated_datapoint.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/aggregated_datapoint.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -21,7 +22,7 @@ import (
 type AggregatedDatapoint struct {
 
 	// The date and time associated with the value of this data point. Format defined by RFC3339.
-	// Example: `2019-02-01T01:02:29.600Z`
+	// Example: `2023-02-01T01:02:29.600Z`
 	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
 
 	// Numeric value of the metric.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -18,12 +19,14 @@ import (
 )
 
 // Alarm The properties that define an alarm.
-// For information about alarms, see Alarms Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#AlarmsOverview).
+// For information about alarms, see
+// Alarms Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#AlarmsOverview).
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access, see
 // Getting Started with Policies (https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
 // For information about endpoints and signing API requests, see
-// About the API (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm). For information about available SDKs and tools, see
+// About the API (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm).
+// For information about available SDKs and tools, see
 // SDKS and Other Tools (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdks.htm).
 type Alarm struct {
 
@@ -31,7 +34,7 @@ type Alarm struct {
 	Id *string `mandatory:"true" json:"id"`
 
 	// A user-friendly name for the alarm. It does not have to be unique, and it's changeable.
-	// This name is sent as the title for notifications related to this alarm.
+	// This value determines the title of each alarm notification.
 	// Example: `High CPU Utilization`
 	DisplayName *string `mandatory:"true" json:"displayName"`
 
@@ -53,9 +56,12 @@ type Alarm struct {
 	// rule (threshold or absence). Supported values for interval depend on the specified time range. More
 	// interval values are supported for smaller time ranges. You can optionally
 	// specify dimensions and grouping functions. Supported grouping functions: `grouping()`, `groupBy()`.
-	// For details about Monitoring Query Language (MQL), see Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
-	// For available dimensions, review the metric definition for the supported service.
-	// See Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
+	// For information about writing MQL expressions, see
+	// Editing the MQL Expression for a Query (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/query-metric-mql.htm).
+	// For details about MQL, see
+	// Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
+	// For available dimensions, review the metric definition for the supported service. See
+	// Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
 	// Example of threshold alarm:
 	//   -----
 	//     CpuUtilization[1m]{availabilityDomain="cumS:PHX-AD-1"}.groupBy(availabilityDomain).percentile(0.9) > 85
@@ -70,10 +76,11 @@ type Alarm struct {
 	// Example: `CRITICAL`
 	Severity AlarmSeverityEnum `mandatory:"true" json:"severity"`
 
-	// A list of destinations to which the notifications for this alarm will be delivered.
-	// Each destination is represented by an OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) related to the supported destination service.
-	// For example, a destination using the Notifications service is represented by a topic OCID.
-	// Supported destination services: Notifications Service. Limit: One destination per supported destination service.
+	// A list of destinations for alarm notifications.
+	// Each destination is represented by the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
+	// of a related resource, such as a NotificationTopic.
+	// Supported destination services: Notifications, Streaming.
+	// Limit: One destination per supported destination service.
 	Destinations []string `mandatory:"true" json:"destinations"`
 
 	// Whether the alarm is enabled.
@@ -85,11 +92,11 @@ type Alarm struct {
 	LifecycleState AlarmLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
 	// The date and time the alarm was created. Format defined by RFC3339.
-	// Example: `2019-02-01T01:02:29.600Z`
+	// Example: `2023-02-01T01:02:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// The date and time the alarm was last updated. Format defined by RFC3339.
-	// Example: `2019-02-03T01:02:29.600Z`
+	// Example: `2023-02-03T01:02:29.600Z`
 	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
 
 	// When true, the alarm evaluates metrics from all compartments and subcompartments. The parameter can
@@ -121,23 +128,23 @@ type Alarm struct {
 	// Example: `PT5M`
 	PendingDuration *string `mandatory:"false" json:"pendingDuration"`
 
-	// The human-readable content of the notification delivered. Oracle recommends providing guidance
+	// The human-readable content of the delivered alarm notification. Oracle recommends providing guidance
 	// to operators for resolving the alarm condition. Consider adding links to standard runbook
-	// practices.
+	// practices. Avoid entering confidential information.
 	// Example: `High CPU usage alert. Follow runbook instructions for resolution.`
 	Body *string `mandatory:"false" json:"body"`
 
-	// When set to `true`, splits notifications per metric stream. When set to `false`, groups notifications across metric streams.
-	// Example: `true`
+	// When set to `true`, splits alarm notifications per metric stream.
+	// When set to `false`, groups alarm notifications across metric streams.
 	IsNotificationsPerMetricDimensionEnabled *bool `mandatory:"false" json:"isNotificationsPerMetricDimensionEnabled"`
 
-	// The format to use for notification messages sent from this alarm. The formats are:
-	// * `RAW` - Raw JSON blob. Default value.
-	// * `PRETTY_JSON`: JSON with new lines and indents.
-	// * `ONS_OPTIMIZED`: Simplified, user-friendly layout. Applies only to messages sent through the Notifications service to the following subscription types: Email.
+	// The format to use for alarm notifications. The formats are:
+	// * `RAW` - Raw JSON blob. Default value. When the `destinations` attribute specifies `Streaming`, all alarm notifications use this format.
+	// * `PRETTY_JSON`: JSON with new lines and indents. Available when the `destinations` attribute specifies `Notifications` only.
+	// * `ONS_OPTIMIZED`: Simplified, user-friendly layout. Available when the `destinations` attribute specifies `Notifications` only. Applies to Email subscription types only.
 	MessageFormat AlarmMessageFormatEnum `mandatory:"false" json:"messageFormat,omitempty"`
 
-	// The frequency at which notifications are re-submitted, if the alarm keeps firing without
+	// The frequency for re-submitting alarm notifications, if the alarm keeps firing without
 	// interruption. Format defined by ISO 8601. For example, `PT4H` indicates four hours.
 	// Minimum: PT1M. Maximum: P30D.
 	// Default value: null (notifications are not re-submitted).

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_dimension_states_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_dimension_states_collection.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -27,8 +28,8 @@ type AlarmDimensionStatesCollection struct {
 	// Example: `true`
 	IsEnabled *bool `mandatory:"true" json:"isEnabled"`
 
-	// When set to `true`, splits notifications per metric stream. When set to `false`, groups notifications across metric streams.
-	// Example: `true`
+	// When set to `true`, splits alarm notifications per metric stream.
+	// When set to `false`, groups alarm notifications across metric streams.
 	IsNotificationsPerMetricDimensionEnabled *bool `mandatory:"true" json:"isNotificationsPerMetricDimensionEnabled"`
 
 	// Array of alarm state entries.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_dimension_states_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_dimension_states_entry.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_history_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_history_collection.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -20,7 +21,7 @@ import (
 // AlarmHistoryCollection The configuration details for retrieving alarm history.
 type AlarmHistoryCollection struct {
 
-	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm for which to retrieve history.
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm to retrieve history for.
 	AlarmId *string `mandatory:"true" json:"alarmId"`
 
 	// Whether the alarm is enabled.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_history_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_history_entry.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -27,12 +28,12 @@ type AlarmHistoryEntry struct {
 	Summary *string `mandatory:"true" json:"summary"`
 
 	// Timestamp for this alarm history entry. Format defined by RFC3339.
-	// Example: `2019-02-01T01:02:29.600Z`
+	// Example: `2023-02-01T01:02:29.600Z`
 	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
 
 	// Timestamp for the transition of the alarm state. For example, the time when the alarm transitioned from OK to Firing.
 	// Available for state transition entries only. Note: A three-minute lag for this value accounts for any late-arriving metrics.
-	// Example: `2019-02-01T0:59:00.789Z`
+	// Example: `2023-02-01T0:59:00.789Z`
 	TimestampTriggered *common.SDKTime `mandatory:"false" json:"timestampTriggered"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_status_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_status_summary.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -18,12 +19,14 @@ import (
 )
 
 // AlarmStatusSummary A summary of properties for the specified alarm and its current evaluation status.
-// For information about alarms, see Alarms Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#AlarmsOverview).
+// For information about alarms, see
+// Alarms Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#AlarmsOverview).
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access, see
 // Getting Started with Policies (https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
 // For information about endpoints and signing API requests, see
-// About the API (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm). For information about available SDKs and tools, see
+// About the API (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm).
+// For information about available SDKs and tools, see
 // SDKS and Other Tools (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdks.htm).
 type AlarmStatusSummary struct {
 
@@ -34,19 +37,18 @@ type AlarmStatusSummary struct {
 	// Example: `High CPU Utilization`
 	DisplayName *string `mandatory:"true" json:"displayName"`
 
-	// The configured severity of the alarm.
+	// The perceived type of response required when the alarm is in the "FIRING" state.
 	// Example: `CRITICAL`
 	Severity AlarmStatusSummarySeverityEnum `mandatory:"true" json:"severity"`
 
 	// Timestamp for the transition of the alarm state. For example, the time when the alarm transitioned from OK to Firing.
 	// Note: A three-minute lag for this value accounts for any late-arriving metrics.
-	// Example: `2019-02-01T01:02:29.600Z`
+	// Example: `2023-02-01T01:02:29.600Z`
 	TimestampTriggered *common.SDKTime `mandatory:"true" json:"timestampTriggered"`
 
 	// The status of this alarm.
 	// Status is collective, across all metric streams in the alarm.
 	// To list alarm status for each metric stream, use RetrieveDimensionStates.
-	// The alarm attribute `isNotificationsPerMetricDimensionEnabled` must be set to `true`.
 	// Example: `FIRING`
 	Status AlarmStatusSummaryStatusEnum `mandatory:"true" json:"status"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_summary.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -18,12 +19,14 @@ import (
 )
 
 // AlarmSummary A summary of properties for the specified alarm.
-// For information about alarms, see Alarms Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#AlarmsOverview).
+// For information about alarms, see
+// Alarms Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#AlarmsOverview).
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access, see
 // Getting Started with Policies (https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
 // For information about endpoints and signing API requests, see
-// About the API (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm). For information about available SDKs and tools, see
+// About the API (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm).
+// For information about available SDKs and tools, see
 // SDKS and Other Tools (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdks.htm).
 type AlarmSummary struct {
 
@@ -31,7 +34,7 @@ type AlarmSummary struct {
 	Id *string `mandatory:"true" json:"id"`
 
 	// A user-friendly name for the alarm. It does not have to be unique, and it's changeable.
-	// This name is sent as the title for notifications related to this alarm.
+	// This value determines the title of each alarm notification.
 	// Example: `High CPU Utilization`
 	DisplayName *string `mandatory:"true" json:"displayName"`
 
@@ -52,9 +55,12 @@ type AlarmSummary struct {
 	// rule condition has been met. The query must specify a metric, statistic, interval, and trigger
 	// rule (threshold or absence). Supported values for interval depend on the specified time range. More
 	// interval values are supported for smaller time ranges. Supported grouping functions: `grouping()`, `groupBy()`.
-	// For details about Monitoring Query Language (MQL), see Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
-	// For available dimensions, review the metric definition for the supported service.
-	// See Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
+	// For information about writing MQL expressions, see
+	// Editing the MQL Expression for a Query (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/query-metric-mql.htm).
+	// For details about MQL, see
+	// Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
+	// For available dimensions, review the metric definition for the supported service. See
+	// Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
 	// Example of threshold alarm:
 	//   -----
 	//     CpuUtilization[1m]{availabilityDomain="cumS:PHX-AD-1"}.groupBy(availabilityDomain).percentile(0.9) > 85
@@ -65,14 +71,15 @@ type AlarmSummary struct {
 	//   -----
 	Query *string `mandatory:"true" json:"query"`
 
-	// The perceived severity of the alarm with regard to the affected system.
+	// The perceived type of response required when the alarm is in the "FIRING" state.
 	// Example: `CRITICAL`
 	Severity AlarmSummarySeverityEnum `mandatory:"true" json:"severity"`
 
-	// A list of destinations to which the notifications for this alarm will be delivered.
-	// Each destination is represented by an OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) related to the supported destination service.
-	// For example, a destination using the Notifications service is represented by a topic OCID.
-	// Supported destination services: Notifications Service. Limit: One destination per supported destination service.
+	// A list of destinations for alarm notifications.
+	// Each destination is represented by the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
+	// of a related resource, such as a NotificationTopic.
+	// Supported destination services: Notifications, Streaming.
+	// Limit: One destination per supported destination service.
 	Destinations []string `mandatory:"true" json:"destinations"`
 
 	// Whether the alarm is enabled.
@@ -85,6 +92,11 @@ type AlarmSummary struct {
 
 	// The configuration details for suppressing an alarm.
 	Suppression *Suppression `mandatory:"false" json:"suppression"`
+
+	// Whether the alarm sends a separate message for each metric stream.
+	// See Creating an Alarm That Splits Messages by Metric Stream (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/create-alarm-split.htm).
+	// Example: `true`
+	IsNotificationsPerMetricDimensionEnabled *bool `mandatory:"false" json:"isNotificationsPerMetricDimensionEnabled"`
 
 	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
 	// Example: `{"Department": "Finance"}`

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AlarmSuppression The configuration details for a dimension-specific alarm suppression.
+type AlarmSuppression struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm suppression.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the alarm suppression.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	AlarmSuppressionTarget AlarmSuppressionTarget `mandatory:"true" json:"alarmSuppressionTarget"`
+
+	// A user-friendly name for the alarm suppression. It does not have to be unique, and it's changeable. Avoid entering confidential information.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// Configured dimension filter for suppressing alarm state entries that include the set of specified dimension key-value pairs.
+	// Example: `{"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"}`
+	Dimensions map[string]string `mandatory:"true" json:"dimensions"`
+
+	// The start date and time for the suppression to take place, inclusive. Format defined by RFC3339.
+	// Example: `2018-02-01T01:02:29.600Z`
+	TimeSuppressFrom *common.SDKTime `mandatory:"true" json:"timeSuppressFrom"`
+
+	// The end date and time for the suppression to take place, inclusive. Format defined by RFC3339.
+	// Example: `2018-02-01T02:02:29.600Z`
+	TimeSuppressUntil *common.SDKTime `mandatory:"true" json:"timeSuppressUntil"`
+
+	// The current lifecycle state of the alarm suppression.
+	// Example: `DELETED`
+	LifecycleState AlarmSuppressionLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time the alarm suppression was created. Format defined by RFC3339.
+	// Example: `2018-02-01T01:02:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time the alarm suppression was last updated (deleted). Format defined by RFC3339.
+	// Example: `2018-02-03T01:02:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// Human-readable reason for this alarm suppression.
+	// It does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	// Oracle recommends including tracking information for the event or associated work,
+	// such as a ticket number.
+	// Example: `Planned outage due to change IT-1234.`
+	Description *string `mandatory:"false" json:"description"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m AlarmSuppression) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AlarmSuppression) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAlarmSuppressionLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetAlarmSuppressionLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *AlarmSuppression) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Description            *string                            `json:"description"`
+		FreeformTags           map[string]string                  `json:"freeformTags"`
+		DefinedTags            map[string]map[string]interface{}  `json:"definedTags"`
+		Id                     *string                            `json:"id"`
+		CompartmentId          *string                            `json:"compartmentId"`
+		AlarmSuppressionTarget alarmsuppressiontarget             `json:"alarmSuppressionTarget"`
+		DisplayName            *string                            `json:"displayName"`
+		Dimensions             map[string]string                  `json:"dimensions"`
+		TimeSuppressFrom       *common.SDKTime                    `json:"timeSuppressFrom"`
+		TimeSuppressUntil      *common.SDKTime                    `json:"timeSuppressUntil"`
+		LifecycleState         AlarmSuppressionLifecycleStateEnum `json:"lifecycleState"`
+		TimeCreated            *common.SDKTime                    `json:"timeCreated"`
+		TimeUpdated            *common.SDKTime                    `json:"timeUpdated"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Description = model.Description
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.Id = model.Id
+
+	m.CompartmentId = model.CompartmentId
+
+	nn, e = model.AlarmSuppressionTarget.UnmarshalPolymorphicJSON(model.AlarmSuppressionTarget.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.AlarmSuppressionTarget = nn.(AlarmSuppressionTarget)
+	} else {
+		m.AlarmSuppressionTarget = nil
+	}
+
+	m.DisplayName = model.DisplayName
+
+	m.Dimensions = model.Dimensions
+
+	m.TimeSuppressFrom = model.TimeSuppressFrom
+
+	m.TimeSuppressUntil = model.TimeSuppressUntil
+
+	m.LifecycleState = model.LifecycleState
+
+	m.TimeCreated = model.TimeCreated
+
+	m.TimeUpdated = model.TimeUpdated
+
+	return
+}
+
+// AlarmSuppressionLifecycleStateEnum Enum with underlying type: string
+type AlarmSuppressionLifecycleStateEnum string
+
+// Set of constants representing the allowable values for AlarmSuppressionLifecycleStateEnum
+const (
+	AlarmSuppressionLifecycleStateActive  AlarmSuppressionLifecycleStateEnum = "ACTIVE"
+	AlarmSuppressionLifecycleStateDeleted AlarmSuppressionLifecycleStateEnum = "DELETED"
+)
+
+var mappingAlarmSuppressionLifecycleStateEnum = map[string]AlarmSuppressionLifecycleStateEnum{
+	"ACTIVE":  AlarmSuppressionLifecycleStateActive,
+	"DELETED": AlarmSuppressionLifecycleStateDeleted,
+}
+
+var mappingAlarmSuppressionLifecycleStateEnumLowerCase = map[string]AlarmSuppressionLifecycleStateEnum{
+	"active":  AlarmSuppressionLifecycleStateActive,
+	"deleted": AlarmSuppressionLifecycleStateDeleted,
+}
+
+// GetAlarmSuppressionLifecycleStateEnumValues Enumerates the set of values for AlarmSuppressionLifecycleStateEnum
+func GetAlarmSuppressionLifecycleStateEnumValues() []AlarmSuppressionLifecycleStateEnum {
+	values := make([]AlarmSuppressionLifecycleStateEnum, 0)
+	for _, v := range mappingAlarmSuppressionLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAlarmSuppressionLifecycleStateEnumStringValues Enumerates the set of values in String for AlarmSuppressionLifecycleStateEnum
+func GetAlarmSuppressionLifecycleStateEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"DELETED",
+	}
+}
+
+// GetMappingAlarmSuppressionLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAlarmSuppressionLifecycleStateEnum(val string) (AlarmSuppressionLifecycleStateEnum, bool) {
+	enum, ok := mappingAlarmSuppressionLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_alarm_target.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_alarm_target.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AlarmSuppressionAlarmTarget The alarm target of the alarm suppression.
+type AlarmSuppressionAlarmTarget struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm that is the target of the alarm suppression.
+	AlarmId *string `mandatory:"true" json:"alarmId"`
+}
+
+func (m AlarmSuppressionAlarmTarget) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AlarmSuppressionAlarmTarget) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m AlarmSuppressionAlarmTarget) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeAlarmSuppressionAlarmTarget AlarmSuppressionAlarmTarget
+	s := struct {
+		DiscriminatorParam string `json:"targetType"`
+		MarshalTypeAlarmSuppressionAlarmTarget
+	}{
+		"ALARM",
+		(MarshalTypeAlarmSuppressionAlarmTarget)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_collection.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AlarmSuppressionCollection Collection of property summaries for dimension-specific alarm suppressions.
+type AlarmSuppressionCollection struct {
+
+	// List of property summaries for dimension-specific alarm suppressions.
+	Items []AlarmSuppressionSummary `mandatory:"true" json:"items"`
+}
+
+func (m AlarmSuppressionCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AlarmSuppressionCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_history_item.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_history_item.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AlarmSuppressionHistoryItem A summary of properties for the specified alarm suppression history item.
+type AlarmSuppressionHistoryItem struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm suppression.
+	SuppressionId *string `mandatory:"true" json:"suppressionId"`
+
+	AlarmSuppressionTarget AlarmSuppressionTarget `mandatory:"true" json:"alarmSuppressionTarget"`
+
+	// The level of this alarm suppression.
+	// `ALARM` indicates a suppression of the entire alarm, regardless of dimension.
+	// `DIMENSION` indicates a suppression configured for specified dimensions.
+	Level AlarmSuppressionHistoryItemLevelEnum `mandatory:"true" json:"level"`
+
+	// A user-friendly name for the alarm suppression. It does not have to be unique, and it's changeable. Avoid entering confidential information.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The start date and time for the suppression actually starts, inclusive. Format defined by RFC3339.
+	// Example: `2023-02-01T01:02:29.600Z`
+	TimeEffectiveFrom *common.SDKTime `mandatory:"true" json:"timeEffectiveFrom"`
+
+	// The end date and time for the suppression actually ends, inclusive. Format defined by RFC3339.
+	// Example: `2023-02-01T02:02:29.600Z`
+	TimeEffectiveUntil *common.SDKTime `mandatory:"true" json:"timeEffectiveUntil"`
+
+	// Human-readable reason for this alarm suppression.
+	// It does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	// Oracle recommends including tracking information for the event or associated work,
+	// such as a ticket number.
+	// Example: `Planned outage due to change IT-1234.`
+	Description *string `mandatory:"false" json:"description"`
+
+	// Configured dimension filter for suppressing alarm state entries that include the set of specified dimension key-value pairs.
+	// Example: `{"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"}`
+	Dimensions map[string]string `mandatory:"false" json:"dimensions"`
+}
+
+func (m AlarmSuppressionHistoryItem) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AlarmSuppressionHistoryItem) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAlarmSuppressionHistoryItemLevelEnum(string(m.Level)); !ok && m.Level != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Level: %s. Supported values are: %s.", m.Level, strings.Join(GetAlarmSuppressionHistoryItemLevelEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *AlarmSuppressionHistoryItem) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Description            *string                              `json:"description"`
+		Dimensions             map[string]string                    `json:"dimensions"`
+		SuppressionId          *string                              `json:"suppressionId"`
+		AlarmSuppressionTarget alarmsuppressiontarget               `json:"alarmSuppressionTarget"`
+		Level                  AlarmSuppressionHistoryItemLevelEnum `json:"level"`
+		DisplayName            *string                              `json:"displayName"`
+		TimeEffectiveFrom      *common.SDKTime                      `json:"timeEffectiveFrom"`
+		TimeEffectiveUntil     *common.SDKTime                      `json:"timeEffectiveUntil"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Description = model.Description
+
+	m.Dimensions = model.Dimensions
+
+	m.SuppressionId = model.SuppressionId
+
+	nn, e = model.AlarmSuppressionTarget.UnmarshalPolymorphicJSON(model.AlarmSuppressionTarget.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.AlarmSuppressionTarget = nn.(AlarmSuppressionTarget)
+	} else {
+		m.AlarmSuppressionTarget = nil
+	}
+
+	m.Level = model.Level
+
+	m.DisplayName = model.DisplayName
+
+	m.TimeEffectiveFrom = model.TimeEffectiveFrom
+
+	m.TimeEffectiveUntil = model.TimeEffectiveUntil
+
+	return
+}
+
+// AlarmSuppressionHistoryItemLevelEnum Enum with underlying type: string
+type AlarmSuppressionHistoryItemLevelEnum string
+
+// Set of constants representing the allowable values for AlarmSuppressionHistoryItemLevelEnum
+const (
+	AlarmSuppressionHistoryItemLevelAlarm     AlarmSuppressionHistoryItemLevelEnum = "ALARM"
+	AlarmSuppressionHistoryItemLevelDimension AlarmSuppressionHistoryItemLevelEnum = "DIMENSION"
+)
+
+var mappingAlarmSuppressionHistoryItemLevelEnum = map[string]AlarmSuppressionHistoryItemLevelEnum{
+	"ALARM":     AlarmSuppressionHistoryItemLevelAlarm,
+	"DIMENSION": AlarmSuppressionHistoryItemLevelDimension,
+}
+
+var mappingAlarmSuppressionHistoryItemLevelEnumLowerCase = map[string]AlarmSuppressionHistoryItemLevelEnum{
+	"alarm":     AlarmSuppressionHistoryItemLevelAlarm,
+	"dimension": AlarmSuppressionHistoryItemLevelDimension,
+}
+
+// GetAlarmSuppressionHistoryItemLevelEnumValues Enumerates the set of values for AlarmSuppressionHistoryItemLevelEnum
+func GetAlarmSuppressionHistoryItemLevelEnumValues() []AlarmSuppressionHistoryItemLevelEnum {
+	values := make([]AlarmSuppressionHistoryItemLevelEnum, 0)
+	for _, v := range mappingAlarmSuppressionHistoryItemLevelEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAlarmSuppressionHistoryItemLevelEnumStringValues Enumerates the set of values in String for AlarmSuppressionHistoryItemLevelEnum
+func GetAlarmSuppressionHistoryItemLevelEnumStringValues() []string {
+	return []string{
+		"ALARM",
+		"DIMENSION",
+	}
+}
+
+// GetMappingAlarmSuppressionHistoryItemLevelEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAlarmSuppressionHistoryItemLevelEnum(val string) (AlarmSuppressionHistoryItemLevelEnum, bool) {
+	enum, ok := mappingAlarmSuppressionHistoryItemLevelEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_history_item_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_history_item_collection.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AlarmSuppressionHistoryItemCollection Collection of property summaries for alarm suppression history items.
+type AlarmSuppressionHistoryItemCollection struct {
+
+	// List of alarm suppression history items.
+	Items []AlarmSuppressionHistoryItem `mandatory:"true" json:"items"`
+}
+
+func (m AlarmSuppressionHistoryItemCollection) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AlarmSuppressionHistoryItemCollection) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_summary.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AlarmSuppressionSummary A summary of properties for the specified dimension-specific alarm suppression.
+type AlarmSuppressionSummary struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm suppression.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the alarm suppression.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	AlarmSuppressionTarget AlarmSuppressionTarget `mandatory:"true" json:"alarmSuppressionTarget"`
+
+	// A user-friendly name for the alarm suppression. It does not have to be unique, and it's changeable. Avoid entering confidential information.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// Configured dimension filter for suppressing alarm state entries that include the set of specified dimension key-value pairs.
+	// Example: `{"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"}`
+	Dimensions map[string]string `mandatory:"true" json:"dimensions"`
+
+	// The start date and time for the suppression to take place, inclusive. Format defined by RFC3339.
+	// Example: `2023-02-01T01:02:29.600Z`
+	TimeSuppressFrom *common.SDKTime `mandatory:"true" json:"timeSuppressFrom"`
+
+	// The end date and time for the suppression to take place, inclusive. Format defined by RFC3339.
+	// Example: `2023-02-01T02:02:29.600Z`
+	TimeSuppressUntil *common.SDKTime `mandatory:"true" json:"timeSuppressUntil"`
+
+	// The current lifecycle state of the alarm suppression.
+	// Example: `DELETED`
+	LifecycleState AlarmSuppressionLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The date and time the alarm suppression was created. Format defined by RFC3339.
+	// Example: `2023-02-01T01:02:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The date and time the alarm suppression was last updated (deleted). Format defined by RFC3339.
+	// Example: `2023-02-03T01:02:29.600Z`
+	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
+
+	// Human-readable reason for this alarm suppression.
+	// It does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	// Oracle recommends including tracking information for the event or associated work,
+	// such as a ticket number.
+	// Example: `Planned outage due to change IT-1234.`
+	Description *string `mandatory:"false" json:"description"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"bar-key": "value"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// Example: `{"foo-namespace": {"bar-key": "value"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m AlarmSuppressionSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AlarmSuppressionSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAlarmSuppressionLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetAlarmSuppressionLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *AlarmSuppressionSummary) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Description            *string                            `json:"description"`
+		FreeformTags           map[string]string                  `json:"freeformTags"`
+		DefinedTags            map[string]map[string]interface{}  `json:"definedTags"`
+		Id                     *string                            `json:"id"`
+		CompartmentId          *string                            `json:"compartmentId"`
+		AlarmSuppressionTarget alarmsuppressiontarget             `json:"alarmSuppressionTarget"`
+		DisplayName            *string                            `json:"displayName"`
+		Dimensions             map[string]string                  `json:"dimensions"`
+		TimeSuppressFrom       *common.SDKTime                    `json:"timeSuppressFrom"`
+		TimeSuppressUntil      *common.SDKTime                    `json:"timeSuppressUntil"`
+		LifecycleState         AlarmSuppressionLifecycleStateEnum `json:"lifecycleState"`
+		TimeCreated            *common.SDKTime                    `json:"timeCreated"`
+		TimeUpdated            *common.SDKTime                    `json:"timeUpdated"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Description = model.Description
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.Id = model.Id
+
+	m.CompartmentId = model.CompartmentId
+
+	nn, e = model.AlarmSuppressionTarget.UnmarshalPolymorphicJSON(model.AlarmSuppressionTarget.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.AlarmSuppressionTarget = nn.(AlarmSuppressionTarget)
+	} else {
+		m.AlarmSuppressionTarget = nil
+	}
+
+	m.DisplayName = model.DisplayName
+
+	m.Dimensions = model.Dimensions
+
+	m.TimeSuppressFrom = model.TimeSuppressFrom
+
+	m.TimeSuppressUntil = model.TimeSuppressUntil
+
+	m.LifecycleState = model.LifecycleState
+
+	m.TimeCreated = model.TimeCreated
+
+	m.TimeUpdated = model.TimeUpdated
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_target.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/alarm_suppression_target.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AlarmSuppressionTarget The target of the alarm suppression.
+type AlarmSuppressionTarget interface {
+}
+
+type alarmsuppressiontarget struct {
+	JsonData   []byte
+	TargetType string `json:"targetType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *alarmsuppressiontarget) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshaleralarmsuppressiontarget alarmsuppressiontarget
+	s := struct {
+		Model Unmarshaleralarmsuppressiontarget
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.TargetType = s.Model.TargetType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *alarmsuppressiontarget) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.TargetType {
+	case "ALARM":
+		mm := AlarmSuppressionAlarmTarget{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for AlarmSuppressionTarget: %s.", m.TargetType)
+		return *m, nil
+	}
+}
+
+func (m alarmsuppressiontarget) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m alarmsuppressiontarget) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// AlarmSuppressionTargetTargetTypeEnum Enum with underlying type: string
+type AlarmSuppressionTargetTargetTypeEnum string
+
+// Set of constants representing the allowable values for AlarmSuppressionTargetTargetTypeEnum
+const (
+	AlarmSuppressionTargetTargetTypeAlarm AlarmSuppressionTargetTargetTypeEnum = "ALARM"
+)
+
+var mappingAlarmSuppressionTargetTargetTypeEnum = map[string]AlarmSuppressionTargetTargetTypeEnum{
+	"ALARM": AlarmSuppressionTargetTargetTypeAlarm,
+}
+
+var mappingAlarmSuppressionTargetTargetTypeEnumLowerCase = map[string]AlarmSuppressionTargetTargetTypeEnum{
+	"alarm": AlarmSuppressionTargetTargetTypeAlarm,
+}
+
+// GetAlarmSuppressionTargetTargetTypeEnumValues Enumerates the set of values for AlarmSuppressionTargetTargetTypeEnum
+func GetAlarmSuppressionTargetTargetTypeEnumValues() []AlarmSuppressionTargetTargetTypeEnum {
+	values := make([]AlarmSuppressionTargetTargetTypeEnum, 0)
+	for _, v := range mappingAlarmSuppressionTargetTargetTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAlarmSuppressionTargetTargetTypeEnumStringValues Enumerates the set of values in String for AlarmSuppressionTargetTargetTypeEnum
+func GetAlarmSuppressionTargetTargetTypeEnumStringValues() []string {
+	return []string{
+		"ALARM",
+	}
+}
+
+// GetMappingAlarmSuppressionTargetTargetTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAlarmSuppressionTargetTargetTypeEnum(val string) (AlarmSuppressionTargetTargetTypeEnum, bool) {
+	enum, ok := mappingAlarmSuppressionTargetTargetTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/change_alarm_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/change_alarm_compartment_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/change_alarm_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/change_alarm_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/create_alarm_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/create_alarm_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -22,7 +23,7 @@ type CreateAlarmDetails struct {
 
 	// A user-friendly name for the alarm. It does not have to be unique, and it's changeable.
 	// Avoid entering confidential information.
-	// This name is sent as the title for notifications related to this alarm.
+	// This value determines the title of each alarm notification.
 	// Example: `High CPU Utilization`
 	DisplayName *string `mandatory:"true" json:"displayName"`
 
@@ -44,9 +45,12 @@ type CreateAlarmDetails struct {
 	// rule (threshold or absence). Supported values for interval depend on the specified time range. More
 	// interval values are supported for smaller time ranges. You can optionally
 	// specify dimensions and grouping functions. Supported grouping functions: `grouping()`, `groupBy()`.
-	// For details about Monitoring Query Language (MQL), see Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
-	// For available dimensions, review the metric definition for the supported service.
-	// See Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
+	// For information about writing MQL expressions, see
+	// Editing the MQL Expression for a Query (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/query-metric-mql.htm).
+	// For details about MQL, see
+	// Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
+	// For available dimensions, review the metric definition for the supported service. See
+	// Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
 	// Example of threshold alarm:
 	//   -----
 	//     CpuUtilization[1m]{availabilityDomain="cumS:PHX-AD-1"}.groupBy(availabilityDomain).percentile(0.9) > 85
@@ -61,10 +65,11 @@ type CreateAlarmDetails struct {
 	// Example: `CRITICAL`
 	Severity AlarmSeverityEnum `mandatory:"true" json:"severity"`
 
-	// A list of destinations to which the notifications for this alarm will be delivered.
-	// Each destination is represented by an OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) related to the supported destination service.
-	// For example, a destination using the Notifications service is represented by a topic OCID.
-	// Supported destination services: Notifications Service. Limit: One destination per supported destination service.
+	// A list of destinations for alarm notifications.
+	// Each destination is represented by the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
+	// of a related resource, such as a NotificationTopic.
+	// Supported destination services: Notifications, Streaming.
+	// Limit: One destination per supported destination service.
 	Destinations []string `mandatory:"true" json:"destinations"`
 
 	// Whether the alarm is enabled.
@@ -101,23 +106,24 @@ type CreateAlarmDetails struct {
 	// Example: `PT5M`
 	PendingDuration *string `mandatory:"false" json:"pendingDuration"`
 
-	// The human-readable content of the notification delivered. Oracle recommends providing guidance
+	// The human-readable content of the delivered alarm notification. Oracle recommends providing guidance
 	// to operators for resolving the alarm condition. Consider adding links to standard runbook
 	// practices. Avoid entering confidential information.
 	// Example: `High CPU usage alert. Follow runbook instructions for resolution.`
 	Body *string `mandatory:"false" json:"body"`
 
-	// When set to `true`, splits notifications per metric stream. When set to `false`, groups notifications across metric streams.
+	// When set to `true`, splits alarm notifications per metric stream.
+	// When set to `false`, groups alarm notifications across metric streams.
 	// Example: `true`
 	IsNotificationsPerMetricDimensionEnabled *bool `mandatory:"false" json:"isNotificationsPerMetricDimensionEnabled"`
 
-	// The format to use for notification messages sent from this alarm. The formats are:
-	// * `RAW` - Raw JSON blob. Default value.
-	// * `PRETTY_JSON`: JSON with new lines and indents.
-	// * `ONS_OPTIMIZED`: Simplified, user-friendly layout. Applies only to messages sent through the Notifications service to the following subscription types: Email.
+	// The format to use for alarm notifications. The formats are:
+	// * `RAW` - Raw JSON blob. Default value. When the `destinations` attribute specifies `Streaming`, all alarm notifications use this format.
+	// * `PRETTY_JSON`: JSON with new lines and indents. Available when the `destinations` attribute specifies `Notifications` only.
+	// * `ONS_OPTIMIZED`: Simplified, user-friendly layout. Available when the `destinations` attribute specifies `Notifications` only. Applies to Email subscription types only.
 	MessageFormat CreateAlarmDetailsMessageFormatEnum `mandatory:"false" json:"messageFormat,omitempty"`
 
-	// The frequency at which notifications are re-submitted, if the alarm keeps firing without
+	// The frequency for re-submitting alarm notifications, if the alarm keeps firing without
 	// interruption. Format defined by ISO 8601. For example, `PT4H` indicates four hours.
 	// Minimum: PT1M. Maximum: P30D.
 	// Default value: null (notifications are not re-submitted).

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/create_alarm_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/create_alarm_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/create_alarm_suppression_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/create_alarm_suppression_details.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateAlarmSuppressionDetails The configuration details for creating a dimension-specific alarm suppression.
+type CreateAlarmSuppressionDetails struct {
+	AlarmSuppressionTarget AlarmSuppressionTarget `mandatory:"true" json:"alarmSuppressionTarget"`
+
+	// A user-friendly name for the alarm suppression. It does not have to be unique, and it's changeable. Avoid entering confidential information.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// A filter to suppress only alarm state entries that include the set of specified dimension key-value pairs.
+	// If you specify {"availabilityDomain": "phx-ad-1"}
+	// and the alarm state entry corresponds to the set {"availabilityDomain": "phx-ad-1" and "resourceId": "ocid1.instance.region1.phx.exampleuniqueID"},
+	// then this alarm will be included for suppression.
+	// The value cannot be an empty object.
+	// Only a single value is allowed per key. No grouping of multiple values is allowed under the same key.
+	// Maximum characters (after serialization): 4000. This maximum satisfies typical use cases.
+	// The response for an exceeded maximum is `HTTP 400` with an "dimensions values are too long" message.
+	Dimensions map[string]string `mandatory:"true" json:"dimensions"`
+
+	// The start date and time for the suppression to take place, inclusive. Format defined by RFC3339.
+	// Example: `2023-02-01T01:02:29.600Z`
+	TimeSuppressFrom *common.SDKTime `mandatory:"true" json:"timeSuppressFrom"`
+
+	// The end date and time for the suppression to take place, inclusive. Format defined by RFC3339.
+	// Example: `2023-02-01T02:02:29.600Z`
+	TimeSuppressUntil *common.SDKTime `mandatory:"true" json:"timeSuppressUntil"`
+
+	// Human-readable reason for this alarm suppression.
+	// It does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	// Oracle recommends including tracking information for the event or associated work,
+	// such as a ticket number.
+	// Example: `Planned outage due to change IT-1234.`
+	Description *string `mandatory:"false" json:"description"`
+
+	// Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Usage of predefined tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateAlarmSuppressionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateAlarmSuppressionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateAlarmSuppressionDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Description            *string                           `json:"description"`
+		FreeformTags           map[string]string                 `json:"freeformTags"`
+		DefinedTags            map[string]map[string]interface{} `json:"definedTags"`
+		AlarmSuppressionTarget alarmsuppressiontarget            `json:"alarmSuppressionTarget"`
+		DisplayName            *string                           `json:"displayName"`
+		Dimensions             map[string]string                 `json:"dimensions"`
+		TimeSuppressFrom       *common.SDKTime                   `json:"timeSuppressFrom"`
+		TimeSuppressUntil      *common.SDKTime                   `json:"timeSuppressUntil"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Description = model.Description
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	nn, e = model.AlarmSuppressionTarget.UnmarshalPolymorphicJSON(model.AlarmSuppressionTarget.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.AlarmSuppressionTarget = nn.(AlarmSuppressionTarget)
+	} else {
+		m.AlarmSuppressionTarget = nil
+	}
+
+	m.DisplayName = model.DisplayName
+
+	m.Dimensions = model.Dimensions
+
+	m.TimeSuppressFrom = model.TimeSuppressFrom
+
+	m.TimeSuppressUntil = model.TimeSuppressUntil
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/create_alarm_suppression_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/create_alarm_suppression_request_response.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateAlarmSuppressionRequest wrapper for the CreateAlarmSuppression operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/CreateAlarmSuppression.go.html to see an example of how to use CreateAlarmSuppressionRequest.
+type CreateAlarmSuppressionRequest struct {
+
+	// The details of the alarm suppression to be created
+	CreateAlarmSuppressionDetails `contributesTo:"body"`
+
+	// Customer part of the request identifier token. If you need to contact Oracle about a particular
+	// request, please provide the complete request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// might be rejected.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateAlarmSuppressionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateAlarmSuppressionRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateAlarmSuppressionRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateAlarmSuppressionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateAlarmSuppressionRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateAlarmSuppressionResponse wrapper for the CreateAlarmSuppression operation
+type CreateAlarmSuppressionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The AlarmSuppression instance
+	AlarmSuppression `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+}
+
+func (response CreateAlarmSuppressionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateAlarmSuppressionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/datapoint.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/datapoint.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -21,7 +22,8 @@ import (
 type Datapoint struct {
 
 	// Timestamp for this metric value. Format defined by RFC3339.
-	// Example: `2019-02-01T01:02:29.600Z`
+	// For a data point to be posted, its timestamp must be near current time (less than two hours in the past and less than 10 minutes in the future).
+	// Example: `2023-02-01T01:02:29.600Z`
 	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
 
 	// Numeric value of the metric.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/delete_alarm_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/delete_alarm_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/delete_alarm_suppression_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/delete_alarm_suppression_request_response.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteAlarmSuppressionRequest wrapper for the DeleteAlarmSuppression operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/DeleteAlarmSuppression.go.html to see an example of how to use DeleteAlarmSuppressionRequest.
+type DeleteAlarmSuppressionRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm suppression.
+	AlarmSuppressionId *string `mandatory:"true" contributesTo:"path" name:"alarmSuppressionId"`
+
+	// Customer part of the request identifier token. If you need to contact Oracle about a particular
+	// request, please provide the complete request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteAlarmSuppressionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteAlarmSuppressionRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteAlarmSuppressionRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteAlarmSuppressionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteAlarmSuppressionRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteAlarmSuppressionResponse wrapper for the DeleteAlarmSuppression operation
+type DeleteAlarmSuppressionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteAlarmSuppressionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteAlarmSuppressionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/failed_metric_record.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/failed_metric_record.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/get_alarm_history_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/get_alarm_history_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -31,21 +31,23 @@ type GetAlarmHistoryRequest struct {
 	AlarmHistorytype GetAlarmHistoryAlarmHistorytypeEnum `mandatory:"false" contributesTo:"query" name:"alarmHistorytype" omitEmpty:"true"`
 
 	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	// Default: 1000
 	// Example: 500
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
 
 	// A filter to return only alarm history entries with timestamps occurring on or after the specified date and time. Format defined by RFC3339.
-	// Example: `2019-01-01T01:00:00.789Z`
+	// Example: `2023-01-01T01:00:00.789Z`
 	TimestampGreaterThanOrEqualTo *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timestampGreaterThanOrEqualTo"`
 
 	// A filter to return only alarm history entries with timestamps occurring before the specified date and time. Format defined by RFC3339.
-	// Example: `2019-01-02T01:00:00.789Z`
+	// Example: `2023-01-02T01:00:00.789Z`
 	TimestampLessThan *common.SDKTime `mandatory:"false" contributesTo:"query" name:"timestampLessThan"`
 
 	// Metadata about the request. This information will not be transmitted to the service, but
@@ -107,7 +109,8 @@ type GetAlarmHistoryResponse struct {
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
 	// For list pagination. When this header appears in the response, additional pages of results remain.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/get_alarm_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/get_alarm_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/get_alarm_suppression_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/get_alarm_suppression_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetAlarmSuppressionRequest wrapper for the GetAlarmSuppression operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/GetAlarmSuppression.go.html to see an example of how to use GetAlarmSuppressionRequest.
+type GetAlarmSuppressionRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm suppression.
+	AlarmSuppressionId *string `mandatory:"true" contributesTo:"path" name:"alarmSuppressionId"`
+
+	// Customer part of the request identifier token. If you need to contact Oracle about a particular
+	// request, please provide the complete request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetAlarmSuppressionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetAlarmSuppressionRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetAlarmSuppressionRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetAlarmSuppressionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetAlarmSuppressionRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetAlarmSuppressionResponse wrapper for the GetAlarmSuppression operation
+type GetAlarmSuppressionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The AlarmSuppression instance
+	AlarmSuppression `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+}
+
+func (response GetAlarmSuppressionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetAlarmSuppressionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_alarm_suppressions_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_alarm_suppressions_request_response.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListAlarmSuppressionsRequest wrapper for the ListAlarmSuppressions operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/ListAlarmSuppressions.go.html to see an example of how to use ListAlarmSuppressionsRequest.
+type ListAlarmSuppressionsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the alarm that is the target of the alarm suppression.
+	AlarmId *string `mandatory:"true" contributesTo:"query" name:"alarmId"`
+
+	// Customer part of the request identifier token. If you need to contact Oracle about a particular
+	// request, please provide the complete request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A filter to return only resources that match the given display name exactly.
+	// Use this filter to list a alarm suppression by name.
+	// Alternatively, when you know the alarm suppression OCID, use the GetAlarmSuppression operation.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// A filter to return only resources that match the given lifecycle state exactly. When not specified, only resources in the ACTIVE lifecycle state are listed.
+	LifecycleState AlarmSuppressionLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// The field to use when sorting returned alarm suppressions. Only one sorting level is provided.
+	// Example: `timeCreated`
+	SortBy ListAlarmSuppressionsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use when sorting returned alarm suppressions. Ascending (ASC) or descending (DESC).
+	// Example: `ASC`
+	SortOrder ListAlarmSuppressionsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Default: 1000
+	// Example: 500
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListAlarmSuppressionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListAlarmSuppressionsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListAlarmSuppressionsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListAlarmSuppressionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListAlarmSuppressionsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAlarmSuppressionLifecycleStateEnum(string(request.LifecycleState)); !ok && request.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", request.LifecycleState, strings.Join(GetAlarmSuppressionLifecycleStateEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListAlarmSuppressionsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListAlarmSuppressionsSortByEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListAlarmSuppressionsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListAlarmSuppressionsSortOrderEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListAlarmSuppressionsResponse wrapper for the ListAlarmSuppressions operation
+type ListAlarmSuppressionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of AlarmSuppressionCollection instances
+	AlarmSuppressionCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For list pagination. When this header appears in the response, next page of results remains.
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// For list pagination. When this header appears in the response, previous pages of results remains.
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPreviousPage *string `presentIn:"header" name:"opc-previous-page"`
+}
+
+func (response ListAlarmSuppressionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListAlarmSuppressionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListAlarmSuppressionsSortByEnum Enum with underlying type: string
+type ListAlarmSuppressionsSortByEnum string
+
+// Set of constants representing the allowable values for ListAlarmSuppressionsSortByEnum
+const (
+	ListAlarmSuppressionsSortByDisplayname      ListAlarmSuppressionsSortByEnum = "displayName"
+	ListAlarmSuppressionsSortByTimecreated      ListAlarmSuppressionsSortByEnum = "timeCreated"
+	ListAlarmSuppressionsSortByTimesuppressfrom ListAlarmSuppressionsSortByEnum = "timeSuppressFrom"
+)
+
+var mappingListAlarmSuppressionsSortByEnum = map[string]ListAlarmSuppressionsSortByEnum{
+	"displayName":      ListAlarmSuppressionsSortByDisplayname,
+	"timeCreated":      ListAlarmSuppressionsSortByTimecreated,
+	"timeSuppressFrom": ListAlarmSuppressionsSortByTimesuppressfrom,
+}
+
+var mappingListAlarmSuppressionsSortByEnumLowerCase = map[string]ListAlarmSuppressionsSortByEnum{
+	"displayname":      ListAlarmSuppressionsSortByDisplayname,
+	"timecreated":      ListAlarmSuppressionsSortByTimecreated,
+	"timesuppressfrom": ListAlarmSuppressionsSortByTimesuppressfrom,
+}
+
+// GetListAlarmSuppressionsSortByEnumValues Enumerates the set of values for ListAlarmSuppressionsSortByEnum
+func GetListAlarmSuppressionsSortByEnumValues() []ListAlarmSuppressionsSortByEnum {
+	values := make([]ListAlarmSuppressionsSortByEnum, 0)
+	for _, v := range mappingListAlarmSuppressionsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAlarmSuppressionsSortByEnumStringValues Enumerates the set of values in String for ListAlarmSuppressionsSortByEnum
+func GetListAlarmSuppressionsSortByEnumStringValues() []string {
+	return []string{
+		"displayName",
+		"timeCreated",
+		"timeSuppressFrom",
+	}
+}
+
+// GetMappingListAlarmSuppressionsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAlarmSuppressionsSortByEnum(val string) (ListAlarmSuppressionsSortByEnum, bool) {
+	enum, ok := mappingListAlarmSuppressionsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListAlarmSuppressionsSortOrderEnum Enum with underlying type: string
+type ListAlarmSuppressionsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListAlarmSuppressionsSortOrderEnum
+const (
+	ListAlarmSuppressionsSortOrderAsc  ListAlarmSuppressionsSortOrderEnum = "ASC"
+	ListAlarmSuppressionsSortOrderDesc ListAlarmSuppressionsSortOrderEnum = "DESC"
+)
+
+var mappingListAlarmSuppressionsSortOrderEnum = map[string]ListAlarmSuppressionsSortOrderEnum{
+	"ASC":  ListAlarmSuppressionsSortOrderAsc,
+	"DESC": ListAlarmSuppressionsSortOrderDesc,
+}
+
+var mappingListAlarmSuppressionsSortOrderEnumLowerCase = map[string]ListAlarmSuppressionsSortOrderEnum{
+	"asc":  ListAlarmSuppressionsSortOrderAsc,
+	"desc": ListAlarmSuppressionsSortOrderDesc,
+}
+
+// GetListAlarmSuppressionsSortOrderEnumValues Enumerates the set of values for ListAlarmSuppressionsSortOrderEnum
+func GetListAlarmSuppressionsSortOrderEnumValues() []ListAlarmSuppressionsSortOrderEnum {
+	values := make([]ListAlarmSuppressionsSortOrderEnum, 0)
+	for _, v := range mappingListAlarmSuppressionsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAlarmSuppressionsSortOrderEnumStringValues Enumerates the set of values in String for ListAlarmSuppressionsSortOrderEnum
+func GetListAlarmSuppressionsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListAlarmSuppressionsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAlarmSuppressionsSortOrderEnum(val string) (ListAlarmSuppressionsSortOrderEnum, bool) {
+	enum, ok := mappingListAlarmSuppressionsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_alarms_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_alarms_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -29,11 +29,13 @@ type ListAlarmsRequest struct {
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
 	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	// Default: 1000
 	// Example: 500
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
@@ -121,7 +123,8 @@ type ListAlarmsResponse struct {
 	Items []AlarmSummary `presentIn:"body"`
 
 	// For list pagination. When this header appears in the response, additional pages of results remain.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_alarms_status_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_alarms_status_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -36,11 +36,13 @@ type ListAlarmsStatusRequest struct {
 	CompartmentIdInSubtree *bool `mandatory:"false" contributesTo:"query" name:"compartmentIdInSubtree"`
 
 	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	// Default: 1000
 	// Example: 500
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
@@ -56,6 +58,26 @@ type ListAlarmsStatusRequest struct {
 	// The sort order to use when sorting returned alarm definitions. Ascending (ASC) or descending (DESC).
 	// Example: `ASC`
 	SortOrder ListAlarmsStatusSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// A filter to return only the resource with the specified OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
+	// The resource must be monitored by the metric that you are searching for.
+	// Example: `ocid1.instance.oc1.phx.exampleuniqueID`
+	ResourceId *string `mandatory:"false" contributesTo:"query" name:"resourceId"`
+
+	// A filter to return only resources that match the given service name exactly.
+	// Use this filter to list all alarms containing metric streams that match the *exact* service-name dimension.
+	// Example: `logging-analytics`
+	ServiceName *string `mandatory:"false" contributesTo:"query" name:"serviceName"`
+
+	// A filter to return only resources that match the given entity OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) exactly.
+	// The resource (entity) must be monitored by the metric that you are searching for.
+	// Example: `ocid1.instance.oc1.phx.exampleuniqueID`
+	EntityId *string `mandatory:"false" contributesTo:"query" name:"entityId"`
+
+	// A filter to return only metric streams that match the specified status.
+	// For example, the value "FIRING" returns only firing metric streams.
+	// Example: `FIRING`
+	Status ListAlarmsStatusStatusEnum `mandatory:"false" contributesTo:"query" name:"status" omitEmpty:"true"`
 
 	// Metadata about the request. This information will not be transmitted to the service, but
 	// represents information that the SDK will consume to drive retry behavior.
@@ -99,6 +121,9 @@ func (request ListAlarmsStatusRequest) ValidateEnumValue() (bool, error) {
 	if _, ok := GetMappingListAlarmsStatusSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
 		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListAlarmsStatusSortOrderEnumStringValues(), ",")))
 	}
+	if _, ok := GetMappingListAlarmsStatusStatusEnum(string(request.Status)); !ok && request.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", request.Status, strings.Join(GetListAlarmsStatusStatusEnumStringValues(), ",")))
+	}
 	if len(errMessage) > 0 {
 		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
 	}
@@ -115,7 +140,8 @@ type ListAlarmsStatusResponse struct {
 	Items []AlarmStatusSummary `presentIn:"body"`
 
 	// For list pagination. When this header appears in the response, additional pages of results remain.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
@@ -213,5 +239,47 @@ func GetListAlarmsStatusSortOrderEnumStringValues() []string {
 // GetMappingListAlarmsStatusSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
 func GetMappingListAlarmsStatusSortOrderEnum(val string) (ListAlarmsStatusSortOrderEnum, bool) {
 	enum, ok := mappingListAlarmsStatusSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListAlarmsStatusStatusEnum Enum with underlying type: string
+type ListAlarmsStatusStatusEnum string
+
+// Set of constants representing the allowable values for ListAlarmsStatusStatusEnum
+const (
+	ListAlarmsStatusStatusFiring ListAlarmsStatusStatusEnum = "FIRING"
+	ListAlarmsStatusStatusOk     ListAlarmsStatusStatusEnum = "OK"
+)
+
+var mappingListAlarmsStatusStatusEnum = map[string]ListAlarmsStatusStatusEnum{
+	"FIRING": ListAlarmsStatusStatusFiring,
+	"OK":     ListAlarmsStatusStatusOk,
+}
+
+var mappingListAlarmsStatusStatusEnumLowerCase = map[string]ListAlarmsStatusStatusEnum{
+	"firing": ListAlarmsStatusStatusFiring,
+	"ok":     ListAlarmsStatusStatusOk,
+}
+
+// GetListAlarmsStatusStatusEnumValues Enumerates the set of values for ListAlarmsStatusStatusEnum
+func GetListAlarmsStatusStatusEnumValues() []ListAlarmsStatusStatusEnum {
+	values := make([]ListAlarmsStatusStatusEnum, 0)
+	for _, v := range mappingListAlarmsStatusStatusEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAlarmsStatusStatusEnumStringValues Enumerates the set of values in String for ListAlarmsStatusStatusEnum
+func GetListAlarmsStatusStatusEnumStringValues() []string {
+	return []string{
+		"FIRING",
+		"OK",
+	}
+}
+
+// GetMappingListAlarmsStatusStatusEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAlarmsStatusStatusEnum(val string) (ListAlarmsStatusStatusEnum, bool) {
+	enum, ok := mappingListAlarmsStatusStatusEnumLowerCase[strings.ToLower(val)]
 	return enum, ok
 }

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_metrics_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_metrics_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -38,11 +39,12 @@ type ListMetricsDetails struct {
 
 	// Qualifiers that you want to use when searching for metric definitions.
 	// Available dimensions vary by metric namespace. Each dimension takes the form of a key-value pair.
-	// Example: `"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"`
+	// Example: `{"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"}`
 	DimensionFilters map[string]string `mandatory:"false" json:"dimensionFilters"`
 
 	// Group metrics by these fields in the response. For example, to list all metric namespaces available
 	//           in a compartment, groupBy the "namespace" field. Supported fields: namespace, name, resourceGroup.
+	// If `groupBy` is used, then `dimensionFilters` is ignored.
 	// Example - group by namespace:
 	// `[ "namespace" ]`
 	GroupBy []string `mandatory:"false" json:"groupBy"`

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_metrics_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/list_metrics_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -32,11 +32,13 @@ type ListMetricsRequest struct {
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
 	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	// Default: 1000
 	// Example: 500
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
@@ -100,7 +102,8 @@ type ListMetricsResponse struct {
 	Items []Metric `presentIn:"body"`
 
 	// For list pagination. When this header appears in the response, additional pages of results remain.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 
 	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/metric.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/metric.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -18,7 +19,8 @@ import (
 )
 
 // Metric The properties that define a metric.
-// For information about metrics, see Metrics Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#MetricsOverview).
+// For information about metrics, see
+// Metrics Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#MetricsOverview).
 type Metric struct {
 
 	// The name of the metric.
@@ -40,7 +42,7 @@ type Metric struct {
 
 	// Qualifiers provided in a metric definition. Available dimensions vary by metric namespace.
 	// Each dimension takes the form of a key-value pair.
-	// Example: `"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"`
+	// Example: `{"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"}`
 	Dimensions map[string]string `mandatory:"false" json:"dimensions"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/metric_data.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/metric_data.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -18,7 +19,8 @@ import (
 )
 
 // MetricData The set of aggregated data returned for a metric.
-// For information about metrics, see Metrics Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#MetricsOverview).
+// For information about metrics, see
+// Metrics Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#MetricsOverview).
 // Limits information for returned data follows.
 // * Data points: 100,000.
 // * Metric streams* within data points: 2,000.
@@ -29,7 +31,8 @@ import (
 // *A metric stream is an individual set of aggregated data for a metric with zero or more dimension values.
 // Metric streams cannot be aggregated across metric groups.
 // A metric group is the combination of a given metric, metric namespace, and tenancy for the purpose of determining limits.
-// For more information about metric-related concepts, see Monitoring Concepts (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#concepts).
+// For more information about metric-related concepts, see
+// Monitoring Concepts (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#concepts).
 type MetricData struct {
 
 	// The reference provided in a metric definition to indicate the source service or
@@ -38,7 +41,7 @@ type MetricData struct {
 	Namespace *string `mandatory:"true" json:"namespace"`
 
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the
-	// resources from which the aggregated data was returned.
+	// resources that the aggregated data was returned from.
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
 	// The name of the metric.
@@ -47,7 +50,7 @@ type MetricData struct {
 
 	// Qualifiers provided in the definition of the returned metric.
 	// Available dimensions vary by metric namespace. Each dimension takes the form of a key-value pair.
-	// Example: `"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"`
+	// Example: `{"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"}`
 	Dimensions map[string]string `mandatory:"true" json:"dimensions"`
 
 	// The list of timestamp-value pairs returned for the specified request. Metric values are rolled up to the start time specified in the request.
@@ -64,7 +67,7 @@ type MetricData struct {
 	Metadata map[string]string `mandatory:"false" json:"metadata"`
 
 	// The time between calculated aggregation windows. Use with the query interval to vary the
-	// frequency at which aggregated data points are returned. For example, use a query interval of
+	// frequency for returning aggregated data points. For example, use a query interval of
 	// 5 minutes with a resolution of 1 minute to retrieve five-minute aggregations at a one-minute
 	// frequency. The resolution must be equal or less than the interval in the query. The default
 	// resolution is 1m (one minute). Supported values: `1m`-`60m`, `1h`-`24h`, `1d`.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/metric_data_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/metric_data_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -21,7 +22,7 @@ import (
 type MetricDataDetails struct {
 
 	// The source service or application emitting the metric.
-	// A valid namespace value starts with an alphabetical character and includes only alphanumeric characters and underscores. The "oci_" prefix is reserved.
+	// A valid namespace value starts with an alphabetical character and includes only alphanumeric characters and underscores. Custom metrics can't use the following reserved prefixes: `oci_` and `oracle_`
 	// Avoid entering confidential information.
 	// Example: `my_namespace`
 	Namespace *string `mandatory:"true" json:"namespace"`
@@ -30,7 +31,7 @@ type MetricDataDetails struct {
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
 	// The name of the metric.
-	// A valid name value starts with an alphabetical character and includes only alphanumeric characters, dots, underscores, hyphens, and dollar signs. The `oci_` prefix is reserved.
+	// A valid name value starts with an alphabetical character and includes only alphanumeric characters, dots, underscores, hyphens, and dollar signs.
 	// Avoid entering confidential information.
 	// Example: `my_app.success_rate`
 	Name *string `mandatory:"true" json:"name"`
@@ -40,10 +41,11 @@ type MetricDataDetails struct {
 	// A valid dimension key includes only printable ASCII, excluding spaces. The character limit for a dimension key is 256.
 	// A valid dimension value includes only Unicode characters. The character limit for a dimension value is 512.
 	// Empty strings are not allowed for keys or values. Avoid entering confidential information.
-	// Example: `"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"`
+	// Example: `{"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"}`
 	Dimensions map[string]string `mandatory:"true" json:"dimensions"`
 
 	// A list of metric values with timestamps. At least one data point is required per call.
+	// For a data point to be posted, its timestamp must be near current time (less than two hours in the past and less than 10 minutes in the future).
 	Datapoints []Datapoint `mandatory:"true" json:"datapoints"`
 
 	// Resource group to assign to the metric. A resource group is a custom string that you can match when retrieving custom metrics. Only one resource group can be applied per metric.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/monitoring_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/monitoring_client.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -29,7 +30,7 @@ type MonitoringClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewMonitoringClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client MonitoringClient, err error) {
 	if enabled := common.CheckForEnabledServices("monitoring"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {
@@ -94,7 +95,8 @@ func (client *MonitoringClient) ConfigurationProvider() *common.ConfigurationPro
 }
 
 // ChangeAlarmCompartment Moves an alarm into a different compartment within the same tenancy.
-// For information about moving resources between compartments, see Moving Resources Between Compartments (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+// For more information, see
+// Moving an Alarm (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/change-compartment-alarm.htm).
 //
 // # See also
 //
@@ -157,7 +159,10 @@ func (client MonitoringClient) changeAlarmCompartment(ctx context.Context, reque
 }
 
 // CreateAlarm Creates a new alarm in the specified compartment.
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Creating an Alarm (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/create-alarm.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
 // Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
 // or transactions, per second (TPS) for a given tenancy.
@@ -222,8 +227,78 @@ func (client MonitoringClient) createAlarm(ctx context.Context, request common.O
 	return response, err
 }
 
+// CreateAlarmSuppression Creates a dimension-specific suppression for an alarm.
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
+// This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
+// Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
+// or transactions, per second (TPS) for a given tenancy.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/CreateAlarmSuppression.go.html to see an example of how to use CreateAlarmSuppression API.
+func (client MonitoringClient) CreateAlarmSuppression(ctx context.Context, request CreateAlarmSuppressionRequest) (response CreateAlarmSuppressionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createAlarmSuppression, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateAlarmSuppressionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateAlarmSuppressionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateAlarmSuppressionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateAlarmSuppressionResponse")
+	}
+	return
+}
+
+// createAlarmSuppression implements the OCIOperation interface (enables retrying operations)
+func (client MonitoringClient) createAlarmSuppression(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/alarmSuppressions", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateAlarmSuppressionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/monitoring/20180401/AlarmSuppression/CreateAlarmSuppression"
+		err = common.PostProcessServiceError(err, "Monitoring", "CreateAlarmSuppression", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // DeleteAlarm Deletes the specified alarm.
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Deleting an Alarm (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/delete-alarm.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
 // Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
 // or transactions, per second (TPS) for a given tenancy.
@@ -283,8 +358,73 @@ func (client MonitoringClient) deleteAlarm(ctx context.Context, request common.O
 	return response, err
 }
 
+// DeleteAlarmSuppression Deletes the specified alarm suppression.
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
+// This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
+// Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
+// or transactions, per second (TPS) for a given tenancy.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/DeleteAlarmSuppression.go.html to see an example of how to use DeleteAlarmSuppression API.
+func (client MonitoringClient) DeleteAlarmSuppression(ctx context.Context, request DeleteAlarmSuppressionRequest) (response DeleteAlarmSuppressionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteAlarmSuppression, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteAlarmSuppressionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteAlarmSuppressionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteAlarmSuppressionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteAlarmSuppressionResponse")
+	}
+	return
+}
+
+// deleteAlarmSuppression implements the OCIOperation interface (enables retrying operations)
+func (client MonitoringClient) deleteAlarmSuppression(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/alarmSuppressions/{alarmSuppressionId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteAlarmSuppressionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/monitoring/20180401/AlarmSuppression/DeleteAlarmSuppression"
+		err = common.PostProcessServiceError(err, "Monitoring", "DeleteAlarmSuppression", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetAlarm Gets the specified alarm.
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Getting an Alarm (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/get-alarm.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
 // Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
 // or transactions, per second (TPS) for a given tenancy.
@@ -345,7 +485,10 @@ func (client MonitoringClient) getAlarm(ctx context.Context, request common.OCIR
 }
 
 // GetAlarmHistory Get the history of the specified alarm.
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Getting History of an Alarm (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/get-alarm-history.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
 // Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
 // or transactions, per second (TPS) for a given tenancy.
@@ -405,8 +548,136 @@ func (client MonitoringClient) getAlarmHistory(ctx context.Context, request comm
 	return response, err
 }
 
+// GetAlarmSuppression Gets the specified alarm suppression.
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
+// This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
+// Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
+// or transactions, per second (TPS) for a given tenancy.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/GetAlarmSuppression.go.html to see an example of how to use GetAlarmSuppression API.
+func (client MonitoringClient) GetAlarmSuppression(ctx context.Context, request GetAlarmSuppressionRequest) (response GetAlarmSuppressionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getAlarmSuppression, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetAlarmSuppressionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetAlarmSuppressionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetAlarmSuppressionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetAlarmSuppressionResponse")
+	}
+	return
+}
+
+// getAlarmSuppression implements the OCIOperation interface (enables retrying operations)
+func (client MonitoringClient) getAlarmSuppression(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/alarmSuppressions/{alarmSuppressionId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetAlarmSuppressionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/monitoring/20180401/AlarmSuppression/GetAlarmSuppression"
+		err = common.PostProcessServiceError(err, "Monitoring", "GetAlarmSuppression", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListAlarmSuppressions Lists alarm suppressions for the specified alarm.
+// Only dimension-level suppressions are listed. Alarm-level suppressions are not listed.
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
+// This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
+// Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
+// or transactions, per second (TPS) for a given tenancy.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/ListAlarmSuppressions.go.html to see an example of how to use ListAlarmSuppressions API.
+func (client MonitoringClient) ListAlarmSuppressions(ctx context.Context, request ListAlarmSuppressionsRequest) (response ListAlarmSuppressionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listAlarmSuppressions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListAlarmSuppressionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListAlarmSuppressionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListAlarmSuppressionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListAlarmSuppressionsResponse")
+	}
+	return
+}
+
+// listAlarmSuppressions implements the OCIOperation interface (enables retrying operations)
+func (client MonitoringClient) listAlarmSuppressions(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/alarmSuppressions", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListAlarmSuppressionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/monitoring/20180401/AlarmSuppressionCollection/ListAlarmSuppressions"
+		err = common.PostProcessServiceError(err, "Monitoring", "ListAlarmSuppressions", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ListAlarms Lists the alarms for the specified compartment.
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Listing Alarms (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/list-alarm.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
 // Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
 // or transactions, per second (TPS) for a given tenancy.
@@ -469,8 +740,11 @@ func (client MonitoringClient) listAlarms(ctx context.Context, request common.OC
 // ListAlarmsStatus List the status of each alarm in the specified compartment.
 // Status is collective, across all metric streams in the alarm.
 // To list alarm status for each metric stream, use RetrieveDimensionStates.
-// The alarm attribute `isNotificationsPerMetricDimensionEnabled` must be set to `true`.
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// Optionally filter by resource or status value.
+// For more information, see
+// Listing Alarm Statuses (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/list-alarm-status.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
 // Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
 // or transactions, per second (TPS) for a given tenancy.
@@ -478,9 +752,10 @@ func (client MonitoringClient) listAlarms(ctx context.Context, request common.OC
 // # See also
 //
 // Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/ListAlarmsStatus.go.html to see an example of how to use ListAlarmsStatus API.
+// A default retry strategy applies to this operation ListAlarmsStatus()
 func (client MonitoringClient) ListAlarmsStatus(ctx context.Context, request ListAlarmsStatusRequest) (response ListAlarmsStatusResponse, err error) {
 	var ociResponse common.OCIResponse
-	policy := common.NoRetryPolicy()
+	policy := common.DefaultRetryPolicy()
 	if client.RetryPolicy() != nil {
 		policy = *client.RetryPolicy()
 	}
@@ -531,8 +806,12 @@ func (client MonitoringClient) listAlarmsStatus(ctx context.Context, request com
 }
 
 // ListMetrics Returns metric definitions that match the criteria specified in the request. Compartment OCID required.
-// For information about metrics, see Metrics Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#MetricsOverview).
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Listing Metric Definitions (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/list-metric.htm).
+// For information about metrics, see
+// Metrics Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#MetricsOverview).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // Transactions Per Second (TPS) per-tenancy limit for this operation: 10.
 //
 // # See also
@@ -591,8 +870,17 @@ func (client MonitoringClient) listMetrics(ctx context.Context, request common.O
 }
 
 // PostMetricData Publishes raw metric data points to the Monitoring service.
-// For more information about publishing metrics, see Publishing Custom Metrics (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/publishingcustommetrics.htm).
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For a data point to be posted, its timestamp must be near current time (less than two hours in the past and less than 10 minutes in the future).
+// For more information about publishing metrics, see
+// Publishing Custom Metrics (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/publishingcustommetrics.htm)
+// and
+// Custom Metrics Walkthrough (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/custom-metrics-walkthrough.htm).
+// For information about developing a metric-posting client, see
+// Developer Guide (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/devtoolslanding.htm).
+// For an example client, see
+// MonitoringMetricPostExample.java (https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/MonitoringMetricPostExample.java).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // Per-call limits information follows.
 // * Dimensions per metric group*. Maximum: 20. Minimum: 1.
 // * Unique metric streams*. Maximum: 50.
@@ -600,8 +888,9 @@ func (client MonitoringClient) listMetrics(ctx context.Context, request common.O
 // *A metric group is the combination of a given metric, metric namespace, and tenancy for the purpose of determining limits.
 // A dimension is a qualifier provided in a metric definition.
 // A metric stream is an individual set of aggregated data for a metric with zero or more dimension values.
-// For more information about metric-related concepts, see Monitoring Concepts (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#concepts).
-// The endpoints for this operation differ from other Monitoring operations. Replace the string `telemetry` with `telemetry-ingestion` in the endpoint, as in the following example:
+// For more information about metric-related concepts, see
+// Monitoring Concepts (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#concepts).
+// **Note:** The endpoints for this operation differ from other Monitoring operations. Replace the string `telemetry` with `telemetry-ingestion` in the endpoint, as in the following example:
 // https://telemetry-ingestion.eu-frankfurt-1.oraclecloud.com
 //
 // # See also
@@ -660,7 +949,10 @@ func (client MonitoringClient) postMetricData(ctx context.Context, request commo
 }
 
 // RemoveAlarmSuppression Removes any existing suppression for the specified alarm.
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Removing Suppression from an Alarm (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/remove-alarm-suppression.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
 // Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
 // or transactions, per second (TPS) for a given tenancy.
@@ -722,15 +1014,13 @@ func (client MonitoringClient) removeAlarmSuppression(ctx context.Context, reque
 
 // RetrieveDimensionStates Lists the current alarm status of each metric stream, where status is derived from the metric stream's last associated transition.
 // Optionally filter by status value and one or more dimension key-value pairs.
-// This operation is only valid for alarms that have notifications per dimension enabled (`isNotificationsPerMetricDimensionEnabled=true`).
-//
-//	If `isNotificationsPerMetricDimensionEnabled` for the alarm is false or null, then no results are returned.
-//
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
-//
-//	This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
-//	Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
-//	or transactions, per second (TPS) for a given tenancy.
+// For more information, see
+// Listing Metric Stream Status in an Alarm (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/list-alarm-status-metric-stream.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
+// This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
+// Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
+// or transactions, per second (TPS) for a given tenancy.
 //
 // # See also
 //
@@ -787,9 +1077,75 @@ func (client MonitoringClient) retrieveDimensionStates(ctx context.Context, requ
 	return response, err
 }
 
+// SummarizeAlarmSuppressionHistory Returns history of suppressions for the specified alarm, including both dimension-specific and and alarm-wide suppressions.
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
+// This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
+// Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
+// or transactions, per second (TPS) for a given tenancy.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/SummarizeAlarmSuppressionHistory.go.html to see an example of how to use SummarizeAlarmSuppressionHistory API.
+func (client MonitoringClient) SummarizeAlarmSuppressionHistory(ctx context.Context, request SummarizeAlarmSuppressionHistoryRequest) (response SummarizeAlarmSuppressionHistoryResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.summarizeAlarmSuppressionHistory, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = SummarizeAlarmSuppressionHistoryResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = SummarizeAlarmSuppressionHistoryResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(SummarizeAlarmSuppressionHistoryResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into SummarizeAlarmSuppressionHistoryResponse")
+	}
+	return
+}
+
+// summarizeAlarmSuppressionHistory implements the OCIOperation interface (enables retrying operations)
+func (client MonitoringClient) summarizeAlarmSuppressionHistory(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/alarms/{alarmId}/actions/summarizeAlarmSuppressionHistory", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SummarizeAlarmSuppressionHistoryResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/monitoring/20180401/AlarmSuppression/SummarizeAlarmSuppressionHistory"
+		err = common.PostProcessServiceError(err, "Monitoring", "SummarizeAlarmSuppressionHistory", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // SummarizeMetricsData Returns aggregated data that match the criteria specified in the request. Compartment OCID required.
-// For information on metric queries, see Building Metric Queries (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/buildingqueries.htm).
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Querying Metric Data (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/query-metric-landing.htm)
+// and
+// Creating a Query (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/query-metric.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // Transactions Per Second (TPS) per-tenancy limit for this operation: 10.
 //
 // # See also
@@ -848,7 +1204,10 @@ func (client MonitoringClient) summarizeMetricsData(ctx context.Context, request
 }
 
 // UpdateAlarm Updates the specified alarm.
-// For important limits information, see Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#Limits).
+// For more information, see
+// Updating an Alarm (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/update-alarm.htm).
+// For important limits information, see
+// Limits on Monitoring (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#limits).
 // This call is subject to a Monitoring limit that applies to the total number of requests across all alarm operations.
 // Monitoring might throttle this call to reject an otherwise valid request when the total rate of alarm operations exceeds 10 requests,
 // or transactions, per second (TPS) for a given tenancy.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/post_metric_data_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/post_metric_data_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/post_metric_data_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/post_metric_data_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/post_metric_data_response_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/post_metric_data_response_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/remove_alarm_suppression_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/remove_alarm_suppression_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/retrieve_dimension_states_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/retrieve_dimension_states_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/retrieve_dimension_states_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/retrieve_dimension_states_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -26,11 +26,13 @@ type RetrieveDimensionStatesRequest struct {
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
 	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	// Default: 1000
 	// Example: 500
 	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
@@ -94,7 +96,8 @@ type RetrieveDimensionStatesResponse struct {
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
 
 	// For list pagination. When this header appears in the response, additional pages of results remain.
-	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/summarize_alarm_suppression_history_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/summarize_alarm_suppression_history_details.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Monitoring API
+//
+// Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
+//
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// SummarizeAlarmSuppressionHistoryDetails The configuration details for returning history of suppressions for the specified alarm.
+type SummarizeAlarmSuppressionHistoryDetails struct {
+
+	// A filter to suppress only alarm state entries that include the set of specified dimension key-value pairs.
+	// If you specify {"availabilityDomain": "phx-ad-1"}
+	// and the alarm state entry corresponds to the set {"availabilityDomain": "phx-ad-1" and "resourceId": "ocid1.instance.region1.phx.exampleuniqueID"},
+	// then this alarm will be included for suppression.
+	// Example: `{"resourceId": "ocid1.instance.region1.phx.exampleuniqueID"}`
+	Dimensions map[string]string `mandatory:"false" json:"dimensions"`
+
+	// A filter to return only entries with "timeSuppressFrom" time occurring on or after the specified time.
+	// The value cannot be a future time.
+	// Format defined by RFC3339.
+	// Example: `2023-02-01T01:02:29.600Z`
+	TimeSuppressFromGreaterThanOrEqualTo *common.SDKTime `mandatory:"false" json:"timeSuppressFromGreaterThanOrEqualTo"`
+
+	// A filter to return only entries with "timeSuppressFrom" time occurring before the specified time.
+	// The value cannot be a future time.
+	// Format defined by RFC3339.
+	// Example: `2023-02-01T01:02:29.600Z`
+	TimeSuppressFromLessThan *common.SDKTime `mandatory:"false" json:"timeSuppressFromLessThan"`
+}
+
+func (m SummarizeAlarmSuppressionHistoryDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m SummarizeAlarmSuppressionHistoryDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/summarize_alarm_suppression_history_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/summarize_alarm_suppression_history_request_response.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package monitoring
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// SummarizeAlarmSuppressionHistoryRequest wrapper for the SummarizeAlarmSuppressionHistory operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/monitoring/SummarizeAlarmSuppressionHistory.go.html to see an example of how to use SummarizeAlarmSuppressionHistoryRequest.
+type SummarizeAlarmSuppressionHistoryRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of an alarm.
+	AlarmId *string `mandatory:"true" contributesTo:"path" name:"alarmId"`
+
+	// Customer part of the request identifier token. If you need to contact Oracle about a particular
+	// request, please provide the complete request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Default: 1000
+	// Example: 500
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// summarize history details
+	SummarizeAlarmSuppressionHistoryDetails `contributesTo:"body"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request SummarizeAlarmSuppressionHistoryRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request SummarizeAlarmSuppressionHistoryRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request SummarizeAlarmSuppressionHistoryRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request SummarizeAlarmSuppressionHistoryRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request SummarizeAlarmSuppressionHistoryRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// SummarizeAlarmSuppressionHistoryResponse wrapper for the SummarizeAlarmSuppressionHistory operation
+type SummarizeAlarmSuppressionHistoryResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of AlarmSuppressionHistoryItemCollection instances
+	AlarmSuppressionHistoryItemCollection `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+	// a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For list pagination. When this header appears in the response, next page of results remains.
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// For list pagination. When this header appears in the response, previous pages of results remains.
+	// For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcPreviousPage *string `presentIn:"header" name:"opc-previous-page"`
+}
+
+func (response SummarizeAlarmSuppressionHistoryResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response SummarizeAlarmSuppressionHistoryResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/summarize_metrics_data_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/summarize_metrics_data_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -29,13 +30,15 @@ type SummarizeMetricsDataDetails struct {
 	// aggregate. The query must specify a metric, statistic, and interval.
 	// Supported values for interval depend on the specified time range. More interval values are supported for smaller time ranges.
 	// You can optionally specify dimensions and grouping functions.
+	// When specifying a dimension value, surround it with double quotes, and escape each double quote with a backslash (`\`) character.
 	// Supported grouping functions: `grouping()`, `groupBy()`.
 	// Construct your query to avoid exceeding limits on returned data. See MetricData.
 	// For details about Monitoring Query Language (MQL), see
 	// Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
-	// For available dimensions, review the metric definition for the supported service.
-	// See Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
-	// Example: `CpuUtilization[1m].sum()`
+	// For available dimensions, review the metric definition for the supported service. See
+	// Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
+	// Example 1: `CpuUtilization[1m].sum()`
+	// Example 2 (escaped double quotes for value string): `CpuUtilization[1m]{resourceId = \"<var>&lt;instance_OCID&gt;</var>\"}.max()`
 	Query *string `mandatory:"true" json:"query"`
 
 	// Resource group that you want to match. A null value returns only metric data that has no resource groups. The specified resource group must exist in the definition of the posted metric. Only one resource group can be applied per metric.
@@ -46,17 +49,17 @@ type SummarizeMetricsDataDetails struct {
 	// The beginning of the time range to use when searching for metric data points.
 	// Format is defined by RFC3339. The response includes metric data points for the startTime.
 	// Default value: the timestamp 3 hours before the call was sent.
-	// Example: `2019-02-01T01:02:29.600Z`
+	// Example: `2023-02-01T01:02:29.600Z`
 	StartTime *common.SDKTime `mandatory:"false" json:"startTime"`
 
 	// The end of the time range to use when searching for metric data points.
 	// Format is defined by RFC3339. The response excludes metric data points for the endTime.
 	// Default value: the timestamp representing when the call was sent.
-	// Example: `2019-02-01T02:02:29.600Z`
+	// Example: `2023-02-01T02:02:29.600Z`
 	EndTime *common.SDKTime `mandatory:"false" json:"endTime"`
 
 	// The time between calculated aggregation windows. Use with the query interval to vary the
-	// frequency at which aggregated data points are returned. For example, use a query interval of
+	// frequency for returning aggregated data points. For example, use a query interval of
 	// 5 minutes with a resolution of 1 minute to retrieve five-minute aggregations at a one-minute
 	// frequency. The resolution must be equal or less than the interval in the query. The default
 	// resolution is 1m (one minute). Supported values: `1m`-`60m`, `1h`-`24h`, `1d`.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/summarize_metrics_data_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/summarize_metrics_data_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/suppression.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/suppression.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -17,16 +18,18 @@ import (
 	"strings"
 )
 
-// Suppression The configuration details for suppressing an alarm.
-// For information about alarms, see Alarms Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#AlarmsOverview).
+// Suppression The configuration details for an alarm-wide suppression.
+// For dimension-specific suppressions, see AlarmSuppression.
+// For information about alarms, see
+// Alarms Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#AlarmsOverview).
 type Suppression struct {
 
 	// The start date and time for the suppression to take place, inclusive. Format defined by RFC3339.
-	// Example: `2019-02-01T01:02:29.600Z`
+	// Example: `2023-02-01T01:02:29.600Z`
 	TimeSuppressFrom *common.SDKTime `mandatory:"true" json:"timeSuppressFrom"`
 
 	// The end date and time for the suppression to take place, inclusive. Format defined by RFC3339.
-	// Example: `2019-02-01T02:02:29.600Z`
+	// Example: `2023-02-01T02:02:29.600Z`
 	TimeSuppressUntil *common.SDKTime `mandatory:"true" json:"timeSuppressUntil"`
 
 	// Human-readable reason for suppressing alarm notifications.

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/update_alarm_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/update_alarm_details.go
@@ -1,12 +1,13 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
 // Monitoring API
 //
 // Use the Monitoring API to manage metric queries and alarms for assessing the health, capacity, and performance of your cloud resources.
-// Endpoints vary by operation. For PostMetric, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
-// For information about monitoring, see Monitoring Overview (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm).
+// Endpoints vary by operation. For PostMetricData, use the `telemetry-ingestion` endpoints; for all other operations, use the `telemetry` endpoints.
+// For more information, see
+// the Monitoring documentation (https://docs.cloud.oracle.com/iaas/Content/Monitoring/home.htm).
 //
 
 package monitoring
@@ -22,7 +23,7 @@ type UpdateAlarmDetails struct {
 
 	// A user-friendly name for the alarm. It does not have to be unique, and it's changeable.
 	// Avoid entering confidential information.
-	// This name is sent as the title for notifications related to this alarm.
+	// This value determines the title of each alarm notification.
 	// Example: `High CPU Utilization`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
@@ -58,9 +59,12 @@ type UpdateAlarmDetails struct {
 	// rule (threshold or absence). Supported values for interval depend on the specified time range. More
 	// interval values are supported for smaller time ranges. You can optionally
 	// specify dimensions and grouping functions. Supported grouping functions: `grouping()`, `groupBy()`.
-	// For details about Monitoring Query Language (MQL), see Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
-	// For available dimensions, review the metric definition for the supported service.
-	// See Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
+	// For information about writing MQL expressions, see
+	// Editing the MQL Expression for a Query (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Tasks/query-metric-mql.htm).
+	// For details about MQL, see
+	// Monitoring Query Language (MQL) Reference (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Reference/mql.htm).
+	// For available dimensions, review the metric definition for the supported service. See
+	// Supported Services (https://docs.cloud.oracle.com/iaas/Content/Monitoring/Concepts/monitoringoverview.htm#SupportedServices).
 	// Example of threshold alarm:
 	//   -----
 	//     CpuUtilization[1m]{availabilityDomain="cumS:PHX-AD-1"}.groupBy(availabilityDomain).percentile(0.9) > 85
@@ -91,29 +95,30 @@ type UpdateAlarmDetails struct {
 	// Example: `CRITICAL`
 	Severity AlarmSeverityEnum `mandatory:"false" json:"severity,omitempty"`
 
-	// The human-readable content of the notification delivered. Oracle recommends providing guidance
+	// The human-readable content of the delivered alarm notification. Oracle recommends providing guidance
 	// to operators for resolving the alarm condition. Consider adding links to standard runbook
 	// practices. Avoid entering confidential information.
 	// Example: `High CPU usage alert. Follow runbook instructions for resolution.`
 	Body *string `mandatory:"false" json:"body"`
 
-	// When set to `true`, splits notifications per metric stream. When set to `false`, groups notifications across metric streams.
-	// Example: `true`
+	// When set to `true`, splits alarm notifications per metric stream.
+	// When set to `false`, groups alarm notifications across metric streams.
 	IsNotificationsPerMetricDimensionEnabled *bool `mandatory:"false" json:"isNotificationsPerMetricDimensionEnabled"`
 
-	// The format to use for notification messages sent from this alarm. The formats are:
-	// * `RAW` - Raw JSON blob. Default value.
-	// * `PRETTY_JSON`: JSON with new lines and indents.
-	// * `ONS_OPTIMIZED`: Simplified, user-friendly layout. Applies only to messages sent through the Notifications service to the following subscription types: Email.
+	// The format to use for alarm notifications. The formats are:
+	// * `RAW` - Raw JSON blob. Default value. When the `destinations` attribute specifies `Streaming`, all alarm notifications use this format.
+	// * `PRETTY_JSON`: JSON with new lines and indents. Available when the `destinations` attribute specifies `Notifications` only.
+	// * `ONS_OPTIMIZED`: Simplified, user-friendly layout. Available when the `destinations` attribute specifies `Notifications` only. Applies to Email subscription types only.
 	MessageFormat UpdateAlarmDetailsMessageFormatEnum `mandatory:"false" json:"messageFormat,omitempty"`
 
-	// A list of destinations to which the notifications for this alarm will be delivered.
-	// Each destination is represented by an OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) related to the supported destination service.
-	// For example, a destination using the Notifications service is represented by a topic OCID.
-	// Supported destination services: Notifications Service. Limit: One destination per supported destination service.
+	// A list of destinations for alarm notifications.
+	// Each destination is represented by the OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
+	// of a related resource, such as a NotificationTopic.
+	// Supported destination services: Notifications, Streaming.
+	// Limit: One destination per supported destination service.
 	Destinations []string `mandatory:"false" json:"destinations"`
 
-	// The frequency at which notifications are re-submitted, if the alarm keeps firing without
+	// The frequency for re-submitting alarm notifications, if the alarm keeps firing without
 	// interruption. Format defined by ISO 8601. For example, `PT4H` indicates four hours.
 	// Minimum: PT1M. Maximum: P30D.
 	// Default value: null (notifications are not re-submitted).

--- a/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/update_alarm_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/monitoring/update_alarm_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/action_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/action_type.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_health.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set_health.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set_health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_set_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/backend_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/change_network_load_balancer_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/change_network_load_balancer_compartment_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/change_network_load_balancer_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/change_network_load_balancer_compartment_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_backend_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_backend_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_backend_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_backend_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_backend_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_backend_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_backend_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_backend_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_listener_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_listener_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_listener_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_listener_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_network_load_balancer_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_network_load_balancer_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_network_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/create_network_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/delete_backend_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/delete_backend_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/delete_backend_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/delete_backend_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/delete_listener_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/delete_listener_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/delete_network_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/delete_network_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_backend_health_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_backend_health_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_backend_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_backend_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_backend_set_health_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_backend_set_health_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_backend_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_backend_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_health_checker_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_health_checker_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_listener_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_listener_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_network_load_balancer_health_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_network_load_balancer_health_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_network_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_network_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/get_work_request_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/hcs_infra_ip_version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/hcs_infra_ip_version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/health_check_protocols.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/health_check_protocols.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/health_check_result.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/health_check_result.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/health_checker.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/health_checker.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/health_checker_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/health_checker_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/ip_address.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/ip_address.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/ip_version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/ip_version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/lifecycle_state.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_backend_sets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_backend_sets_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_backends_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_backends_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_listeners_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_listeners_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_network_load_balancer_healths_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_network_load_balancer_healths_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_network_load_balancers_policies_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_network_load_balancers_policies_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_network_load_balancers_protocols_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_network_load_balancers_protocols_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_network_load_balancers_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_network_load_balancers_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_work_request_errors_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_work_request_errors_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_work_request_logs_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_work_request_logs_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_work_requests_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/list_work_requests_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener_protocols.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener_protocols.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/listener_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_health.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_health_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_health_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_health_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_health_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancer_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancers_policy_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancers_policy_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancers_policy_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancers_policy_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancers_protocol_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancers_protocol_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancers_protocol_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancers_protocol_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancing_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/network_load_balancing_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/networkloadbalancer_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/networkloadbalancer_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 
@@ -27,7 +27,7 @@ type NetworkLoadBalancerClient struct {
 // the configuration provider will be used for the default signer as well as reading the region
 func NewNetworkLoadBalancerClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client NetworkLoadBalancerClient, err error) {
 	if enabled := common.CheckForEnabledServices("networkloadbalancer"); !enabled {
-		return client, fmt.Errorf("the Alloy configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local alloy_config file configured the service you're targeting or contact the cloud provider on the availability of this service")
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
 	}
 	provider, err := auth.GetGenericConfigurationProvider(configProvider)
 	if err != nil {

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/nlb_ip_version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/nlb_ip_version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/operation_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/operation_status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/operation_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/operation_type.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/reserved_ip.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/reserved_ip.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/sort_order.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/sort_order.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_backend_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_backend_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_backend_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_backend_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_backend_set_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_backend_set_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_backend_set_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_backend_set_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_health_checker_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_health_checker_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_health_checker_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_health_checker_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_listener_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_listener_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_listener_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_listener_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_network_load_balancer_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_network_load_balancer_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_network_load_balancer_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_network_load_balancer_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_network_security_groups_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_network_security_groups_details.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_network_security_groups_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/update_network_security_groups_request_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_error_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_error_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_log_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_log_entry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_log_entry_collection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_log_entry_collection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_resource.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/networkloadbalancer/work_request_summary.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, 2018, 2023, Oracle and/or its affiliates.  All rights reserved.
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
 // This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
 // Code generated. DO NOT EDIT.
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -266,7 +266,7 @@ github.com/opencontainers/go-digest
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/oracle/oci-go-sdk/v65 v65.49.2
+# github.com/oracle/oci-go-sdk/v65 v65.56.0
 ## explicit; go 1.13
 github.com/oracle/oci-go-sdk/v65/common
 github.com/oracle/oci-go-sdk/v65/common/auth


### PR DESCRIPTION
Changes
- Updating OCI Go-SDK to latest version to support oci endpoint urls for new regions
- Support for http/https proxy via environemnt variables: ```HTTP_PROXY``` & ```HHTPS_PROXY```
- Support for custom CA bundle via environement variable: ```OCI_DEFAULT_CERTS_PATH```

_For more details on CA bundle support:
https://docs.oracle.com/en-us/iaas/tools/go/65.56.1/#:~:text=Using%20custom%20CA%20Bundle%20or%20custom%20client%20certs_

E2E Tests (Subset): Results in https://github.com/oracle/oci-cloud-controller-manager/pull/450