### PR TITLE
Fix CapacityBytes when no size change in ControllerExpandVolume

### DIFF
--- a/pkg/csi/driver/bv_controller.go
+++ b/pkg/csi/driver/bv_controller.go
@@ -1231,7 +1231,7 @@ func (d *BlockVolumeControllerDriver) ControllerExpandVolume(ctx context.Context
 	if newSizeInGB <= oldSize {
 		log.Infof("Existing volume size: %v Requested volume size: %v No action needed.", *volume.SizeInGBs, newSizeInGB)
 		return &csi.ControllerExpandVolumeResponse{
-			CapacityBytes:         oldSize,
+			CapacityBytes:         oldSize * client.GiB,
 			NodeExpansionRequired: true,
 		}, nil
 	}

--- a/pkg/csi/driver/bv_controller_test.go
+++ b/pkg/csi/driver/bv_controller_test.go
@@ -1236,6 +1236,24 @@ func TestControllerDriver_ControllerExpandVolume(t *testing.T) {
 			wantErr: errors.New("Update volume failed"),
 		},
 		{
+			name:   "If no changes then do nothing in ControllerExpandVolume",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.ControllerExpandVolumeRequest{
+					VolumeId: "valid_volume_id",
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: int64(csi_util.MaximumVolumeSizeInBytes),
+					},
+				},
+			},
+			want: &csi.ControllerExpandVolumeResponse{
+				CapacityBytes:         int64(csi_util.MaximumVolumeSizeInBytes),
+				NodeExpansionRequired: true,
+			},
+			wantErr: nil,
+		},
+		{
 			name:   "Uhp volume expand success in ControllerExpandVolume",
 			fields: fields{},
 			args: args{


### PR DESCRIPTION
This MR solves https://github.com/oracle/oci-cloud-controller-manager/issues/466, where if there is no change in the volume size, then `CapacityBytes` would be in GiB instead of Bytes.

This bug makes resizing PVCs unreliable, as `ControllerExpandVolume` can be called multiple times, so in case the PVC has already been expanded it breaks.