### PR TITLE
OKE OSS Release 1.26.4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${GITHUB_ACTOR,,} --password-stdin
 
       - name: Build Image
-        run: OSS_REGISTRY="ghcr.io/oracle" VERSION="${{ github.ref_name }}" make image
+        run: OSS_REGISTRY="ghcr.io/${GITHUB_ACTOR,,}" VERSION="${{ github.ref_name }}" make image
 
       - name: Push Image
-        run: OSS_REGISTRY="ghcr.io/oracle" VERSION="${{ github.ref_name }}" make docker-push-all
+        run: OSS_REGISTRY="ghcr.io/${GITHUB_ACTOR,,}" VERSION="${{ github.ref_name }}" make docker-push-all

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${GITHUB_ACTOR,,} --password-stdin
 
       - name: Build Image
-        run: OSS_REGISTRY="ghcr.io/${GITHUB_ACTOR,,}" VERSION="${{ github.ref_name }}" make image
+        run: OSS_REGISTRY="ghcr.io/$oracle" VERSION="${{ github.ref_name }}" make image
 
       - name: Push Image
-        run: OSS_REGISTRY="ghcr.io/${GITHUB_ACTOR,,}" VERSION="${{ github.ref_name }}" make docker-push-all
+        run: OSS_REGISTRY="ghcr.io/oracle" VERSION="${{ github.ref_name }}" make docker-push-all

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ else
     VERSION   ?= ${VERSION}
 endif
 
-RELEASE = v1.26.0
+RELEASE = v1.26.4
 
 GOOS ?= linux
 ARCH ?= amd64

--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@ cloud-provider specific code out of the Kubernetes codebase.
 | v1.23.0   | v1.23                  | -                      |
 | v1.24.2   | v1.24                  | -                      |
 | v1.25.2   | v1.25                  | -                      |
-| v1.26.3   | v1.26                  | -                      |
-| v1.27.2   | v1.27                  | -                      |
-| v1.28.0   | v1.28                  | -                      |
+| v1.26.4   | v1.26                  | -                      |
+| v1.27.3   | v1.27                  | -                      |
+| v1.28.1   | v1.28                  | -                      |
+| v1.29.0   | v1.29                  | -                      |
 
 
 
 Note: 
-Versions older than v1.25.2 are no longer supported, new features / bug fixes will be available in v1.25.2 and later. 
+Versions older than v1.27.3 are no longer supported, new features / bug fixes will be available in v1.27.3 and later. 
 
 ## Implementation
  Currently `oci-cloud-controller-manager` implements:
@@ -169,12 +170,6 @@ details.
 
 Oracle gratefully acknowledges the contributions to this project that have been made
 by the community.
-
-## Upcoming Releases
-
-| Release               | Expected Release Date |
-|-----------------------|-----------------------|
-| Support for K8s v1.24 | August 2022           |
 
 ## License
 

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -162,8 +162,7 @@ This product includes software developed at CoreOS, Inc.
 github.com/davecgh/go-spew
 
 == License Type
-===ISC-c06795ed
-
+=== ISC-c06795ed
 ISC License
 
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
@@ -179,6 +178,7 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
 
 
 == Copyright
@@ -231,8 +231,7 @@ Copyright 2021 Ernest Micklei. All rights reserved.
 github.com/evanphx/json-patch
 
 == License Type
-===BSD-3-Clause-96ae735c
-
+=== BSD-3-Clause-96ae735c
 Copyright (c) 2014, Evan Phoenix
 All rights reserved.
 
@@ -260,6 +259,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+
 == Copyright
 Copyright (c) 2014, Evan Phoenix
 
@@ -284,6 +284,7 @@ SPDX:BSD-3-Clause--modified-by-Google
 
 == Copyright
 Copyright © 2012 The Go Authors. All rights reserved.
+Copyright © fsnotify Authors. All rights reserved.
 
 --------------------------------- (separator) ----------------------------------
 
@@ -351,8 +352,7 @@ Copyright 2015 go-swagger maintainers
 github.com/gofrs/flock
 
 == License Type
-===BSD-3-Clause-4e7459b3
-
+=== BSD-3-Clause-4e7459b3
 Copyright (c) 2015-2020, Tim Heckman
 All rights reserved.
 
@@ -380,6 +380,7 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 
 == Copyright
@@ -455,8 +456,8 @@ Copyright 2020 The Go Authors. All rights reserved.
 github.com/google/cel-go
 
 == License Type
-===Apache-2.0-9e40c772
-
+=== Apache-2.0-9e40c772
+=== BSD-3-Clause--modified-by-Google
 
                                  Apache License
                            Version 2.0, January 2004
@@ -692,6 +693,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+
 == Copyright
 Copyright (c) 2018 The Go Authors. All rights reserved.
 Copyright 2018 Google LLC
@@ -776,8 +778,7 @@ Copyright 2016 Michal Witkowski. All Rights Reserved.
 github.com/grpc-ecosystem/grpc-gateway/v2
 
 == License Type
-===BSD-3-Clause--modified-by-Google-c510a2a0
-
+=== BSD-3-Clause--modified-by-Google-c510a2a0
 Copyright (c) 2015, Gengo, Inc.
 All rights reserved.
 
@@ -805,6 +806,7 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 
 == Copyright
@@ -893,8 +895,7 @@ Copyright 2022 The Kubernetes Authors.
 github.com/magiconair/properties
 
 == License Type
-===BSD-2-Clause-714beb73
-
+=== BSD-2-Clause-714beb73
 Copyright (c) 2013-2020, Frank Schroeder
 
 All rights reserved.
@@ -919,6 +920,7 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 
 == Copyright
@@ -1042,8 +1044,7 @@ SPDX:Apache-2.0
 github.com/munnerz/goautoneg
 
 == License Type
-===BSD-3-Clause-0c241922
-
+=== BSD-3-Clause-0c241922
 Copyright (c) 2011, Open Knowledge Foundation Ltd.
 All rights reserved.
 
@@ -1077,6 +1078,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+
 == Copyright
 Copyright (c) 2011, Open Knowledge Foundation Ltd.
 
@@ -1107,6 +1109,7 @@ SPDX:MIT
 == Copyright
 Copyright (c) 2013-2014 Onsi Fakhouri
 Copyright (c) 2016 Yasuhiro Matsumoto
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
 Copyright 2013 The Go Authors. All rights reserved.
 
 --------------------------------- (separator) ----------------------------------
@@ -1143,8 +1146,9 @@ Copyright © 2019, 2020 OCI Contributors
 github.com/oracle/oci-go-sdk/v65
 
 == License Type
-===Apache-2.0-9010f56e
-
+=== Apache-2.0-9010f56e
+=== UPL-1.0
+=== Apache-2.0
 Copyright (c) 2016, 2023, Oracle and/or its affiliates.  All rights reserved.
 This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl
 or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
@@ -1249,6 +1253,7 @@ END OF TERMS AND CONDITIONS
    limitations under the License.
 
 
+
 == Copyright
 Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 Copyright (c) 2013 The Go Authors. All rights reserved.
@@ -1270,8 +1275,8 @@ Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.
 github.com/pelletier/go-toml
 
 == License Type
-===Apache-2.0-e49b63d8
-
+=== MIT-e49b63d8
+=== Apache-2.0
 The bulk of github.com/pelletier/go-toml is distributed under the MIT license
 (see below), with the exception of localtime.go and localtime.test.go.
 Those two files have been copied over from Google's civil library at revision
@@ -1521,6 +1526,7 @@ License:
    limitations under the License.
 
 
+
 == Copyright
 Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton
 Copyright 2016 Google LLC
@@ -1694,6 +1700,8 @@ Copyright © 2015 Jerry Jacobs <jerry.jacobs@xor-gate.org>.
 Copyright © 2015 Steve Francia <spf@spf13.com>.
 Copyright © 2016 Steve Francia <spf@spf13.com>.
 Copyright © 2018 Steve Francia <spf@spf13.com>.
+Copyright © 2021 Vasily Ovchinnikov <vasily@remerge.io>.
+Copyright © 2022 Steve Francia <spf@spf13.com>.
 
 --------------------------------- (separator) ----------------------------------
 
@@ -1969,6 +1977,7 @@ go.uber.org/zap
 SPDX:MIT
 
 == Copyright
+Copyright (c) "*" Uber Technologies, Inc.")
 Copyright (c) 2016 Uber Technologies, Inc.
 Copyright (c) 2016, 2017 Uber Technologies, Inc.
 Copyright (c) 2016-2017 Uber Technologies, Inc.
@@ -2378,6 +2387,24 @@ Copyright 2019 gRPC authors.
 Copyright 2020 The gRPC Authors
 Copyright 2020 gRPC authors.
 Copyright 2021 gRPC authors.
+Copyright 2022 gRPC authors.
+Copyright 2023 gRPC authors.
+
+== Notices
+Copyright 2014 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 
 --------------------------------- (separator) ----------------------------------
 
@@ -2467,8 +2494,7 @@ Copyright (c) 2014 Nate Finch
 gopkg.in/tomb.v1
 
 == License Type
-===BSD-3-Clause-95d4102f
-
+=== BSD-3-Clause-95d4102f
 tomb - support for clean goroutine termination in Go.
 
 Copyright (c) 2010-2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
@@ -2498,6 +2524,7 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 
 == Copyright
@@ -2538,8 +2565,8 @@ limitations under the License.
 gopkg.in/yaml.v3
 
 == License Type
-===Apache-2.0-3c91c172
-
+=== MIT-3c91c172
+=== Apache-2.0
 
 This project is covered by two different licenses: MIT and Apache.
 
@@ -2590,6 +2617,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 
 
 == Copyright
@@ -2833,6 +2861,7 @@ k8s.io/kube-openapi
 SPDX:Apache-2.0
 
 == Copyright
+Copyright (C) MongoDB, Inc. 2017-present.
 Copyright (c) 2020 The Go Authors. All rights reserved.
 Copyright 2015 go-swagger maintainers
 Copyright 2016 The Kubernetes Authors.
@@ -2908,6 +2937,7 @@ SPDX:Apache-2.0
 Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright (c) 2015-2016 Manfred Touron
 Copyright (c) 2015-2018 gimme contributors
+Copyright (c) Microsoft Corporation. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2014 The Kubernetes Authors.
 Copyright 2015 The Kubernetes Authors.
@@ -2979,8 +3009,8 @@ Copyright 2022 The Kubernetes Authors.
 sigs.k8s.io/json
 
 == License Type
-===Apache-2.0-545d3f23
-
+=== BSD-3-Clause--modified-by-Google-545d3f23
+=== Apache-2.0
 Files other than internal/golang/* licensed under:
 
 
@@ -3221,6 +3251,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+
 == Copyright
 Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
@@ -3267,8 +3298,8 @@ Copyright 2020 The Kubernetes Authors.
 sigs.k8s.io/yaml
 
 == License Type
-===BSD-3-Clause--modified-by-Google-0ceb9ff3
-
+=== MIT-0ceb9ff3
+=== BSD-3-Clause--modified-by-Google
 The MIT License (MIT)
 
 Copyright (c) 2014 Sam Ghods
@@ -3319,6 +3350,7 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 
 == Copyright
@@ -3906,5 +3938,5 @@ the Mozilla Public License, v. 2.0.
 
 
 === ATTRIBUTION-HELPER-GENERATED:
-=== Attribution helper version: {Major:0 Minor:11 GitVersion:0.10.0-69-g9cf205e3 GitCommit:9cf205e3ce436f506f0901d927c1e417e72f384f GitTreeState:dirty BuildDate:2022-10-10T19:24:17Z GoVersion:go1.19 Compiler:gc Platform:darwin/amd64}
-=== License file based on go.mod with md5 sum:  c183edbb789997dd3b3bac3e846cf78b
+=== Attribution helper version: {Major:0 Minor:11 GitVersion: GitCommit: GitTreeState:dirty BuildDate:1970-01-01T00:00:00Z GoVersion:go1.19.3 Compiler:gc Platform:darwin/arm64}
+=== License file based on go.mod with md5 sum:  41747060c5d7089ecb0b557be34262a4

--- a/cmd/oci-csi-controller-driver/csioptions/csioptions.go
+++ b/cmd/oci-csi-controller-driver/csioptions/csioptions.go
@@ -28,7 +28,7 @@ const (
 	CrossNamespaceVolumeDataSource = "CrossNamespaceVolumeDataSource"
 )
 
-// CSIOptions structure which contains flag values
+//CSIOptions structure which contains flag values
 type CSIOptions struct {
 	Master                  string
 	Kubeconfig              string
@@ -59,7 +59,7 @@ type CSIOptions struct {
 	EnableResizer           bool
 }
 
-// NewCSIOptions initializes the flag
+//NewCSIOptions initializes the flag
 func NewCSIOptions() *CSIOptions {
 	csioptions := CSIOptions{
 		Master:                  *flag.String("master", "", "kube master"),

--- a/hack/run_e2e_test.sh
+++ b/hack/run_e2e_test.sh
@@ -30,6 +30,7 @@ check-env "FSS_VOLUME_HANDLE"         $FSS_VOLUME_HANDLE
 check-env "MNT_TARGET_ID"             $MNT_TARGET_ID
 check-env "MNT_TARGET_SUBNET_ID"      $MNT_TARGET_SUBNET_ID
 check-env "MNT_TARGET_COMPARTMENT_ID" $MNT_TARGET_COMPARTMENT_ID
+check-env "ENABLE_PARALLEL_RUN"       $ENABLE_PARALLEL_RUN
 check-env "RUN_UHP_E2E"               $RUN_UHP_E2E
 
 
@@ -59,6 +60,7 @@ function run_e2e_tests_existing_cluster() {
         --architecture=${ARCHITECTURE} \
         --volume-handle=${FSS_VOLUME_HANDLE} \
         --static-snapshot-compartment-id=${STATIC_SNAPSHOT_COMPARTMENT_ID} \
+        --enable-parallel-run=${ENABLE_PARALLEL_RUN} \
         --run-uhp-e2e=${RUN_UHP_E2E}
     retval=$?
     return $retval

--- a/hack/run_e2e_test.sh
+++ b/hack/run_e2e_test.sh
@@ -61,7 +61,8 @@ function run_e2e_tests_existing_cluster() {
         --volume-handle=${FSS_VOLUME_HANDLE} \
         --static-snapshot-compartment-id=${STATIC_SNAPSHOT_COMPARTMENT_ID} \
         --enable-parallel-run=${ENABLE_PARALLEL_RUN} \
-        --run-uhp-e2e=${RUN_UHP_E2E}
+        --run-uhp-e2e=${RUN_UHP_E2E} \
+        --add-oke-system-tags="false"
     retval=$?
     return $retval
 }

--- a/hack/run_e2e_test.sh
+++ b/hack/run_e2e_test.sh
@@ -43,26 +43,54 @@ function set_image_pull_repo_and_delete_namespace_flag () {
 }
 
 function run_e2e_tests_existing_cluster() {
-    ginkgo -v -progress --trace "${FOCUS_OPT}" "${FOCUS_FP_OPT}"  \
-        test/e2e/cloud-provider-oci -- \
-        --cluster-kubeconfig=${CLUSTER_KUBECONFIG} \
-        --cloud-config=${CLOUD_CONFIG} \
-        --adlocation=${ADLOCATION} \
-        --delete-namespace=${DELETE_NAMESPACE} \
-        --image-pull-repo=${IMAGE_PULL_REPO} \
-        --cmek-kms-key=${CMEK_KMS_KEY} \
-        --mnt-target-id=${MNT_TARGET_ID} \
-        --mnt-target-subnet-id=${MNT_TARGET_SUBNET_ID} \
-        --mnt-target-compartment-id=${MNT_TARGET_COMPARTMENT_ID} \
-        --nsg-ocids=${NSG_OCIDS} \
-        --backend-nsg-ocids=${BACKEND_NSG_OCIDS} \
-        --reserved-ip=${RESERVED_IP} \
-        --architecture=${ARCHITECTURE} \
-        --volume-handle=${FSS_VOLUME_HANDLE} \
-        --static-snapshot-compartment-id=${STATIC_SNAPSHOT_COMPARTMENT_ID} \
-        --enable-parallel-run=${ENABLE_PARALLEL_RUN} \
-        --run-uhp-e2e=${RUN_UHP_E2E} \
-        --add-oke-system-tags="false"
+    if [[ -z "${E2E_NODE_COUNT}" ]]; then
+        E2E_NODE_COUNT=1
+    fi
+
+    if [ "$ENABLE_PARALLEL_RUN" == "true" ] || [ "$ENABLE_PARALLEL_RUN" == "TRUE" ]; then
+        ginkgo -v -p -progress --trace "${FOCUS_OPT}" "${FOCUS_FP_OPT}"  \
+                    test/e2e/cloud-provider-oci -- \
+                    --cluster-kubeconfig=${CLUSTER_KUBECONFIG} \
+                    --cloud-config=${CLOUD_CONFIG} \
+                    --adlocation=${ADLOCATION} \
+                    --delete-namespace=${DELETE_NAMESPACE} \
+                    --image-pull-repo=${IMAGE_PULL_REPO} \
+                    --cmek-kms-key=${CMEK_KMS_KEY} \
+                    --mnt-target-id=${MNT_TARGET_ID} \
+                    --mnt-target-subnet-id=${MNT_TARGET_SUBNET_ID} \
+                    --mnt-target-compartment-id=${MNT_TARGET_COMPARTMENT_ID} \
+                    --nsg-ocids=${NSG_OCIDS} \
+                    --backend-nsg-ocids=${BACKEND_NSG_OCIDS} \
+                    --reserved-ip=${RESERVED_IP} \
+                    --architecture=${ARCHITECTURE} \
+                    --volume-handle=${FSS_VOLUME_HANDLE} \
+                    --static-snapshot-compartment-id=${STATIC_SNAPSHOT_COMPARTMENT_ID} \
+                    --enable-parallel-run=${ENABLE_PARALLEL_RUN} \
+                    --run-uhp-e2e=${RUN_UHP_E2E} \
+                    --add-oke-system-tags="false"
+    else
+        ginkgo -v -progress --trace -nodes=${E2E_NODE_COUNT} "${FOCUS_OPT}" "${FOCUS_FP_OPT}"  \
+            ginkgo -v -p -progress --trace "${FOCUS_OPT}" "${FOCUS_FP_OPT}"  \
+                    test/e2e/cloud-provider-oci -- \
+                    --cluster-kubeconfig=${CLUSTER_KUBECONFIG} \
+                    --cloud-config=${CLOUD_CONFIG} \
+                    --adlocation=${ADLOCATION} \
+                    --delete-namespace=${DELETE_NAMESPACE} \
+                    --image-pull-repo=${IMAGE_PULL_REPO} \
+                    --cmek-kms-key=${CMEK_KMS_KEY} \
+                    --mnt-target-id=${MNT_TARGET_ID} \
+                    --mnt-target-subnet-id=${MNT_TARGET_SUBNET_ID} \
+                    --mnt-target-compartment-id=${MNT_TARGET_COMPARTMENT_ID} \
+                    --nsg-ocids=${NSG_OCIDS} \
+                    --backend-nsg-ocids=${BACKEND_NSG_OCIDS} \
+                    --reserved-ip=${RESERVED_IP} \
+                    --architecture=${ARCHITECTURE} \
+                    --volume-handle=${FSS_VOLUME_HANDLE} \
+                    --static-snapshot-compartment-id=${STATIC_SNAPSHOT_COMPARTMENT_ID} \
+                    --enable-parallel-run=${ENABLE_PARALLEL_RUN} \
+                    --run-uhp-e2e=${RUN_UHP_E2E} \
+                    --add-oke-system-tags="false"
+    fi
     retval=$?
     return $retval
 }

--- a/manifests/cloud-controller-manager/oci-cloud-controller-manager.yaml
+++ b/manifests/cloud-controller-manager/oci-cloud-controller-manager.yaml
@@ -42,7 +42,7 @@ spec:
             path: /etc/kubernetes
       containers:
         - name: oci-cloud-controller-manager
-          image: ghcr.io/oracle/cloud-provider-oci:v1.26.3
+          image: ghcr.io/oracle/cloud-provider-oci:v1.26.4
           command: ["/usr/local/bin/oci-cloud-controller-manager"]
           args:
             - --cloud-config=/etc/oci/cloud-provider.yaml

--- a/manifests/container-storage-interface/oci-csi-controller-driver.yaml
+++ b/manifests/container-storage-interface/oci-csi-controller-driver.yaml
@@ -96,7 +96,7 @@ spec:
             - --fss-csi-endpoint=unix://var/run/shared-tmpfs/csi-fss.sock
           command:
             - /usr/local/bin/oci-csi-controller-driver
-          image: ghcr.io/oracle/cloud-provider-oci:v1.26.3
+          image: ghcr.io/oracle/cloud-provider-oci:v1.26.4
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/manifests/container-storage-interface/oci-csi-node-driver.yaml
+++ b/manifests/container-storage-interface/oci-csi-node-driver.yaml
@@ -117,7 +117,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: PATH
               value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/host/usr/bin:/host/sbin
-          image: ghcr.io/oracle/cloud-provider-oci:v1.26.3
+          image: ghcr.io/oracle/cloud-provider-oci:v1.26.4
           securityContext:
             privileged: true
           volumeMounts:

--- a/manifests/flexvolume-driver/oci-flexvolume-driver.yaml
+++ b/manifests/flexvolume-driver/oci-flexvolume-driver.yaml
@@ -40,7 +40,7 @@ spec:
             secretName: oci-flexvolume-driver
       containers:
         - name: oci-flexvolume-driver
-          image: ghcr.io/oracle/cloud-provider-oci:v1.26.3
+          image: ghcr.io/oracle/cloud-provider-oci:v1.26.4
           command: ["/usr/local/bin/install.py", "-c", "/tmp/config.yaml"]
           securityContext:
             privileged: true
@@ -76,7 +76,7 @@ spec:
             type: DirectoryOrCreate
       containers:
         - name: oci-flexvolume-driver
-          image: ghcr.io/oracle/cloud-provider-oci:v1.26.3
+          image: ghcr.io/oracle/cloud-provider-oci:v1.26.4
           command: ["/usr/local/bin/install.py"]
           securityContext:
             privileged: true

--- a/manifests/volume-provisioner/oci-volume-provisioner-fss.yaml
+++ b/manifests/volume-provisioner/oci-volume-provisioner-fss.yaml
@@ -35,7 +35,7 @@ spec:
             secretName: oci-volume-provisioner
       containers:
         - name: oci-volume-provisioner
-          image: ghcr.io/oracle/cloud-provider-oci:v1.26.3
+          image: ghcr.io/oracle/cloud-provider-oci:v1.26.4
           command: ["/usr/local/bin/oci-volume-provisioner"]
           env:
             - name: NODE_NAME

--- a/manifests/volume-provisioner/oci-volume-provisioner.yaml
+++ b/manifests/volume-provisioner/oci-volume-provisioner.yaml
@@ -35,7 +35,7 @@ spec:
             secretName: oci-volume-provisioner
       containers:
         - name: oci-volume-provisioner
-          image: ghcr.io/oracle/cloud-provider-oci:v1.26.3
+          image: ghcr.io/oracle/cloud-provider-oci:v1.26.4
           command: ["/usr/local/bin/oci-volume-provisioner"]
           env:
             - name: NODE_NAME

--- a/pkg/cloudprovider/providers/oci/config/config.go
+++ b/pkg/cloudprovider/providers/oci/config/config.go
@@ -22,7 +22,6 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/common/auth"
 	"github.com/pkg/errors"
-
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 )
@@ -127,6 +126,7 @@ type InitialTags struct {
 	LoadBalancer *TagConfig `yaml:"loadBalancer"`
 	BlockVolume  *TagConfig `yaml:"blockVolume"`
 	FSS          *TagConfig `yaml:"fss"`
+	Common       *TagConfig `yaml:"common"`
 }
 
 // Config holds the OCI cloud-provider config passed to Kubernetes components
@@ -151,7 +151,7 @@ type Config struct {
 	// cluster resides.
 	VCNID string `yaml:"vcn"`
 
-	//Metadata service to help fill in certain fields
+	// Metadata service to help fill in certain fields
 	metadataSvc metadata.Interface
 }
 

--- a/pkg/cloudprovider/providers/oci/instances_test.go
+++ b/pkg/cloudprovider/providers/oci/instances_test.go
@@ -310,6 +310,10 @@ func (MockOCIClient) Identity() client.IdentityInterface {
 // MockComputeClient mocks Compute client implementation
 type MockComputeClient struct{}
 
+func (c MockComputeClient) ListInstancesByCompartmentAndAD(ctx context.Context, compartmentId, availabilityDomain string) (response []core.Instance, err error) {
+	return nil, nil
+}
+
 func (MockComputeClient) GetInstance(ctx context.Context, id string) (*core.Instance, error) {
 	if instance, ok := instances[id]; ok {
 		return instance, nil

--- a/pkg/cloudprovider/providers/oci/instances_test.go
+++ b/pkg/cloudprovider/providers/oci/instances_test.go
@@ -439,7 +439,7 @@ func (c *MockLoadBalancerClient) ListWorkRequests(ctx context.Context, compartme
 	return nil, nil
 }
 
-func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails) (string, error) {
+func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails, serviceUid *string) (string, error) {
 	return "", nil
 }
 
@@ -533,7 +533,7 @@ func (c *MockNetworkLoadBalancerClient) ListWorkRequests(ctx context.Context, co
 	return nil, nil
 }
 
-func (c *MockNetworkLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails) (string, error) {
+func (c *MockNetworkLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails, serviceUid *string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/cloudprovider/providers/oci/instances_test.go
+++ b/pkg/cloudprovider/providers/oci/instances_test.go
@@ -497,6 +497,18 @@ func (c *MockLoadBalancerClient) DeleteListener(ctx context.Context, lbID, name 
 	return "", nil
 }
 
+var updateLoadBalancerErrors = map[string]error{
+	"work request fail": errors.New("internal server error"),
+}
+
+func (c *MockLoadBalancerClient) UpdateLoadBalancer(ctx context.Context, lbID string, details *client.GenericUpdateLoadBalancerDetails) (string, error) {
+	if err, ok := updateLoadBalancerErrors[lbID]; ok {
+		return "", err
+	}
+
+	return "", nil
+}
+
 var awaitLoadbalancerWorkrequestMap = map[string]error{
 	"failedToGetUpdateNetworkSecurityGroupsWorkRequest": errors.New("internal server error for get workrequest call"),
 }
@@ -609,6 +621,10 @@ func (c *MockNetworkLoadBalancerClient) UpdateNetworkSecurityGroups(ctx context.
 	if wrID, ok := updateNetworkSecurityGroupsLBsWorkRequests[lbId]; ok {
 		return wrID, nil
 	}
+	return "", nil
+}
+
+func (c *MockNetworkLoadBalancerClient) UpdateLoadBalancer(ctx context.Context, lbID string, details *client.GenericUpdateLoadBalancerDetails) (string, error) {
 	return "", nil
 }
 

--- a/pkg/cloudprovider/providers/oci/load_balancer.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer.go
@@ -52,8 +52,9 @@ const (
 	NetworkLoadBalancingPolicyTwoTuple   = "TWO_TUPLE"
 	NetworkLoadBalancingPolicyThreeTuple = "THREE_TUPLE"
 	NetworkLoadBalancingPolicyFiveTuple  = "FIVE_TUPLE"
-	LbOperationAlreadyExistsFmt          = "An operation for the %s: %s already exists."
 )
+
+var LbOperationAlreadyExists = errors.New("An operation for the service is already in progress.")
 
 // DefaultLoadBalancerBEProtocol defines the default protocol for load
 // balancer listeners created by the CCM.
@@ -491,7 +492,7 @@ func (cp *CloudProvider) EnsureLoadBalancer(ctx context.Context, clusterName str
 	loadBalancerService := fmt.Sprintf("%s/%s", service.Namespace, service.Name)
 	if acquired := cp.lbLocks.TryAcquire(loadBalancerService); !acquired {
 		logger.Error("Could not acquire lock for Ensuring Load Balancer")
-		return nil, errors.Errorf(LbOperationAlreadyExistsFmt, loadBalancerType, loadBalancerService)
+		return nil, LbOperationAlreadyExists
 	}
 	defer cp.lbLocks.Release(loadBalancerService)
 
@@ -1149,7 +1150,7 @@ func (cp *CloudProvider) UpdateLoadBalancer(ctx context.Context, clusterName str
 	loadBalancerService := fmt.Sprintf("%s/%s", service.Namespace, service.Name)
 	if acquired := cp.lbLocks.TryAcquire(loadBalancerService); !acquired {
 		logger.Error("Could not acquire lock for Updating Load Balancer")
-		return errors.Errorf(LbOperationAlreadyExistsFmt, loadBalancerType, loadBalancerService)
+		return LbOperationAlreadyExists
 	}
 	defer cp.lbLocks.Release(loadBalancerService)
 
@@ -1316,7 +1317,7 @@ func (cp *CloudProvider) EnsureLoadBalancerDeleted(ctx context.Context, clusterN
 	loadBalancerService := fmt.Sprintf("%s/%s", service.Namespace, service.Name)
 	if acquired := cp.lbLocks.TryAcquire(loadBalancerService); !acquired {
 		logger.Error("Could not acquire lock for Deleting Load Balancer")
-		return errors.Errorf(LbOperationAlreadyExistsFmt, loadBalancerType, loadBalancerService)
+		return LbOperationAlreadyExists
 	}
 	defer cp.lbLocks.Release(loadBalancerService)
 

--- a/pkg/cloudprovider/providers/oci/load_balancer.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer.go
@@ -394,7 +394,8 @@ func (clb *CloudLoadBalancerProvider) createLoadBalancer(ctx context.Context, sp
 		}
 	}
 
-	wrID, err := clb.lbClient.CreateLoadBalancer(ctx, &details)
+	serviceUid := fmt.Sprintf("%s", spec.service.UID)
+	wrID, err := clb.lbClient.CreateLoadBalancer(ctx, &details, &serviceUid)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "creating load balancer")
 	}

--- a/pkg/cloudprovider/providers/oci/load_balancer.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer.go
@@ -1229,6 +1229,22 @@ func (cp *CloudProvider) UpdateLoadBalancer(ctx context.Context, clusterName str
 		return err
 	}
 
+	var sslConfig *SSLConfig
+	if requiresCertificate(service) {
+		ports, err := getSSLEnabledPorts(service)
+		if err != nil {
+			logger.With(zap.Error(err)).Error("Failed to parse SSL port.")
+			errorType = util.GetError(err)
+			lbMetricDimension = util.GetMetricDimensionForComponent(errorType, util.LoadBalancerType)
+			dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
+			metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, Update), time.Since(startTime).Seconds(), dimensionsMap)
+			return err
+		}
+		secretListenerString := service.Annotations[ServiceAnnotationLoadBalancerTLSSecret]
+		secretBackendSetString := service.Annotations[ServiceAnnotationLoadBalancerTLSBackendSetSecret]
+		sslConfig = NewSSLConfig(secretListenerString, secretBackendSetString, service, ports, cp)
+	}
+
 	subnets, err := cp.getLoadBalancerSubnets(ctx, logger, service)
 	if err != nil {
 		logger.With(zap.Error(err)).Error("Failed to get Load balancer Subnets.")
@@ -1239,7 +1255,7 @@ func (cp *CloudProvider) UpdateLoadBalancer(ctx context.Context, clusterName str
 		return err
 	}
 
-	spec, err := NewLBSpec(logger, service, nodes, subnets, nil, cp.securityListManagerFactory, cp.config.Tags, lb)
+	spec, err := NewLBSpec(logger, service, nodes, subnets, sslConfig, cp.securityListManagerFactory, cp.config.Tags, lb)
 	if err != nil {
 		logger.With(zap.Error(err)).Error("Failed to derive LBSpec")
 		errorType = util.GetError(err)

--- a/pkg/cloudprovider/providers/oci/load_balancer.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer.go
@@ -477,7 +477,7 @@ func (cp *CloudProvider) EnsureLoadBalancer(ctx context.Context, clusterName str
 	loadBalancerType := getLoadBalancerType(service)
 	logger := cp.logger.With("loadBalancerName", lbName, "serviceName", service.Name, "loadBalancerType", loadBalancerType, "serviceUid", service.UID)
 	if sa, useWI := service.Annotations[ServiceAnnotationServiceAccountName]; useWI { // When using Workload Identity
-		logger = logger.With("serviceAccount", sa, "nameSpace", service.Namespace)
+		logger = logger.With("serviceAccount", sa, "namespace", service.Namespace)
 	}
 
 	if deleted, err := cp.serviceDeletedOrDoesNotExist(ctx, service); deleted {
@@ -521,7 +521,6 @@ func (cp *CloudProvider) EnsureLoadBalancer(ctx context.Context, clusterName str
 		dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
 		dimensionsMap[metrics.ResourceOCIDDimension] = lbName
 		metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, Update), time.Since(startTime).Seconds(), dimensionsMap)
-		return nil, err
 	}
 	lbExists := !client.IsNotFound(err)
 	lbOCID := ""
@@ -530,42 +529,18 @@ func (cp *CloudProvider) EnsureLoadBalancer(ctx context.Context, clusterName str
 	} else {
 		// if the LB does not exist already use the k8s service UID for reference
 		// in logs and metrics
-		lbOCID = GetLoadBalancerName(service)
+		lbOCID = lbName
 	}
 
 	logger = logger.With("loadBalancerID", lbOCID, "loadBalancerType", getLoadBalancerType(service))
 	dimensionsMap[metrics.ResourceOCIDDimension] = lbOCID
 
-	// This code block checks if we have pending work requests before processing the LoadBalancer further
+	// Checks if we have pending work requests before processing the LoadBalancer further
 	// Will error out if any in-progress work request are present for the LB
 	if lb != nil && lb.Id != nil {
-		listWorkRequestTime := time.Now()
-		lbInProgressWorkRequests, err := lbProvider.lbClient.ListWorkRequests(ctx, *lb.CompartmentId, *lb.Id)
-		logger.With("loadBalancerID", *lb.Id).Infof("time (in seconds) to list work-requests for LB %f", time.Since(listWorkRequestTime).Seconds())
+		err = cp.checkPendingLBWorkRequests(ctx, logger, lbProvider, lb, service, startTime)
 		if err != nil {
-			logger.With(zap.Error(err)).Error("Failed to list work-requests in-progress")
-			errorType = util.GetError(err)
-			lbMetricDimension = util.GetMetricDimensionForComponent(errorType, util.LoadBalancerType)
-			dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
-			dimensionsMap[metrics.ResourceOCIDDimension] = lbName
-			metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, List), time.Since(startTime).Seconds(), dimensionsMap)
 			return nil, err
-		}
-
-		for _, wr := range lbInProgressWorkRequests {
-			lbType := getLoadBalancerType(service)
-			switch lbType {
-			case NLB:
-				if wr.Status == string(networkloadbalancer.OperationStatusInProgress) || wr.Status == string(networkloadbalancer.OperationStatusAccepted) {
-					logger.With("loadBalancerID", *lb.Id).Infof("current in-progress work requests for Network Load Balancer %s", *wr.Id)
-					return nil, errors.New("Network Load Balancer has work requests in progress, will wait and retry")
-				}
-			default:
-				if *wr.LifecycleState == string(loadbalancer.WorkRequestLifecycleStateInProgress) || *wr.LifecycleState == string(loadbalancer.WorkRequestLifecycleStateAccepted) {
-					logger.With("loadBalancerID", *lb.Id).Infof("current in-progress work requests for Load Balancer %s", *wr.Id)
-					return nil, errors.New("Load Balancer has work requests in progress, will wait and retry")
-				}
-			}
 		}
 	}
 
@@ -795,26 +770,12 @@ func (cp *CloudProvider) EnsureLoadBalancer(ctx context.Context, clusterName str
 		}
 	}
 
-	// Service controller provided empty nodes list
-	// TODO: Revisit this condition when clusters with mixed node pools are introduced, possibly add len(virtualPods) == 0 check
-	if len(nodes) == 0 {
-		// List all nodes in the cluster
-		nodeList, err := cp.NodeLister.List(labels.Everything())
-		if err != nil {
-			logger.With(zap.Error(err)).Error("Failed to check if all backend nodes are not ready, error listing nodes")
-			return nil, err
-		}
-
-		if len(nodeList) == 0 {
-			logger.Info("Cluster has zero nodes, continue reconciling")
-		} else if allNodesNotReady := cp.checkAllBackendNodesNotReady(nodeList); allNodesNotReady {
-			logger.Info("Not removing backends since all nodes are Not Ready")
-			return loadBalancerToStatus(lb)
-		} else {
-			err = errors.Errorf("backend node status is inconsistent, will retry")
-			logger.With(zap.Error(err)).Error("Not removing backends since backend node status is inconsistent with what was observed by service controller")
-			return nil, err
-		}
+	// If network partition, do not proceed
+	isNetworkPartition, err := cp.checkForNetworkPartition(logger, clusterNodes)
+	if err != nil {
+		return nil, err
+	} else if isNetworkPartition {
+		return nil, nil
 	}
 
 	if err := lbProvider.updateLoadBalancer(ctx, lb, spec); err != nil {
@@ -922,7 +883,7 @@ func (cp *CloudProvider) getLoadBalancerSubnets(ctx context.Context, logger *zap
 func (clb *CloudLoadBalancerProvider) updateLoadBalancer(ctx context.Context, lb *client.GenericLoadBalancer, spec *LBSpec) error {
 	lbID := *lb.Id
 
-	logger := clb.logger.With("loadBalancerID", lbID, "compartmentID", clb.config.CompartmentID, "loadBalancerType", getLoadBalancerType(spec.service))
+	logger := clb.logger.With("loadBalancerID", lbID, "compartmentID", clb.config.CompartmentID, "loadBalancerType", getLoadBalancerType(spec.service), "serviceName", spec.service.Name)
 
 	var actualPublicReservedIP *string
 
@@ -934,13 +895,6 @@ func (clb *CloudLoadBalancerProvider) updateLoadBalancer(ctx context.Context, lb
 		if ip.ReservedIp != nil && *ip.IsPublic {
 			actualPublicReservedIP = ip.IpAddress
 			break
-		}
-	}
-
-	//check if the reservedIP has changed in spec
-	if spec.LoadBalancerIP != "" || actualPublicReservedIP != nil {
-		if actualPublicReservedIP == nil || *actualPublicReservedIP != spec.LoadBalancerIP {
-			return errors.Errorf("The Load Balancer service reserved IP cannot be updated after the Load Balancer is created.")
 		}
 	}
 
@@ -959,26 +913,6 @@ func (clb *CloudLoadBalancerProvider) updateLoadBalancer(ctx context.Context, lb
 	nodeSubnets, err := getSubnetsForNodes(ctx, spec.nodes, clb.client)
 	if err != nil {
 		return errors.Wrap(err, "get subnets for nodes")
-	}
-
-	// Only LB supports fixed shapes which can be changed
-	if spec.Type == LB {
-		shapeChanged := hasLoadbalancerShapeChanged(ctx, spec, lb)
-
-		if shapeChanged {
-			err = clb.updateLoadbalancerShape(ctx, lb, spec)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	nsgChanged := hasLoadBalancerNetworkSecurityGroupsChanged(ctx, lb.NetworkSecurityGroupIds, spec.NetworkSecurityGroupIds)
-	if nsgChanged {
-		err = clb.updateLoadBalancerNetworkSecurityGroups(ctx, lb, spec)
-		if err != nil {
-			return err
-		}
 	}
 
 	if len(backendSetActions) == 0 && len(listenerActions) == 0 {
@@ -1016,6 +950,67 @@ func (clb *CloudLoadBalancerProvider) updateLoadBalancer(ctx context.Context, lb
 			err := clb.updateListener(ctx, lbID, a, ports, lbSubnets, nodeSubnets, spec.SourceCIDRs, spec.securityListManager, spec)
 			if err != nil {
 				return errors.Wrap(err, "updating listener")
+			}
+		}
+	}
+
+	// Check if the customer managed LB NSGs have changed
+	nsgChanged := hasLoadBalancerNetworkSecurityGroupsChanged(ctx, lb.NetworkSecurityGroupIds, spec.NetworkSecurityGroupIds)
+	if nsgChanged {
+		err = clb.updateLoadBalancerNetworkSecurityGroups(ctx, lb, spec)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Only LB supports fixed/flexible shapes which can be changed
+	if spec.Type == LB {
+		shapeChanged := hasLoadbalancerShapeChanged(ctx, spec, lb)
+
+		if shapeChanged {
+			err = clb.updateLoadbalancerShape(ctx, lb, spec)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Check if the reservedIP has changed in spec
+	if spec.LoadBalancerIP != "" || actualPublicReservedIP != nil {
+		if actualPublicReservedIP == nil || *actualPublicReservedIP != spec.LoadBalancerIP {
+			return errors.Errorf("The Load Balancer service reserved IP cannot be updated after the Load Balancer is created.")
+		}
+	}
+	return nil
+}
+
+func (clb *CloudLoadBalancerProvider) updateLoadBalancerBackends(ctx context.Context, lb *client.GenericLoadBalancer, spec *LBSpec) error {
+	lbID := *lb.Id
+
+	logger := clb.logger.With("loadBalancerID", lbID, "compartmentID", clb.config.CompartmentID, "loadBalancerType", getLoadBalancerType(spec.service), "serviceName", spec.service.Name)
+
+	actualBackendSets := lb.BackendSets
+	desiredBackendSets := spec.BackendSets
+	backendSetActions := getBackendSetChanges(logger, actualBackendSets, desiredBackendSets)
+
+	lbSubnets, err := getSubnets(ctx, spec.Subnets, clb.client.Networking())
+	if err != nil {
+		return errors.Wrapf(err, "getting load balancer subnets")
+	}
+	nodeSubnets, err := getSubnetsForNodes(ctx, spec.nodes, clb.client)
+	if err != nil {
+		return errors.Wrap(err, "get subnets for nodes")
+	}
+
+	for _, action := range backendSetActions {
+		switch a := action.(type) {
+		case *BackendSetAction:
+			switch a.Type() {
+			case Update:
+				err := clb.updateBackendSet(ctx, lbID, a, lbSubnets, nodeSubnets, spec.securityListManager, spec)
+				if err != nil {
+					return errors.Wrap(err, "updating BackendSet")
+				}
 			}
 		}
 	}
@@ -1135,11 +1130,150 @@ func (clb *CloudLoadBalancerProvider) updateListener(ctx context.Context, lbID s
 
 // UpdateLoadBalancer updates an existing loadbalancer
 func (cp *CloudProvider) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
-	name := cp.GetLoadBalancerName(ctx, clusterName, service)
-	cp.logger.With("loadBalancerName", name, "loadBalancerType", getLoadBalancerType(service)).Info("Updating load balancer")
+	startTime := time.Now()
+	lbName := GetLoadBalancerName(service)
+	loadBalancerType := getLoadBalancerType(service)
+	logger := cp.logger.With("loadBalancerName", lbName, "serviceName", service.Name, "loadBalancerType", loadBalancerType, "serviceUid", service.UID)
+	if sa, useWI := service.Annotations[ServiceAnnotationServiceAccountName]; useWI { // When using Workload Identity
+		logger = logger.With("serviceAccount", sa, "namespace", service.Namespace)
+	}
 
-	_, err := cp.EnsureLoadBalancer(ctx, clusterName, service, nodes)
-	return err
+	if deleted, err := cp.serviceDeletedOrDoesNotExist(ctx, service); deleted {
+		if err != nil {
+			logger.With(zap.Error(err)).Error("Failed to check if service exists")
+			return errors.Wrap(err, "Failed to check service status")
+		}
+		logger.Info("Service already deleted or no more exists")
+		return errors.New("Service already deleted or no more exists")
+	}
+	loadBalancerService := fmt.Sprintf("%s/%s", service.Namespace, service.Name)
+	if acquired := cp.lbLocks.TryAcquire(loadBalancerService); !acquired {
+		logger.Error("Could not acquire lock for Updating Load Balancer")
+		return errors.Errorf(LbOperationAlreadyExistsFmt, loadBalancerType, loadBalancerService)
+	}
+	defer cp.lbLocks.Release(loadBalancerService)
+
+	nodes, err := filterNodes(service, nodes)
+	if err != nil {
+		logger.With(zap.Error(err)).Error("Failed to filter nodes with label selector")
+		return err
+	}
+
+	logger.With("nodes", len(nodes)).Info("Ensuring load balancer")
+
+	// If network partition, do not proceed
+	isNetworkPartition, err := cp.checkForNetworkPartition(logger, nodes)
+	if err != nil {
+		return err
+	} else if isNetworkPartition {
+		return nil
+	}
+
+	dimensionsMap := make(map[string]string)
+
+	var errorType string
+	var lbMetricDimension string
+
+	lbProvider, err := cp.getLoadBalancerProvider(ctx, service)
+	if err != nil {
+		return errors.Wrap(err, "Unable to get Load Balancer Client.")
+	}
+	lb, err := lbProvider.lbClient.GetLoadBalancerByName(ctx, cp.config.CompartmentID, lbName)
+	if err != nil && !client.IsNotFound(err) {
+		logger.With(zap.Error(err)).Error("Failed to get loadbalancer by name")
+		errorType = util.GetError(err)
+		lbMetricDimension = util.GetMetricDimensionForComponent(errorType, util.LoadBalancerType)
+		dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
+		dimensionsMap[metrics.ResourceOCIDDimension] = lbName
+		metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, Update), time.Since(startTime).Seconds(), dimensionsMap)
+		return err
+	} else if client.IsNotFound(err) {
+		logger.Infof("Could not find load balancer, will not retry UpdateLoadBalancer.")
+		return nil
+	}
+
+	if lb.LifecycleState == nil || *lb.LifecycleState != lbLifecycleStateActive {
+		logger := logger.With("lifecycleState", lb.LifecycleState)
+		switch loadBalancerType {
+		case NLB:
+			// This check is added here since NLBs are marked as failed in case nlb work-requests fail NLB-26239
+			if *lb.LifecycleState == string(networkloadbalancer.LifecycleStateFailed) {
+				logger.Infof("NLB is in %s state, process the Loadbalancer", *lb.LifecycleState)
+			} else {
+				return errors.Errorf("NLB is in %s state, wait for NLB to move to %s", *lb.LifecycleState, lbLifecycleStateActive)
+			}
+			break
+		default:
+			logger.Infof("LB is not in %s state, will retry UpdateLoadBalancer", lbLifecycleStateActive)
+			return errors.Errorf("rejecting request to update LB which is not in %s state", lbLifecycleStateActive)
+		}
+	}
+
+	lbOCID := ""
+	if lb != nil && lb.Id != nil {
+		lbOCID = *lb.Id
+	} else {
+		// if the LB does not exist already use the k8s service UID for reference
+		// in logs and metrics
+		logger.Error("Load Balancer Id is empty, will retry UpdateLoadBalancer.")
+		return errors.New("Load Balancer service returned empty Id, will wait and retry")
+	}
+
+	logger = logger.With("loadBalancerID", lbOCID)
+	dimensionsMap[metrics.ResourceOCIDDimension] = lbOCID
+
+	err = cp.checkPendingLBWorkRequests(ctx, logger, lbProvider, lb, service, startTime)
+	if err != nil {
+		return err
+	}
+
+	subnets, err := cp.getLoadBalancerSubnets(ctx, logger, service)
+	if err != nil {
+		logger.With(zap.Error(err)).Error("Failed to get Load balancer Subnets.")
+		errorType = util.GetError(err)
+		lbMetricDimension = util.GetMetricDimensionForComponent(errorType, util.LoadBalancerType)
+		dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
+		metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, Update), time.Since(startTime).Seconds(), dimensionsMap)
+		return err
+	}
+
+	spec, err := NewLBSpec(logger, service, nodes, subnets, nil, cp.securityListManagerFactory, cp.config.Tags, lb)
+	if err != nil {
+		logger.With(zap.Error(err)).Error("Failed to derive LBSpec")
+		errorType = util.GetError(err)
+		lbMetricDimension = util.GetMetricDimensionForComponent(errorType, util.LoadBalancerType)
+		dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
+		metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, Update), time.Since(startTime).Seconds(), dimensionsMap)
+
+		return err
+	}
+
+	// Existing load balancers cannot change subnets. This ensures that the spec matches
+	// what the actual load balancer has listed as the subnet ids. If the load balancer
+	// was just created then these values would be equal; however, if the load balancer
+	// already existed and the default subnet ids changed, then this would ensure
+	// we are setting the security rules on the correct subnets.
+	spec, err = updateSpecWithLbSubnets(spec, lb.SubnetIds)
+	if err != nil {
+		return err
+	}
+
+	if err := lbProvider.updateLoadBalancerBackends(ctx, lb, spec); err != nil {
+		errorType = util.GetError(err)
+		lbMetricDimension = util.GetMetricDimensionForComponent(errorType, util.LoadBalancerType)
+		logger.With(zap.Error(err)).Error("Failed to update LoadBalancer backends")
+		dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
+		metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, Update), time.Since(startTime).Seconds(), dimensionsMap)
+		return err
+	}
+
+	syncTime := time.Since(startTime).Seconds()
+	logger.Info("Successfully updated loadbalancer backends")
+	lbMetricDimension = util.GetMetricDimensionForComponent(util.Success, util.LoadBalancerType)
+	dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
+	dimensionsMap[metrics.BackendSetsCountDimension] = strconv.Itoa(len(lb.BackendSets))
+	metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, Update), syncTime, dimensionsMap)
+	return nil
 }
 
 // getNodesByIPs returns a slice of Nodes corresponding to the given IP addresses.
@@ -1570,4 +1704,66 @@ func (cp *CloudProvider) getFrontendNsgByName(ctx context.Context, logger *zap.S
 		}
 	}
 	return "", nil, nil
+}
+
+// checkPendingLBWorkRequests checks if we have pending work requests before processing the LoadBalancer further
+// Will error out if any in-progress work request are present for the LB
+func (cp *CloudProvider) checkPendingLBWorkRequests(ctx context.Context, logger *zap.SugaredLogger, lbProvider CloudLoadBalancerProvider, lb *client.GenericLoadBalancer, service *v1.Service, startTime time.Time) (err error) {
+	listWorkRequestTime := time.Now()
+	loadBalancerType := getLoadBalancerType(service)
+	lbName := GetLoadBalancerName(service)
+	dimensionsMap := make(map[string]string)
+	dimensionsMap[metrics.ResourceOCIDDimension] = *lb.Id
+
+	lbInProgressWorkRequests, err := lbProvider.lbClient.ListWorkRequests(ctx, *lb.CompartmentId, *lb.Id)
+	logger.With("loadBalancerID", *lb.Id).Infof("time (in seconds) to list work-requests for LB %f", time.Since(listWorkRequestTime).Seconds())
+	if err != nil {
+		logger.With(zap.Error(err)).Error("Failed to list work-requests in-progress")
+		errorType := util.GetError(err)
+		lbMetricDimension := util.GetMetricDimensionForComponent(errorType, util.LoadBalancerType)
+		dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
+		dimensionsMap[metrics.ResourceOCIDDimension] = lbName
+		metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, List), time.Since(startTime).Seconds(), dimensionsMap)
+		return err
+	}
+	for _, wr := range lbInProgressWorkRequests {
+		switch loadBalancerType {
+		case NLB:
+			if wr.Status == string(networkloadbalancer.OperationStatusInProgress) || wr.Status == string(networkloadbalancer.OperationStatusAccepted) {
+				logger.With("loadBalancerID", *lb.Id).Infof("current in-progress work requests for Network Load Balancer %s", *wr.Id)
+				return errors.New("Network Load Balancer has work requests in progress, will wait and retry")
+			}
+		default:
+			if *wr.LifecycleState == string(loadbalancer.WorkRequestLifecycleStateInProgress) || *wr.LifecycleState == string(loadbalancer.WorkRequestLifecycleStateAccepted) {
+				logger.With("loadBalancerID", *lb.Id).Infof("current in-progress work requests for Load Balancer %s", *wr.Id)
+				return errors.New("Load Balancer has work requests in progress, will wait and retry")
+			}
+		}
+	}
+	return
+}
+
+// checkForNetworkPartition return true if network partition is present (all nodes are not ready) else throws an error if any
+func (cp *CloudProvider) checkForNetworkPartition(logger *zap.SugaredLogger, nodes []*v1.Node) (isNetworkPartition bool, err error) {
+	// Service controller provided empty provisioned nodes list
+	if len(nodes) == 0 {
+		// List all nodes in the cluster
+		nodeList, err := cp.NodeLister.List(labels.Everything())
+		if err != nil {
+			logger.With(zap.Error(err)).Error("Failed to check if all backend nodes are not ready, error listing nodes")
+			return false, err
+		}
+
+		if len(nodeList) == 0 {
+			logger.Info("Cluster has zero nodes, continue reconciling")
+		} else if allNodesNotReady := cp.checkAllBackendNodesNotReady(nodeList); allNodesNotReady {
+			logger.Info("Not removing backends since all nodes are Not Ready")
+			return true, nil
+		} else {
+			err = errors.Errorf("backend node status is inconsistent, will retry")
+			logger.With(zap.Error(err)).Error("Not removing backends since backend node status is inconsistent with what was observed by service controller")
+			return false, err
+		}
+	}
+	return
 }

--- a/pkg/cloudprovider/providers/oci/load_balancer.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer.go
@@ -539,6 +539,7 @@ func (cp *CloudProvider) EnsureLoadBalancer(ctx context.Context, clusterName str
 		dimensionsMap[metrics.ComponentDimension] = lbMetricDimension
 		dimensionsMap[metrics.ResourceOCIDDimension] = lbName
 		metrics.SendMetricData(cp.metricPusher, getMetric(loadBalancerType, Update), time.Since(startTime).Seconds(), dimensionsMap)
+		return nil, err
 	}
 	lbExists := !client.IsNotFound(err)
 	lbOCID := ""

--- a/pkg/cloudprovider/providers/oci/load_balancer.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer.go
@@ -1422,6 +1422,7 @@ func (cp *CloudProvider) cleanupSecurityRulesForLoadBalancerDelete(lb *client.Ge
 			return errors.Wrapf(err, "delete security rules for listener %q on load balancer %q", listenerName, name)
 		}
 
+		logger.Infof("Security rule management mode %s", securityRuleManagerMode)
 		if securityRuleManagerMode == ManagementModeAll || securityRuleManagerMode == ManagementModeFrontend {
 			if err = securityListManager.Delete(ctx, lbSubnets, nodeSubnets, ports, sourceCIDRs, isPreserveSource); err != nil {
 				logger.With(zap.Error(err)).Errorf("Failed to delete security rules for listener %q on load balancer %q", listenerName, name)

--- a/pkg/cloudprovider/providers/oci/load_balancer_security_lists.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_security_lists.go
@@ -680,21 +680,22 @@ func healthCheckPortInUse(serviceLister listersv1.ServiceLister, port int32) (bo
 		return false, err
 	}
 	for _, service := range serviceList {
-		if service.DeletionTimestamp == nil || service.Spec.Type == api.ServiceTypeLoadBalancer {
-			if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyCluster {
-				// This service is using the default healthcheck port, so we must check if
-				// any other service is also using this default healthcheck port.
-				if port == lbNodesHealthCheckPort {
-					return true, nil
-				}
-			} else if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyLocal {
-				// This service is using a custom healthcheck port (enabled through setting
-				// externalTrafficPolicy=Local on the service). As this port is unique
-				// per service, we know no other service will be using this port too.
-				if port == service.Spec.HealthCheckNodePort {
-					// Service with this healthCheckerPort is still not deleted (this would be a "delete listener" call in that case)
-					return true, nil
-				}
+		if service.DeletionTimestamp != nil || service.Spec.Type != api.ServiceTypeLoadBalancer {
+			continue
+		}
+		if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyCluster {
+			// This service is using the default healthcheck port, so we must check if
+			// any other service is also using this default healthcheck port.
+			if port == lbNodesHealthCheckPort {
+				return true, nil
+			}
+		} else if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyLocal {
+			// This service is using a custom healthcheck port (enabled through setting
+			// externalTrafficPolicy=Local on the service). As this port is unique
+			// per service, we know no other service will be using this port too.
+			if port == service.Spec.HealthCheckNodePort {
+				// Service with this healthCheckerPort is still not deleted (this would be a "delete listener" call in that case)
+				return true, nil
 			}
 		}
 	}

--- a/pkg/cloudprovider/providers/oci/load_balancer_security_lists.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_security_lists.go
@@ -683,13 +683,13 @@ func healthCheckPortInUse(serviceLister listersv1.ServiceLister, port int32) (bo
 		if service.DeletionTimestamp != nil || service.Spec.Type != api.ServiceTypeLoadBalancer {
 			continue
 		}
-		if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyCluster {
+		if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyTypeCluster {
 			// This service is using the default healthcheck port, so we must check if
 			// any other service is also using this default healthcheck port.
 			if port == lbNodesHealthCheckPort {
 				return true, nil
 			}
-		} else if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyLocal {
+		} else if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyTypeLocal {
 			// This service is using a custom healthcheck port (enabled through setting
 			// externalTrafficPolicy=Local on the service). As this port is unique
 			// per service, we know no other service will be using this port too.

--- a/pkg/cloudprovider/providers/oci/load_balancer_security_lists.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_security_lists.go
@@ -30,7 +30,6 @@ import (
 	sets "k8s.io/apimachinery/pkg/util/sets"
 	informersv1 "k8s.io/client-go/informers/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
-	helper "k8s.io/cloud-provider/service/helpers"
 )
 
 const (
@@ -429,7 +428,7 @@ func getNodeIngressRules(
 			"source", *rule.Source,
 			"destinationPortRangeMin", *rule.TcpOptions.DestinationPortRange.Min,
 			"destinationPortRangeMax", *rule.TcpOptions.DestinationPortRange.Max,
-		).Debug("Deleting node ingres security rule")
+		).Debug("Deleting node ingress security rule")
 	}
 
 	if desiredBackend.Len() == 0 && desiredHealthChecker.Len() == 0 {
@@ -676,25 +675,26 @@ func portInUse(serviceLister listersv1.ServiceLister, port int32) (bool, error) 
 }
 
 func healthCheckPortInUse(serviceLister listersv1.ServiceLister, port int32) (bool, error) {
-	if port != lbNodesHealthCheckPort {
-		// This service is using a custom healthcheck port (enabled through setting
-		// extenalTrafficPolicy=Local on the service). As this port is unique
-		// per service, we know no other service will be using this port too.
-		return false, nil
-	}
-
-	// This service is using the default healthcheck port, so we must check if
-	// any other service is also using this default healthcheck port.
 	serviceList, err := serviceLister.List(labels.Everything())
 	if err != nil {
 		return false, err
 	}
 	for _, service := range serviceList {
-		if service.Spec.Type == api.ServiceTypeLoadBalancer {
-			healthCheckPath, _ := helper.GetServiceHealthCheckPathPort(service)
-			if healthCheckPath == "" {
-				// We have found another service using the default port.
-				return true, nil
+		if service.DeletionTimestamp == nil || service.Spec.Type == api.ServiceTypeLoadBalancer {
+			if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyCluster {
+				// This service is using the default healthcheck port, so we must check if
+				// any other service is also using this default healthcheck port.
+				if port == lbNodesHealthCheckPort {
+					return true, nil
+				}
+			} else if service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyLocal {
+				// This service is using a custom healthcheck port (enabled through setting
+				// externalTrafficPolicy=Local on the service). As this port is unique
+				// per service, we know no other service will be using this port too.
+				if port == service.Spec.HealthCheckNodePort {
+					// Service with this healthCheckerPort is still not deleted (this would be a "delete listener" call in that case)
+					return true, nil
+				}
 			}
 		}
 	}

--- a/pkg/cloudprovider/providers/oci/load_balancer_security_lists_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_security_lists_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	k8sports "k8s.io/kubernetes/pkg/cluster/ports"
 )
 
@@ -171,7 +170,7 @@ func TestGetNodeIngressRules(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-default-health-check-port"},
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyCluster),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
 						Ports:                 []v1.ServicePort{{Port: 443}},
 					},
 				},
@@ -201,7 +200,7 @@ func TestGetNodeIngressRules(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-default-health-check-port"},
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyCluster),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
 						Ports:                 []v1.ServicePort{{Port: 443}},
 					},
 				},
@@ -209,7 +208,7 @@ func TestGetNodeIngressRules(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-NodePort-health-check-port"},
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyLocal),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
 						Ports:                 []v1.ServicePort{{Port: 8081}},
 						HealthCheckNodePort:   32000,
 					},
@@ -316,7 +315,7 @@ func TestGetNodeIngressRules(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-non-default-health-check-port"},
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyLocal),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 						Ports:                 []v1.ServicePort{{Port: 8081}},
 					},
 				},
@@ -495,7 +494,7 @@ func TestGetNodeIngressRules_NLB(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-default-health-check-port"},
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyCluster),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
 						Ports:                 []v1.ServicePort{{Port: 443}},
 					},
 				},
@@ -996,7 +995,7 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-default-health-check-port"},
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyCluster),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
 						Ports:                 []v1.ServicePort{{Port: 80}},
 					},
 				},
@@ -1020,7 +1019,7 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-default-health-check-port"},
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyLocal),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 						HealthCheckNodePort:   30000,
 					},
 				},
@@ -1045,7 +1044,7 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "namespace", Name: "using-Nodeport-health-check-port"},
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyLocal),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 						Ports:                 []v1.ServicePort{{Port: 80}},
 						HealthCheckNodePort:   30000,
 					},
@@ -1055,7 +1054,7 @@ func TestGetLoadBalancerEgressRules(t *testing.T) {
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
 						Ports:                 []v1.ServicePort{{Port: 8080}},
-						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicy(api.ServiceExternalTrafficPolicyCluster),
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
 					},
 				},
 			},

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec.go
@@ -17,6 +17,7 @@ package oci
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/oracle/oci-cloud-controller-manager/pkg/util"
 	"net"
 	"net/http"
 	"strconv"
@@ -376,6 +377,10 @@ func NewLBSpec(logger *zap.SugaredLogger, svc *v1.Service, nodes []*v1.Node, sub
 	lbTags, err := getLoadBalancerTags(svc, initialLBTags)
 	if err != nil {
 		return nil, err
+	}
+	// merge lbtags with common tags if present
+	if util.IsCommonTagPresent(initialLBTags) {
+		lbTags = util.MergeTagConfig(lbTags, initialLBTags.Common)
 	}
 
 	ruleManagementMode, managedNsg, err := getRuleManagementMode(svc)
@@ -1286,6 +1291,7 @@ func getLoadBalancerTags(svc *v1.Service, initialTags *config.InitialTags) (*con
 	if initialTags == nil || initialTags.LoadBalancer == nil {
 		return &config.TagConfig{}, nil
 	}
+
 	// return initial tags
 	return initialTags.LoadBalancer, nil
 }

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec.go
@@ -17,7 +17,6 @@ package oci
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/oracle/oci-cloud-controller-manager/pkg/util"
 	"net"
 	"net/http"
 	"strconv"
@@ -30,6 +29,7 @@ import (
 
 	"github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/oci/client"
+	"github.com/oracle/oci-cloud-controller-manager/pkg/util"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/pkg/errors"
 	helper "k8s.io/cloud-provider/service/helpers"
@@ -318,6 +318,7 @@ type LBSpec struct {
 	NetworkSecurityGroupIds     []string
 	FreeformTags                map[string]string
 	DefinedTags                 map[string]map[string]interface{}
+	SystemTags                  map[string]map[string]interface{}
 
 	service *v1.Service
 	nodes   []*v1.Node
@@ -379,7 +380,7 @@ func NewLBSpec(logger *zap.SugaredLogger, svc *v1.Service, nodes []*v1.Node, sub
 		return nil, err
 	}
 	// merge lbtags with common tags if present
-	if util.IsCommonTagPresent(initialLBTags) {
+	if enableOkeSystemTags && util.IsCommonTagPresent(initialLBTags) {
 		lbTags = util.MergeTagConfig(lbTags, initialLBTags.Common)
 	}
 
@@ -421,6 +422,7 @@ func NewLBSpec(logger *zap.SugaredLogger, svc *v1.Service, nodes []*v1.Node, sub
 		securityListManager:         secListFactory(ruleManagementMode),
 		FreeformTags:                lbTags.FreeformTags,
 		DefinedTags:                 lbTags.DefinedTags,
+		SystemTags:                  getResourceTrackingSysTagsFromConfig(logger, initialLBTags),
 	}, nil
 }
 
@@ -1350,4 +1352,23 @@ func updateSpecWithLbSubnets(spec *LBSpec, lbSubnetId []string) (*LBSpec, error)
 	spec.Subnets = lbSubnetId
 
 	return spec, nil
+}
+
+// getResourceTrackingSysTagsFromConfig reads resource tracking tags from config
+// which are specified under common tags
+func getResourceTrackingSysTagsFromConfig(logger *zap.SugaredLogger, initialTags *config.InitialTags) (resourceTrackingTags map[string]map[string]interface{}) {
+	resourceTrackingTags = make(map[string]map[string]interface{})
+	// TODO: Fix the double negative
+	if !(util.IsCommonTagPresent(initialTags) && initialTags.Common.DefinedTags != nil) {
+		logger.Error("oke resource tracking system tags are not present in cloud-config.yaml")
+		return nil
+	}
+
+	if tag, exists := initialTags.Common.DefinedTags[OkeSystemTagNamesapce]; exists {
+		resourceTrackingTags[OkeSystemTagNamesapce] = tag
+		return
+	}
+
+	logger.Error("tag config doesn't consist resource tracking tags")
+	return nil
 }

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
@@ -4007,13 +4007,23 @@ func Test_getSecurityListManagementMode(t *testing.T) {
 		service  *v1.Service
 		expected string
 	}{
-		"defaults": {
+		"defaults - lb": {
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{},
 				},
 			},
-			expected: "",
+			expected: "All",
+		},
+		"defaults - nlb": {
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationLoadBalancerType: "nlb",
+					},
+				},
+			},
+			expected: "None",
 		},
 		"lb mode None": {
 			service: &v1.Service{
@@ -4115,7 +4125,22 @@ func Test_getRuleManagementMode(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 			},
-			expected: "",
+			expected: "All",
+			nsg: &ManagedNetworkSecurityGroup{
+				nsgRuleManagementMode: ManagementModeNone,
+				frontendNsgId:         "",
+				backendNsgId:          []string{},
+			},
+		},
+		"defaults - nlb": {
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationLoadBalancerType: "nlb",
+					},
+				},
+			},
+			expected: "None",
 			nsg: &ManagedNetworkSecurityGroup{
 				nsgRuleManagementMode: ManagementModeNone,
 				frontendNsgId:         "",

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec_test.go
@@ -2733,7 +2733,7 @@ func TestNewLBSpecForTags(t *testing.T) {
 				return newSecurityListManagerNOOP()
 			}
 
-			result, err := NewLBSpec(logger.Sugar(), tc.service, tc.nodes, tc.virtualPods, subnets, tc.sslConfig, slManagerFactory, tc.clusterTags, nil)
+			result, err := NewLBSpec(logger.Sugar(), tc.service, tc.nodes, subnets, tc.sslConfig, slManagerFactory, tc.clusterTags, nil)
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/csi-util/utils.go
+++ b/pkg/csi-util/utils.go
@@ -109,14 +109,16 @@ func (u *Util) LookupNodeAvailableDomain(k kubernetes.Interface, nodeID string) 
 		return "", fmt.Errorf("failed to get node %s", nodeID)
 	}
 	if n.Labels != nil {
-		ad, ok := n.Labels[kubeAPI.LabelZoneFailureDomain]
+		ad, ok := n.Labels[kubeAPI.LabelTopologyZone]
+		if !ok {
+			ad, ok = n.Labels[kubeAPI.LabelZoneFailureDomain]
+		}
 		if ok {
 			return ad, nil
 		}
 	}
-
-	errMsg := fmt.Sprint("Did not find the label for the fault domain.")
-	u.Logger.With("nodeId", nodeID, "label", kubeAPI.LabelZoneFailureDomain).Error(errMsg)
+	errMsg := fmt.Sprintf("Did not find the label for the fault domain. Checked Topology Labels: %s, %s", kubeAPI.LabelTopologyZone, kubeAPI.LabelZoneFailureDomain)
+	u.Logger.With("nodeId", nodeID).Error(errMsg)
 	return "", fmt.Errorf(errMsg)
 }
 

--- a/pkg/csi-util/utils.go
+++ b/pkg/csi-util/utils.go
@@ -452,3 +452,17 @@ func ValidateFssId(id string) *FSSVolumeHandler {
 	}
 	return volumeHandler
 }
+
+func GetIsFeatureEnabledFromEnv(logger *zap.SugaredLogger, featureName string, defaultValue bool) bool {
+	enableFeature := defaultValue
+	enableFeatureEnvVar, ok := os.LookupEnv(featureName)
+	if ok {
+		var err error
+		enableFeature, err = strconv.ParseBool(enableFeatureEnvVar)
+		if err != nil {
+			logger.With(zap.Error(err)).Errorf("failed to parse %s envvar, defaulting to %t", featureName, defaultValue)
+			return defaultValue
+		}
+	}
+	return enableFeature
+}

--- a/pkg/csi/driver/bv_controller.go
+++ b/pkg/csi/driver/bv_controller.go
@@ -65,7 +65,10 @@ const (
 	multipathEnabled              = "multipathEnabled"
 	multipathDevices              = "multipathDevices"
 	//device is the consistent device path that would be used for paravirtualized attachment
-	device = "device"
+	device                          = "device"
+	resourceTrackingFeatureFlagName = "CPO_ENABLE_RESOURCE_ATTRIBUTION"
+	OkeSystemTagNamesapce           = "orcl-containerengine"
+	MaxDefinedTagPerVolume          = 64
 )
 
 var (
@@ -76,6 +79,8 @@ var (
 		Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 	}
 )
+
+var enableOkeSystemTags = csi_util.GetIsFeatureEnabledFromEnv(zap.S(), resourceTrackingFeatureFlagName, false)
 
 // VolumeParameters holds configuration
 type VolumeParameters struct {
@@ -412,10 +417,23 @@ func (d *BlockVolumeControllerDriver) CreateVolume(ctx context.Context, req *csi
 			return nil, status.Errorf(codes.InvalidArgument, "invalid available domain: %s or compartment ID: %s", availableDomainShortName, d.config.CompartmentID)
 		}
 
-		bvTags := getBVTags(d.config.Tags, volumeParams)
+		bvTags := getBVTags(log, d.config.Tags, volumeParams)
 
 		provisionedVolume, err = provision(ctx, log, d.client, volumeName, size, *ad.Name, d.config.CompartmentID, srcSnapshotId, srcVolumeId,
 			volumeParams.diskEncryptionKey, volumeParams.vpusPerGB, bvTags)
+
+		if err != nil && client.IsSystemTagNotFoundOrNotAuthorisedError(log, errors.Unwrap(err)) {
+			log.With("Ad name", *ad.Name, "Compartment Id", d.config.CompartmentID).With(zap.Error(err)).Warn("New volume creation failed due to oke system tags error. sending metric & retrying without oke system tags")
+			errorType = util.SystemTagErrTypePrefix + util.GetError(err)
+			metricDimension = util.GetMetricDimensionForComponent(errorType, metricType)
+			dimensionsMap[metrics.ComponentDimension] = metricDimension
+			metrics.SendMetricData(d.metricPusher, metric, time.Since(startTime).Seconds(), dimensionsMap)
+
+			// retry provision without oke system tags
+			delete(bvTags.DefinedTags, OkeSystemTagNamesapce)
+			provisionedVolume, err = provision(ctx, log, d.client, volumeName, size, *ad.Name, d.config.CompartmentID, srcSnapshotId, srcVolumeId,
+				volumeParams.diskEncryptionKey, volumeParams.vpusPerGB, bvTags)
+		}
 		if err != nil {
 			log.With("Ad name", *ad.Name, "Compartment Id", d.config.CompartmentID).With(zap.Error(err)).Error("New volume creation failed.")
 			errorType = util.GetError(err)
@@ -1309,6 +1327,11 @@ func provision(ctx context.Context, log *zap.SugaredLogger, c client.Interface, 
 	}
 	if bvTags != nil && bvTags.DefinedTags != nil {
 		volumeDetails.DefinedTags = bvTags.DefinedTags
+		if len(volumeDetails.DefinedTags) > MaxDefinedTagPerVolume {
+			log.With("service", "blockstorage", "verb", "create", "resource", "volume", "volumeName", volName).
+				Warn("the number of defined tags in the volume create request is beyond the limit. removing system tags from the details")
+			delete(volumeDetails.DefinedTags, OkeSystemTagNamesapce)
+		}
 	}
 
 	newVolume, err := c.BlockStorage().CreateVolume(ctx, volumeDetails)
@@ -1352,7 +1375,7 @@ func isBlockVolumeAvailable(backup core.VolumeBackup) (bool, error) {
 	return false, nil
 }
 
-func getBVTags(tags *config.InitialTags, vp VolumeParameters) *config.TagConfig {
+func getBVTags(logger *zap.SugaredLogger, tags *config.InitialTags, vp VolumeParameters) *config.TagConfig {
 
 	bvTags := &config.TagConfig{}
 	if tags != nil && tags.BlockVolume != nil {
@@ -1368,7 +1391,7 @@ func getBVTags(tags *config.InitialTags, vp VolumeParameters) *config.TagConfig 
 		bvTags = scTags
 	}
 	// merge final tags with common tags
-	if util.IsCommonTagPresent(tags) {
+	if enableOkeSystemTags && util.IsCommonTagPresent(tags) {
 		bvTags = util.MergeTagConfig(bvTags, tags.Common)
 	}
 	return bvTags

--- a/pkg/csi/driver/bv_controller.go
+++ b/pkg/csi/driver/bv_controller.go
@@ -1229,7 +1229,7 @@ func (d *BlockVolumeControllerDriver) ControllerExpandVolume(ctx context.Context
 	if newSizeInGB <= oldSize {
 		log.Infof("Existing volume size: %v Requested volume size: %v No action needed.", *volume.SizeInGBs, newSizeInGB)
 		return &csi.ControllerExpandVolumeResponse{
-			CapacityBytes:         oldSize,
+			CapacityBytes:         oldSize * client.GiB,
 			NodeExpansionRequired: true,
 		}, nil
 	}

--- a/pkg/csi/driver/bv_controller_test.go
+++ b/pkg/csi/driver/bv_controller_test.go
@@ -465,7 +465,7 @@ func (c *MockLoadBalancerClient) ListWorkRequests(ctx context.Context, compartme
 	return nil, nil
 }
 
-func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails) (string, error) {
+func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails, serviceUid *string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/csi/driver/bv_controller_test.go
+++ b/pkg/csi/driver/bv_controller_test.go
@@ -1236,6 +1236,24 @@ func TestControllerDriver_ControllerExpandVolume(t *testing.T) {
 			wantErr: errors.New("Update volume failed"),
 		},
 		{
+			name:   "If no changes then do nothing in ControllerExpandVolume",
+			fields: fields{},
+			args: args{
+				ctx: nil,
+				req: &csi.ControllerExpandVolumeRequest{
+					VolumeId: "valid_volume_id",
+					CapacityRange: &csi.CapacityRange{
+						RequiredBytes: int64(csi_util.MaximumVolumeSizeInBytes),
+					},
+				},
+			},
+			want: &csi.ControllerExpandVolumeResponse{
+				CapacityBytes:         int64(csi_util.MaximumVolumeSizeInBytes),
+				NodeExpansionRequired: true,
+			},
+			wantErr: nil,
+		},
+		{
 			name:   "Uhp volume expand success in ControllerExpandVolume",
 			fields: fields{},
 			args: args{

--- a/pkg/csi/driver/bv_controller_test.go
+++ b/pkg/csi/driver/bv_controller_test.go
@@ -542,6 +542,10 @@ type MockComputeClient struct {
 	compute util.MockOCIComputeClient
 }
 
+func (c *MockComputeClient) ListInstancesByCompartmentAndAD(ctx context.Context, compartmentId, availabilityDomain string) (response []core.Instance, err error) {
+	return nil, nil
+}
+
 // GetInstance gets information about the specified instance.
 func (c *MockComputeClient) GetInstance(ctx context.Context, id string) (*core.Instance, error) {
 	if instance, ok := instances[id]; ok {

--- a/pkg/csi/driver/bv_node.go
+++ b/pkg/csi/driver/bv_node.go
@@ -659,6 +659,7 @@ func (d BlockVolumeNodeDriver) NodeGetInfo(ctx context.Context, req *csi.NodeGet
 		AccessibleTopology: &csi.Topology{
 			Segments: map[string]string{
 				kubeAPI.LabelZoneFailureDomain: ad,
+				kubeAPI.LabelTopologyZone:      ad,
 			},
 		},
 	}, nil

--- a/pkg/csi/driver/fss_node.go
+++ b/pkg/csi/driver/fss_node.go
@@ -428,6 +428,7 @@ func (d FSSNodeDriver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequ
 		AccessibleTopology: &csi.Topology{
 			Segments: map[string]string{
 				kubeAPI.LabelZoneFailureDomain: ad,
+				kubeAPI.LabelTopologyZone:      ad,
 			},
 		},
 	}, nil

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -104,6 +104,7 @@ type loadBalancerClient interface {
 	DeleteListener(ctx context.Context, request loadbalancer.DeleteListenerRequest) (response loadbalancer.DeleteListenerResponse, err error)
 	UpdateLoadBalancerShape(ctx context.Context, request loadbalancer.UpdateLoadBalancerShapeRequest) (response loadbalancer.UpdateLoadBalancerShapeResponse, err error)
 	UpdateNetworkSecurityGroups(ctx context.Context, request loadbalancer.UpdateNetworkSecurityGroupsRequest) (response loadbalancer.UpdateNetworkSecurityGroupsResponse, err error)
+	UpdateLoadBalancer(ctx context.Context, request loadbalancer.UpdateLoadBalancerRequest) (response loadbalancer.UpdateLoadBalancerResponse, err error)
 }
 
 type networkLoadBalancerClient interface {
@@ -120,6 +121,7 @@ type networkLoadBalancerClient interface {
 	UpdateListener(ctx context.Context, request networkloadbalancer.UpdateListenerRequest) (response networkloadbalancer.UpdateListenerResponse, err error)
 	DeleteListener(ctx context.Context, request networkloadbalancer.DeleteListenerRequest) (response networkloadbalancer.DeleteListenerResponse, err error)
 	UpdateNetworkSecurityGroups(ctx context.Context, request networkloadbalancer.UpdateNetworkSecurityGroupsRequest) (response networkloadbalancer.UpdateNetworkSecurityGroupsResponse, err error)
+	UpdateNetworkLoadBalancer(ctx context.Context, request networkloadbalancer.UpdateNetworkLoadBalancerRequest) (response networkloadbalancer.UpdateNetworkLoadBalancerResponse, err error)
 }
 
 type filestorageClient interface {

--- a/pkg/oci/client/client_test.go
+++ b/pkg/oci/client/client_test.go
@@ -173,6 +173,22 @@ func (c *mockComputeClient) DetachVolume(ctx context.Context, request core.Detac
 }
 
 func (c *mockComputeClient) ListInstanceDevices(ctx context.Context, request core.ListInstanceDevicesRequest) (response core.ListInstanceDevicesResponse, err error) {
+	devicePath := "/dev/oracleoci/oraclevdac"
+
+	if *request.InstanceId == "ocid1.device-path-returns-error" {
+		return core.ListInstanceDevicesResponse{}, errNotFound
+	} else if  *request.InstanceId == "ocid1.device-path-not-available" {
+		return core.ListInstanceDevicesResponse{
+				Items: []core.Device{},
+			}, nil
+	} else if  *request.InstanceId == "ocid1.one-device-path-available" {
+		return core.ListInstanceDevicesResponse{
+			Items: []core.Device{{
+					Name: &devicePath,
+				},
+			},
+		}, nil
+	}
 	return core.ListInstanceDevicesResponse{}, nil
 }
 

--- a/pkg/oci/client/errors.go
+++ b/pkg/oci/client/errors.go
@@ -18,13 +18,21 @@ import (
 	"context"
 	"math"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 var errNotFound = errors.New("not found")
+
+/*
+Addition of system tags can fail due to permission issue while API returns error code: RelatedResourceNotAuthorizedOrNotFound &
+the error message "The following tag namespaces / keys are not authorized or not found: 'orcl-containerengine'"
+*/
+var regexSystemTagNotFoundNotAuthorised = regexp.MustCompile(".*tag namespace.*orcl-containerengine.*")
 
 // HTTP Error Types
 const (
@@ -110,4 +118,21 @@ func NewRetryPolicyWithMaxAttempts(retryAttempts uint) *common.RetryPolicy {
 		retryAttempts, isRetryableOperation, nextDuration,
 	)
 	return &policy
+}
+
+func IsSystemTagNotFoundOrNotAuthorisedError(logger *zap.SugaredLogger, err error) bool {
+
+	var ociServiceError common.ServiceError
+
+	// unwrap till ociServiceError is found
+	if errors.As(err, &ociServiceError) {
+		logger.Debugf("API error code: %s", ociServiceError.GetCode())
+		logger.Debugf("service error message: %s", ociServiceError.GetMessage())
+
+		if ociServiceError.GetHTTPStatusCode() == http.StatusBadRequest &&
+			ociServiceError.GetCode() == HTTP400RelatedResourceNotAuthorizedOrNotFoundCode {
+			return regexSystemTagNotFoundNotAuthorised.MatchString(ociServiceError.GetMessage())
+		}
+	}
+	return false
 }

--- a/pkg/oci/client/generic_load_balancer_types.go
+++ b/pkg/oci/client/generic_load_balancer_types.go
@@ -146,6 +146,7 @@ type GenericLoadBalancer struct {
 
 	FreeformTags map[string]string
 	DefinedTags  map[string]map[string]interface{}
+	SystemTags   map[string]map[string]interface{}
 }
 
 type GenericWorkRequest struct {
@@ -161,4 +162,9 @@ type GenericWorkRequest struct {
 
 type GenericUpdateNetworkSecurityGroupsDetails struct {
 	NetworkSecurityGroupIds []string
+}
+
+type GenericUpdateLoadBalancerDetails struct {
+	FreeformTags map[string]string
+	DefinedTags  map[string]map[string]interface{}
 }

--- a/pkg/oci/client/load_balancer.go
+++ b/pkg/oci/client/load_balancer.go
@@ -133,6 +133,7 @@ func (c *loadbalancerClientStruct) CreateLoadBalancer(ctx context.Context, detai
 			DefinedTags:             details.DefinedTags,
 		},
 		RequestMetadata: c.requestMetadata,
+		OpcRetryToken:   details.DisplayName,
 	})
 	incRequestCounter(err, createVerb, loadBalancerResource)
 

--- a/pkg/oci/client/load_balancer.go
+++ b/pkg/oci/client/load_balancer.go
@@ -61,6 +61,7 @@ type GenericLoadBalancerInterface interface {
 
 	AwaitWorkRequest(ctx context.Context, id string) (*GenericWorkRequest, error)
 	ListWorkRequests(ctx context.Context, compartmentId, lbId string) ([]*GenericWorkRequest, error)
+	UpdateLoadBalancer(ctx context.Context, lbID string, details *GenericUpdateLoadBalancerDetails) (string, error)
 }
 
 func (c *loadbalancerClientStruct) GetLoadBalancer(ctx context.Context, id string) (*GenericLoadBalancer, error) {
@@ -515,6 +516,25 @@ func (c *loadbalancerClientStruct) UpdateNetworkSecurityGroups(ctx context.Conte
 	return *resp.OpcWorkRequestId, nil
 }
 
+func (c *loadbalancerClientStruct) UpdateLoadBalancer(ctx context.Context, lbID string, details *GenericUpdateLoadBalancerDetails) (string, error) {
+	if !c.rateLimiter.Writer.TryAccept() {
+		return "", RateLimitError(true, "UpdateLoadBalancer")
+	}
+
+	resp, err := c.loadbalancer.UpdateLoadBalancer(ctx, loadbalancer.UpdateLoadBalancerRequest{
+		UpdateLoadBalancerDetails: loadbalancer.UpdateLoadBalancerDetails{
+			FreeformTags: details.FreeformTags,
+			DefinedTags:  details.DefinedTags,
+		},
+		LoadBalancerId:  &lbID,
+		RequestMetadata: c.requestMetadata,
+	})
+	incRequestCounter(err, updateVerb, loadBalancerResource)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return *resp.OpcWorkRequestId, nil
+}
 func (c *loadbalancerClientStruct) loadbalancerToGenericLoadbalancer(lb *loadbalancer.LoadBalancer) *GenericLoadBalancer {
 	if lb == nil {
 		return nil
@@ -536,6 +556,7 @@ func (c *loadbalancerClientStruct) loadbalancerToGenericLoadbalancer(lb *loadbal
 		BackendSets:             c.backendSetsToGenericBackendSetDetails(lb.BackendSets),
 		FreeformTags:            lb.FreeformTags,
 		DefinedTags:             lb.DefinedTags,
+		SystemTags:              lb.SystemTags,
 	}
 }
 

--- a/pkg/oci/client/load_balancer.go
+++ b/pkg/oci/client/load_balancer.go
@@ -39,7 +39,7 @@ type loadbalancerClientStruct struct {
 }
 
 type GenericLoadBalancerInterface interface {
-	CreateLoadBalancer(ctx context.Context, details *GenericCreateLoadBalancerDetails) (string, error)
+	CreateLoadBalancer(ctx context.Context, details *GenericCreateLoadBalancerDetails, serviceUid *string) (string, error)
 
 	GetLoadBalancer(ctx context.Context, id string) (*GenericLoadBalancer, error)
 	GetLoadBalancerByName(ctx context.Context, compartmentID, name string) (*GenericLoadBalancer, error)
@@ -111,11 +111,10 @@ func (c *loadbalancerClientStruct) GetLoadBalancerByName(ctx context.Context, co
 	return nil, errors.WithStack(errNotFound)
 }
 
-func (c *loadbalancerClientStruct) CreateLoadBalancer(ctx context.Context, details *GenericCreateLoadBalancerDetails) (string, error) {
+func (c *loadbalancerClientStruct) CreateLoadBalancer(ctx context.Context, details *GenericCreateLoadBalancerDetails, serviceUid *string) (string, error) {
 	if !c.rateLimiter.Writer.TryAccept() {
 		return "", RateLimitError(true, "CreateLoadBalancer")
 	}
-
 	resp, err := c.loadbalancer.CreateLoadBalancer(ctx, loadbalancer.CreateLoadBalancerRequest{
 		CreateLoadBalancerDetails: loadbalancer.CreateLoadBalancerDetails{
 			CompartmentId:           details.CompartmentId,
@@ -133,7 +132,7 @@ func (c *loadbalancerClientStruct) CreateLoadBalancer(ctx context.Context, detai
 			DefinedTags:             details.DefinedTags,
 		},
 		RequestMetadata: c.requestMetadata,
-		OpcRetryToken:   details.DisplayName,
+		OpcRetryToken:   serviceUid,
 	})
 	incRequestCounter(err, createVerb, loadBalancerResource)
 

--- a/pkg/oci/client/load_balancer_test.go
+++ b/pkg/oci/client/load_balancer_test.go
@@ -220,6 +220,9 @@ func (c *MockLoadBalancerClient) UpdateLoadBalancerShape(ctx context.Context, re
 func (c *MockLoadBalancerClient) UpdateNetworkSecurityGroups(ctx context.Context, request loadbalancer.UpdateNetworkSecurityGroupsRequest) (response loadbalancer.UpdateNetworkSecurityGroupsResponse, err error) {
 	return
 }
+func (c *MockLoadBalancerClient) UpdateLoadBalancer(ctx context.Context, request loadbalancer.UpdateLoadBalancerRequest) (response loadbalancer.UpdateLoadBalancerResponse, err error) {
+	return
+}
 
 func assertError(actual, expected error) bool {
 	if expected == nil || actual == nil {

--- a/pkg/oci/client/network_load_balancer.go
+++ b/pkg/oci/client/network_load_balancer.go
@@ -84,7 +84,7 @@ func (c *networkLoadbalancer) GetLoadBalancerByName(ctx context.Context, compart
 	return nil, errors.WithStack(errNotFound)
 }
 
-func (c *networkLoadbalancer) CreateLoadBalancer(ctx context.Context, details *GenericCreateLoadBalancerDetails) (string, error) {
+func (c *networkLoadbalancer) CreateLoadBalancer(ctx context.Context, details *GenericCreateLoadBalancerDetails, serviceUid *string) (string, error) {
 	if !c.rateLimiter.Writer.TryAccept() {
 		return "", RateLimitError(true, "CreateLoadBalancer")
 	}
@@ -104,7 +104,7 @@ func (c *networkLoadbalancer) CreateLoadBalancer(ctx context.Context, details *G
 			DefinedTags:                 details.DefinedTags,
 		},
 		RequestMetadata: c.requestMetadata,
-		OpcRetryToken:   details.DisplayName,
+		OpcRetryToken:   serviceUid,
 	})
 	incRequestCounter(err, createVerb, networkLoadBalancerResource)
 

--- a/pkg/oci/client/network_load_balancer.go
+++ b/pkg/oci/client/network_load_balancer.go
@@ -104,6 +104,7 @@ func (c *networkLoadbalancer) CreateLoadBalancer(ctx context.Context, details *G
 			DefinedTags:                 details.DefinedTags,
 		},
 		RequestMetadata: c.requestMetadata,
+		OpcRetryToken:   details.DisplayName,
 	})
 	incRequestCounter(err, createVerb, networkLoadBalancerResource)
 

--- a/pkg/oci/client/network_load_balancer.go
+++ b/pkg/oci/client/network_load_balancer.go
@@ -385,6 +385,27 @@ func (c *networkLoadbalancer) UpdateNetworkSecurityGroups(ctx context.Context, l
 	return *resp.OpcWorkRequestId, nil
 }
 
+func (c *networkLoadbalancer) UpdateLoadBalancer(ctx context.Context, lbID string, details *GenericUpdateLoadBalancerDetails) (string, error) {
+	if !c.rateLimiter.Writer.TryAccept() {
+		return "", RateLimitError(true, "UpdateLoadBalancer")
+	}
+
+	resp, err := c.networkloadbalancer.UpdateNetworkLoadBalancer(ctx, networkloadbalancer.UpdateNetworkLoadBalancerRequest{
+		UpdateNetworkLoadBalancerDetails: networkloadbalancer.UpdateNetworkLoadBalancerDetails{
+			FreeformTags: details.FreeformTags,
+			DefinedTags:  details.DefinedTags,
+		},
+		NetworkLoadBalancerId: &lbID,
+	})
+	incRequestCounter(err, updateVerb, networkLoadBalancerResource)
+
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return *resp.OpcWorkRequestId, nil
+}
+
 func backendsToBackendDetails(backends []GenericBackend) []networkloadbalancer.BackendDetails {
 	backendDetails := make([]networkloadbalancer.BackendDetails, 0)
 	for _, backend := range backends {
@@ -430,6 +451,7 @@ func (c *networkLoadbalancer) networkLoadbalancerToGenericLoadbalancer(nlb *netw
 		BackendSets:             c.backendSetsToGenericBackendSetDetails(nlb.BackendSets),
 		FreeformTags:            nlb.FreeformTags,
 		DefinedTags:             nlb.DefinedTags,
+		SystemTags:              nlb.SystemTags,
 	}
 }
 
@@ -448,6 +470,7 @@ func (c *networkLoadbalancer) networkLoadbalancerSummaryToGenericLoadbalancer(nl
 		BackendSets:             c.backendSetsToGenericBackendSetDetails(nlb.BackendSets),
 		FreeformTags:            nlb.FreeformTags,
 		DefinedTags:             nlb.DefinedTags,
+		SystemTags:              nlb.SystemTags,
 	}
 }
 

--- a/pkg/oci/client/network_load_balancer_test.go
+++ b/pkg/oci/client/network_load_balancer_test.go
@@ -208,3 +208,7 @@ func (c *MockNetworkLoadBalancerClient) DeleteListener(ctx context.Context, requ
 func (c *MockNetworkLoadBalancerClient) UpdateNetworkSecurityGroups(ctx context.Context, request networkloadbalancer.UpdateNetworkSecurityGroupsRequest) (response networkloadbalancer.UpdateNetworkSecurityGroupsResponse, err error) {
 	return
 }
+func (c *MockNetworkLoadBalancerClient) UpdateNetworkLoadBalancer(ctx context.Context, request networkloadbalancer.UpdateNetworkLoadBalancerRequest) (response networkloadbalancer.UpdateNetworkLoadBalancerResponse, err error) {
+	//TODO implement me
+	return
+}

--- a/pkg/oci/client/networking.go
+++ b/pkg/oci/client/networking.go
@@ -232,7 +232,7 @@ func (c *client) CreateNetworkSecurityGroup(ctx context.Context, compartmentId, 
 			DisplayName:   &displayName,
 			FreeformTags:  map[string]string{"CreatedBy": "CCM", "ServiceUid": serviceUid},
 		},
-		OpcRetryToken:   &displayName,
+		OpcRetryToken:   &serviceUid,
 		RequestMetadata: requestMetadata,
 	})
 

--- a/pkg/oci/client/volume_attachment_test.go
+++ b/pkg/oci/client/volume_attachment_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func Test_getDevicePath(t *testing.T) {
+	var tests = map[string]struct {
+		instanceID   string
+		want         string
+		wantErr      error
+	}{
+		"getDevicePathNoDeviceAvailable": {
+			instanceID: "ocid1.device-path-not-available",
+			wantErr: fmt.Errorf("Max number of volumes are already attached to instance %s. Please schedule workload on different node.", "ocid1.device-path-not-available"),
+
+		},
+		"getDevicePathOneDeviceAvailable": {
+			instanceID: "ocid1.one-device-path-available",
+			want: "/dev/oracleoci/oraclevdac",
+		},
+		"getDevicePathReturnsError": {
+			instanceID: "ocid1.device-path-returns-error",
+			wantErr: errNotFound,
+		},
+	}
+	
+	vaClient := &client{
+		compute: &mockComputeClient{},
+		logger: zap.S(),
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := vaClient.getDevicePath(context.Background(), tc.instanceID)
+			if tc.wantErr != nil && !strings.EqualFold(tc.wantErr.Error(), err.Error()) {
+				t.Errorf("getDevicePath() = %v, want %v", err.Error(), tc.wantErr.Error())
+			}
+			if tc.want != "" && !strings.EqualFold(tc.want, *result) {
+				t.Errorf("getDevicePath() = %v, want %v", *result, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	metricErrors "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,14 +35,15 @@ const (
 	CompartmentIDAnnotation = "oci.oraclecloud.com/compartment-id"
 
 	// Error codes
-	Err429           = "429"
-	Err4XX           = "4XX"
-	Err5XX           = "5XX"
-	ErrValidation    = "VALIDATION_ERROR"
-	ErrLimitExceeded = "LIMIT_EXCEEDED"
-	ErrCtxTimeout    = "CTX_TIMEOUT"
-	Success          = "SUCCESS"
-	BackupCreating   = "CREATING"
+	Err429             = "429"
+	Err4XX             = "4XX"
+	Err5XX             = "5XX"
+	ErrValidation      = "VALIDATION_ERROR"
+	ErrLimitExceeded   = "LIMIT_EXCEEDED"
+	ErrCtxTimeout      = "CTX_TIMEOUT"
+	ErrTagLimitReached = "TAG_LIMIT_REACHED"
+	Success            = "SUCCESS"
+	BackupCreating     = "CREATING"
 
 	// Components generating errors
 	// Load Balancer
@@ -51,6 +52,9 @@ const (
 	// storage types
 	CSIStorageType = "CSI"
 	FVDStorageType = "FVD"
+
+	// Errorcode prefixes
+	SystemTagErrTypePrefix = "SYSTEM_TAG_"
 )
 
 // LookupNodeCompartment returns the compartment OCID for the given nodeName.
@@ -153,7 +157,6 @@ func MergeTagConfig(srcTagConfig, dstTagConfig *config.TagConfig) *config.TagCon
 
 // IsCommonTagPresent return true if Common tags are initialised in config
 func IsCommonTagPresent(initialTags *config.InitialTags) bool {
-	// TODO: perform feature enabled check
 
 	return initialTags != nil && initialTags.Common != nil
 }

--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
 	"regexp"
 	"strconv"
 	"strings"
@@ -119,4 +120,40 @@ func GetHttpStatusCode(err error) int {
 		}
 	}
 	return statusCode
+}
+
+func mergeFreeFormTags(freefromTags ...map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for _, t := range freefromTags {
+		for k, v := range t {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+func mergeDefinedTags(definedTags ...map[string]map[string]interface{}) map[string]map[string]interface{} {
+	merged := make(map[string]map[string]interface{})
+	for _, t := range definedTags {
+		for k, v := range t {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+// MergeTagConfig merges TagConfig's where dstTagConfig takes precedence
+func MergeTagConfig(srcTagConfig, dstTagConfig *config.TagConfig) *config.TagConfig {
+	var mergedTag config.TagConfig
+	mergedTag.FreeformTags = mergeFreeFormTags(srcTagConfig.FreeformTags, dstTagConfig.FreeformTags)
+	mergedTag.DefinedTags = mergeDefinedTags(srcTagConfig.DefinedTags, dstTagConfig.DefinedTags)
+
+	return &mergedTag
+}
+
+// IsCommonTagPresent return true if Common tags are initialised in config
+func IsCommonTagPresent(initialTags *config.InitialTags) bool {
+	// TODO: perform feature enabled check
+
+	return initialTags != nil && initialTags.Common != nil
 }

--- a/pkg/util/commons_test.go
+++ b/pkg/util/commons_test.go
@@ -16,9 +16,10 @@ package util
 
 import (
 	"errors"
-	"github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
 	"reflect"
 	"testing"
+
+	"github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
 
 	errors2 "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/pkg/volume/provisioner/block/block_test.go
+++ b/pkg/volume/provisioner/block/block_test.go
@@ -457,6 +457,10 @@ func (c *MockLoadBalancerClient) UpdateNetworkSecurityGroups(context.Context, st
 	return "", nil
 }
 
+func (c *MockLoadBalancerClient) UpdateLoadBalancer(ctx context.Context, lbID string, details *client.GenericUpdateLoadBalancerDetails) (string, error) {
+	return "", nil
+}
+
 func (c *MockVirtualNetworkClient) AddNetworkSecurityGroupSecurityRules(ctx context.Context, id string, details core.AddNetworkSecurityGroupSecurityRulesDetails) (*core.AddNetworkSecurityGroupSecurityRulesResponse, error) {
 	return nil, nil
 }

--- a/pkg/volume/provisioner/block/block_test.go
+++ b/pkg/volume/provisioner/block/block_test.go
@@ -226,6 +226,10 @@ func (c *MockFileStorageClient) AwaitMountTargetActive(ctx context.Context, logg
 
 type MockComputeClient struct{}
 
+func (c *MockComputeClient) ListInstancesByCompartmentAndAD(ctx context.Context, compartmentId, availabilityDomain string) (response []core.Instance, err error) {
+	return nil, nil
+}
+
 // GetInstance gets information about the specified instance.
 func (c *MockComputeClient) GetInstance(ctx context.Context, id string) (*core.Instance, error) {
 	return nil, nil

--- a/pkg/volume/provisioner/block/block_test.go
+++ b/pkg/volume/provisioner/block/block_test.go
@@ -393,7 +393,7 @@ func (c *MockLoadBalancerClient) ListWorkRequests(ctx context.Context, compartme
 	return nil, nil
 }
 
-func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails) (string, error) {
+func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails, serviceUid *string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/volume/provisioner/fss/fss_test.go
+++ b/pkg/volume/provisioner/fss/fss_test.go
@@ -455,6 +455,9 @@ func (c *MockLoadBalancerClient) AwaitWorkRequest(ctx context.Context, id string
 func (c *MockLoadBalancerClient) UpdateNetworkSecurityGroups(context.Context, string, []string) (string, error) {
 	return "", nil
 }
+func (c *MockLoadBalancerClient) UpdateLoadBalancer(ctx context.Context, lbID string, details *client.GenericUpdateLoadBalancerDetails) (string, error) {
+	return "", nil
+}
 
 func (c *MockVirtualNetworkClient) AddNetworkSecurityGroupSecurityRules(ctx context.Context, id string, details core.AddNetworkSecurityGroupSecurityRulesDetails) (*core.AddNetworkSecurityGroupSecurityRulesResponse, error) {
 	return nil, nil

--- a/pkg/volume/provisioner/fss/fss_test.go
+++ b/pkg/volume/provisioner/fss/fss_test.go
@@ -392,7 +392,7 @@ func (c *MockLoadBalancerClient) ListWorkRequests(ctx context.Context, compartme
 	return nil, nil
 }
 
-func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails) (string, error) {
+func (c *MockLoadBalancerClient) CreateLoadBalancer(ctx context.Context, details *client.GenericCreateLoadBalancerDetails, serviceUid *string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/volume/provisioner/fss/fss_test.go
+++ b/pkg/volume/provisioner/fss/fss_test.go
@@ -225,6 +225,10 @@ func (c *MockFileStorageClient) AwaitMountTargetActive(ctx context.Context, logg
 
 type MockComputeClient struct{}
 
+func (c *MockComputeClient) ListInstancesByCompartmentAndAD(ctx context.Context, compartmentId, availabilityDomain string) (response []core.Instance, err error) {
+	return nil, nil
+}
+
 // GetInstance gets information about the specified instance.
 func (c *MockComputeClient) GetInstance(ctx context.Context, id string) (*core.Instance, error) {
 	return nil, nil

--- a/test/e2e/cloud-provider-oci/block_volume_creation.go
+++ b/test/e2e/cloud-provider-oci/block_volume_creation.go
@@ -35,11 +35,11 @@ var _ = Describe("Block Volume Creation", func() {
 		It("Should be possible to create a persistent volume claim (PVC) for a block storage of Ext3 file system ", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "volume-provisioner-e2e-tests-pvc")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIExt3, core.ProvisionerNameDefault, map[string]string{block.FSType: "ext3"}, pvcJig.Labels, "", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, core.ProvisionerNameDefault, map[string]string{block.FSType: "ext3"}, pvcJig.Labels, "", false, "Delete", nil)
 			f.StorageClasses = append(f.StorageClasses, scName)
 			pvc := pvcJig.CreateAndAwaitPVCOrFail(f.Namespace.Name, framework.MinVolumeBlock, scName, setupF.AdLabel, nil)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIExt3)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 
 		It("Should be possible to create a persistent volume claim (PVC) for a block storage with no AD specified ", func() {

--- a/test/e2e/cloud-provider-oci/csi_volume_cloning.go
+++ b/test/e2e/cloud-provider-oci/csi_volume_cloning.go
@@ -16,7 +16,7 @@ var _ = Describe("CSI Volume Creation with PVC datasource", func() {
 		It("Create PVC with source PVC name specified in dataSource", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-cloning-basic")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			srcPod := pvcJig.NewPodForCSI("app1", f.Namespace.Name, srcPvc.Name, setupF.AdLabel)
 
@@ -38,7 +38,7 @@ var _ = Describe("CSI Volume Creation with PVC datasource", func() {
 		It("Create Clone PVC with size greater than the source PVC", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-volume-size-test")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			pvcJig.NewPodForCSI("app1", f.Namespace.Name, srcPvc.Name, setupF.AdLabel)
 
@@ -63,7 +63,7 @@ var _ = Describe("CSI Volume Creation with PVC datasource", func() {
 				framework.KmsKey:         setupF.CMEKKMSKey,
 				framework.AttachmentType: framework.AttachmentTypeParavirtualized,
 			}
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIKMS, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			srcPod := pvcJig.NewPodForCSI("app1", f.Namespace.Name, srcPvc.Name, setupF.AdLabel)
 			pvcJig.CheckCMEKKey(f.Client.BlockStorage(), srcPvc.Name, f.Namespace.Name, setupF.CMEKKMSKey)
@@ -80,7 +80,7 @@ var _ = Describe("CSI Volume Creation with PVC datasource", func() {
 			pvcJig.CheckAttachmentTypeAndEncryptionType(f.Client.Compute(), clonePvc.Name, f.Namespace.Name, clonePod, framework.AttachmentTypeParavirtualized)
 
 			f.VolumeIds = append(f.VolumeIds, srcPvc.Spec.VolumeName, clonePvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIKMS)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 
@@ -92,7 +92,7 @@ var _ = Describe("CSI Volume Creation with PVC datasource", func() {
 				framework.KmsKey:         setupF.CMEKKMSKey,
 				framework.AttachmentType: framework.AttachmentTypeISCSI,
 			}
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			pvcJig.NewPodForCSI("app1", f.Namespace.Name, srcPvc.Name, setupF.AdLabel)
 
@@ -114,7 +114,7 @@ var _ = Describe("CSI Volume Creation with PVC datasource", func() {
 				framework.KmsKey:         setupF.CMEKKMSKey,
 				framework.AttachmentType: framework.AttachmentTypeParavirtualized,
 			}
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			pvcJig.NewPodForCSI("app1", f.Namespace.Name, srcPvc.Name, setupF.AdLabel)
 
@@ -139,7 +139,7 @@ var _ = Describe("CSI Volume Cloning with different storage classes", func() {
 				framework.AttachmentType: framework.AttachmentTypeISCSI,
 				csi_util.VpusPerGB:       "20",
 			}
-			scName1 := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", scParameters1, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName1 := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", scParameters1, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName1, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			pvcJig.NewPodForCSI("app1", f.Namespace.Name, srcPvc.Name, setupF.AdLabel)
 
@@ -149,7 +149,7 @@ var _ = Describe("CSI Volume Cloning with different storage classes", func() {
 				framework.AttachmentType: framework.AttachmentTypeISCSI,
 				csi_util.VpusPerGB:       "0",
 			}
-			scName2 := f.CreateStorageClassOrFail(framework.ClassOCILowCost, "blockvolume.csi.oraclecloud.com", scParameters2, pvcJig.Labels, "Immediate", true, "Delete", nil)
+			scName2 := f.CreateStorageClassOrFail(f.Namespace.Name+"-2", "blockvolume.csi.oraclecloud.com", scParameters2, pvcJig.Labels, "Immediate", true, "Delete", nil)
 			clonePvc := pvcJig.CreateAndAwaitClonePVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName2, srcPvc.Name, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 
 			clonePod := pvcJig.NewPodForCSIClone("app2", f.Namespace.Name, clonePvc.Name, setupF.AdLabel)
@@ -157,6 +157,8 @@ var _ = Describe("CSI Volume Cloning with different storage classes", func() {
 			pvcJig.CheckFileCorruption(f.Namespace.Name, clonePod, "/data", "testdata.txt")
 			pvcJig.CheckAttachmentTypeAndEncryptionType(f.Client.Compute(), clonePvc.Name, f.Namespace.Name, clonePod, framework.AttachmentTypeISCSI)
 			pvcJig.CheckVolumePerformanceLevel(f.BlockStorageClient, clonePvc.Namespace, clonePvc.Name, csi_util.LowCostPerformanceOption)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
+			_ = f.DeleteStorageClass(f.Namespace.Name+"-2")
 		})
 	})
 })
@@ -167,7 +169,7 @@ var _ = Describe("CSI Volume Cloning with static source Volume", func() {
 		It("Create Clone PVC from a statically created source volume", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-static-cloning-test")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 
 			compartmentId := ""
@@ -203,7 +205,7 @@ var _ = Describe("CSI Volume Cloning Performance Level", func() {
 		It("Create high performance clone from a low performance source volume", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-cloning-perf-test")
 
-			scName1 := f.CreateStorageClassOrFail(framework.ClassOCILowCost, "blockvolume.csi.oraclecloud.com",
+			scName1 := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "0"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			srcPvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName1, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -213,7 +215,7 @@ var _ = Describe("CSI Volume Cloning Performance Level", func() {
 
 			pvcJig.CheckVolumePerformanceLevel(f.BlockStorageClient, srcPvc.Namespace, srcPvc.Name, csi_util.LowCostPerformanceOption)
 
-			scName2 := f.CreateStorageClassOrFail(framework.ClassOCIHigh, "blockvolume.csi.oraclecloud.com",
+			scName2 := f.CreateStorageClassOrFail(f.Namespace.Name+"-2", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "20"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			clonePvc := pvcJig.CreateAndAwaitClonePVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName2, srcPvc.Name, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -226,7 +228,8 @@ var _ = Describe("CSI Volume Cloning Performance Level", func() {
 			pvcJig.CheckVolumePerformanceLevel(f.BlockStorageClient, clonePvc.Namespace, clonePvc.Name, csi_util.HigherPerformanceOption)
 
 			f.VolumeIds = append(f.VolumeIds, srcPvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCILowCost)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
+			_ = f.DeleteStorageClass(f.Namespace.Name+"-2")
 		})
 	})
 })

--- a/test/e2e/cloud-provider-oci/csi_volume_creation.go
+++ b/test/e2e/cloud-provider-oci/csi_volume_creation.go
@@ -33,7 +33,7 @@ var _ = Describe("CSI Volume Creation", func() {
 		It("Create PVC and POD for CSI.", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			pvcJig.NewPodForCSI("app1", f.Namespace.Name, pvc.Name, setupF.AdLabel)
@@ -42,7 +42,7 @@ var _ = Describe("CSI Volume Creation", func() {
 		It("Create PVC with VolumeSize 1Gi but should use default 50Gi", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests-pvc-with-1gi")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.VolumeFss, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			pvcJig.NewPodForCSI("app2", f.Namespace.Name, pvc.Name, setupF.AdLabel)
@@ -55,7 +55,7 @@ var _ = Describe("CSI Volume Creation", func() {
 		It("Create PVC with VolumeSize 100Gi should use 100Gi", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests-pvc-with-100gi")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MaxVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			pvcJig.NewPodForCSI("app3", f.Namespace.Name, pvc.Name, setupF.AdLabel)
@@ -68,7 +68,7 @@ var _ = Describe("CSI Volume Creation", func() {
 		It("Data should persist on CSI volume on pod restart", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-pod-restart-data-persistence")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			pvcJig.CheckDataPersistenceWithDeployment(pvc.Name, f.Namespace.Name)
@@ -77,7 +77,7 @@ var _ = Describe("CSI Volume Creation", func() {
 		It("FsGroup test for CSI", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-pod-nginx")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 
 			pvcJig.CheckVolumeDirectoryOwnership(f.Namespace.Name, pvc)
@@ -92,7 +92,7 @@ var _ = Describe("CSI Volume Creation with different fstypes", func() {
 		It("Create PVC with fstype as XFS", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests-fstype-xfs")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIXfs, "blockvolume.csi.oraclecloud.com", map[string]string{framework.FstypeKey: "xfs"}, pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", map[string]string{framework.FstypeKey: "xfs"}, pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MaxVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			podName := pvcJig.NewPodForCSI("app-xfs", f.Namespace.Name, pvc.Name, setupF.AdLabel)
@@ -100,12 +100,12 @@ var _ = Describe("CSI Volume Creation with different fstypes", func() {
 			time.Sleep(60 * time.Second) //waiting for pod to up and running
 
 			pvcJig.CheckFilesystemTypeOfVolumeInsidePod(f.Namespace.Name, podName, "xfs")
-			_ = f.DeleteStorageClass(framework.ClassOCIXfs)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 		It("Create PVC with fstype as EXT3", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests-fstype-ext3")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIExt3, "blockvolume.csi.oraclecloud.com", map[string]string{framework.FstypeKey: "ext3"}, pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", map[string]string{framework.FstypeKey: "ext3"}, pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MaxVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			podName := pvcJig.NewPodForCSI("app-ext3", f.Namespace.Name, pvc.Name, setupF.AdLabel)
@@ -113,14 +113,14 @@ var _ = Describe("CSI Volume Creation with different fstypes", func() {
 			time.Sleep(60 * time.Second) //waiting for pod to up and running
 
 			pvcJig.CheckFilesystemTypeOfVolumeInsidePod(f.Namespace.Name, podName, "ext3")
-			_ = f.DeleteStorageClass(framework.ClassOCIExt3)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 	Context("[cloudprovider][storage][csi][fstypes][paravirtualized]", func() {
 		It("Create PVC with fstype as XFS with paravirtualized attachment type", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests-fstype-xfs")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIXfs, "blockvolume.csi.oraclecloud.com", map[string]string{framework.FstypeKey: "xfs", framework.KmsKey: setupF.CMEKKMSKey, framework.AttachmentType: framework.AttachmentTypeParavirtualized}, pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", map[string]string{framework.FstypeKey: "xfs", framework.KmsKey: setupF.CMEKKMSKey, framework.AttachmentType: framework.AttachmentTypeParavirtualized}, pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MaxVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			podName := pvcJig.NewPodForCSI("app-xfs", f.Namespace.Name, pvc.Name, setupF.AdLabel)
@@ -129,7 +129,7 @@ var _ = Describe("CSI Volume Creation with different fstypes", func() {
 			time.Sleep(60 * time.Second) //waiting for pod to up and running
 
 			pvcJig.CheckFilesystemTypeOfVolumeInsidePod(f.Namespace.Name, podName, "xfs")
-			_ = f.DeleteStorageClass(framework.ClassOCIXfs)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 	Context("[cloudprovider][storage][csi][expand][fstypes][iSCSI]", func() {
@@ -137,7 +137,7 @@ var _ = Describe("CSI Volume Creation with different fstypes", func() {
 			var size = "100Gi"
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-pvc-expand-to-100gi-iscsi-xfs")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIXfs, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, framework.FstypeKey: "xfs"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -156,13 +156,13 @@ var _ = Describe("CSI Volume Creation with different fstypes", func() {
 			pvcJig.CheckExpandedVolumeReadWrite(f.Namespace.Name, podName)
 			pvcJig.CheckUsableVolumeSizeInsidePod(f.Namespace.Name, podName, "100G")
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIXfs)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 		It("Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for iSCSI volumes with ext3 filesystem type", func() {
 			var size = "100Gi"
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-pvc-expand-to-100gi-iscsi-ext3")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIExt3, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, framework.FstypeKey: "ext3"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -181,7 +181,7 @@ var _ = Describe("CSI Volume Creation with different fstypes", func() {
 			pvcJig.CheckExpandedVolumeReadWrite(f.Namespace.Name, podName)
 			pvcJig.CheckUsableVolumeSizeInsidePod(f.Namespace.Name, podName, "99G")
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIExt3)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 })
@@ -193,7 +193,7 @@ var _ = Describe("CSI Volume Expansion iSCSI", func() {
 			var size = "100Gi"
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-resizer-pvc-expand-to-100gi-iscsi")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -222,7 +222,7 @@ var _ = Describe("CSI Volume Expansion iSCSI", func() {
 			var size = "100Gi"
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-resizer-pvc-expand-to-100gi-iscsi")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSIExpand, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -240,7 +240,7 @@ var _ = Describe("CSI Volume Expansion iSCSI", func() {
 			pvcJig.CheckExpandedVolumeReadWrite(f.Namespace.Name, podName)
 			pvcJig.CheckUsableVolumeSizeInsidePod(f.Namespace.Name, podName, "99G")
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCICSIExpand)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 })
@@ -251,7 +251,7 @@ var _ = Describe("CSI Volume Performance Level", func() {
 		It("Create CSI block volume with Performance Level as Low Cost", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-perf-iscsi-lowcost")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCILowCost, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "0"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -261,12 +261,12 @@ var _ = Describe("CSI Volume Performance Level", func() {
 
 			pvcJig.CheckVolumePerformanceLevel(f.BlockStorageClient, pvc.Namespace, pvc.Name, csi_util.LowCostPerformanceOption)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCILowCost)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 		It("Create CSI block volume with no Performance Level and verify default", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-perf-iscsi-default")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			pvcJig.NewPodForCSI("default-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 
@@ -278,7 +278,7 @@ var _ = Describe("CSI Volume Performance Level", func() {
 		It("Create CSI block volume with Performance Level as High", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-perf-iscsi-high")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIHigh, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "20"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -288,14 +288,14 @@ var _ = Describe("CSI Volume Performance Level", func() {
 			pvcJig.CheckVolumePerformanceLevel(f.BlockStorageClient, pvc.Namespace, pvc.Name, csi_util.HigherPerformanceOption)
 			pvcJig.CheckISCSIQueueDepthOnNode(f.Namespace.Name, podName)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIHigh)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 	Context("[cloudprovider][storage][csi][perf][paravirtualized]", func() {
 		It("Create CSI block volume with Performance Level as Low Cost", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-perf-paravirtual-lowcost")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCILowCost, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "0"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -305,12 +305,12 @@ var _ = Describe("CSI Volume Performance Level", func() {
 
 			pvcJig.CheckVolumePerformanceLevel(f.BlockStorageClient, pvc.Namespace, pvc.Name, csi_util.LowCostPerformanceOption)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCILowCost)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 		It("Create CSI block volume with no Performance Level and verify default", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-perf-paravirtual-balanced")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIBalanced, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "10"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -320,13 +320,13 @@ var _ = Describe("CSI Volume Performance Level", func() {
 
 			pvcJig.CheckVolumePerformanceLevel(f.BlockStorageClient, pvc.Namespace, pvc.Name, csi_util.BalancedPerformanceOption)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIBalanced)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 
 		It("Create CSI block volume with Performance Level as High", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-perf-paravirtual-high")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIHigh, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "20"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -335,7 +335,7 @@ var _ = Describe("CSI Volume Performance Level", func() {
 			time.Sleep(60 * time.Second) //waiting for pod to up and running
 			pvcJig.CheckVolumePerformanceLevel(f.BlockStorageClient, pvc.Namespace, pvc.Name, csi_util.HigherPerformanceOption)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIHigh)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 
@@ -343,7 +343,7 @@ var _ = Describe("CSI Volume Performance Level", func() {
 		It("High Performance Static Provisioning CSI", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-perf-static-high")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIHigh, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "20"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 
@@ -366,7 +366,7 @@ var _ = Describe("CSI Volume Performance Level", func() {
 			pvcJig.CheckVolumeCapacity("50Gi", pvc.Name, f.Namespace.Name)
 			pvcJig.CheckISCSIQueueDepthOnNode(pvc.Namespace, podName)
 			f.VolumeIds = append(f.VolumeIds, volumeId)
-			_ = f.DeleteStorageClass(framework.ClassOCIHigh)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 })
@@ -380,102 +380,78 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			if compartmentId == "" {
 				framework.Failf("Compartment Id undefined.")
 			}
+			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-uhp")
+			ctx := context.Background()
 
-			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-iscsi-uhp")
-
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIUHP, "blockvolume.csi.oraclecloud.com",
+			By("Running test: Create ISCSI CSI block volume with UHP Performance Level")
+			scName := f.CreateStorageClassOrFail(framework.ClassOCIUHP+"-1", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
-			pvcJig.NewPodForCSI("uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
-
-			ctx := context.Background()
+			podName := pvcJig.NewPodForCSI("uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIUHP)
-		})
-		It("Create Paravirtualized CSI block volume with UHP Performance Level", func() {
-			checkUhpPrerequisites(f)
-			compartmentId := f.GetCompartmentId(*setupF)
-			if compartmentId == "" {
-				framework.Failf("Compartment Id undefined.")
+			err := pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName); if err != nil {
+				framework.Failf("Error deleting pod: %v", err)
 			}
+			_ = f.DeleteStorageClass(scName)
+			By("Completed test: Create ISCSI CSI block volume with UHP Performance Level")
 
-			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-paravirtualized-uhp")
-
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIUHP, "blockvolume.csi.oraclecloud.com",
+			By("Running test: Create Paravirtualized CSI block volume with UHP Performance Level")
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP+"-2", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
-			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
-			pvcJig.NewPodForCSI("uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
-
-			ctx := context.Background()
+			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
+			podName = pvcJig.NewPodForCSI("uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIUHP)
-		})
-		It("Create CSI block volume with UHP Performance Level and xfs file system", func() {
-			checkUhpPrerequisites(f)
-			compartmentId := f.GetCompartmentId(*setupF)
-			if compartmentId == "" {
-				framework.Failf("Compartment Id undefined.")
+			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName); if err != nil {
+				framework.Failf("Error deleting pod: %v", err)
 			}
+			_ = f.DeleteStorageClass(scName)
+			By("Completed test: Create Paravirtualized CSI block volume with UHP Performance Level")
 
-			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-uhp-xfs")
-
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIUHP, "blockvolume.csi.oraclecloud.com",
+			By("Running test: Create CSI block volume with UHP Performance Level and xfs file system")
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP+"-3", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "30", framework.FstypeKey: "xfs"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
-			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
-			pvcJig.NewPodForCSI("uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
-
-			ctx := context.Background()
+			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
+			podName = pvcJig.NewPodForCSI("uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIUHP)
-		})
-		It("Static Provisioning CSI UHP", func() {
-			checkUhpPrerequisites(f)
-			compartmentId := f.GetCompartmentId(*setupF)
-			if compartmentId == "" {
-				framework.Failf("Compartment Id undefined.")
+			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName); if err != nil {
+				framework.Failf("Error deleting pod: %v", err)
 			}
+			_ = f.DeleteStorageClass(scName)
+			By("Completed test: Create CSI block volume with UHP Performance Level and xfs file system")
 
-			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests-pvc-with-static-uhp")
-
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIUHP, "blockvolume.csi.oraclecloud.com",
+			By("Running test: Static Provisioning CSI UHP")
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP + "-4", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 
 			pvc, volumeId := pvcJig.CreateAndAwaitStaticPVCOrFailCSI(f.BlockStorageClient, f.Namespace.Name, framework.MinVolumeBlock, 30, scName, setupF.AdLocation, compartmentId, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			pvcJig.NewPodForCSI("app4", f.Namespace.Name, pvc.Name, setupF.AdLabel)
-
-			ctx := context.Background()
+			podName = pvcJig.NewPodForCSI("app4", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			pvcJig.CheckVolumeCapacity("50Gi", pvc.Name, f.Namespace.Name)
-			f.VolumeIds = append(f.VolumeIds, volumeId)
-		})
-		It("Basic Pod Delete UHP", func() {
-			checkUhpPrerequisites(f)
-			compartmentId := f.GetCompartmentId(*setupF)
-			if compartmentId == "" {
-				framework.Failf("Compartment Id undefined.")
+			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName); if err != nil {
+				framework.Failf("Error deleting pod: %v", err)
 			}
+			f.VolumeIds = append(f.VolumeIds, volumeId)
+			_ = f.DeleteStorageClass(scName)
+			By("Completed test: Static Provisioning CSI UHP")
 
-			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-iscsi-uhp")
-
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIUHP, "blockvolume.csi.oraclecloud.com",
+			By("Running test: Basic Pod Delete UHP")
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP + "-5", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
-			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
-			podName := pvcJig.NewPodForCSI("uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
-
-			ctx := context.Background()
+			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
+			podName = pvcJig.NewPodForCSI("uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			volumeName := pvcJig.GetVolumeNameFromPVC(pvc.Name, f.Namespace.Name)
@@ -483,7 +459,7 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			framework.Logf("Persistent volume name : %s", volumeName)
 
 			pvcJig.DeleteAndAwaitPodOrFail(f.Namespace.Name, podName)
-			err := pvcJig.DeletePersistentVolumeClaim(f.Namespace.Name, pvc.Name)
+			err = pvcJig.DeletePersistentVolumeClaim(f.Namespace.Name, pvc.Name)
 			if err != nil {
 				framework.Failf("Failed to delete persistent volume claim: %s", err.Error())
 			}
@@ -491,35 +467,27 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			if err != nil {
 				framework.Failf("Persistent volume did not terminate : %s", err.Error())
 			}
+			_ = f.DeleteStorageClass(scName)
+			By("Completed test: Basic Pod Delete UHP")
 
-			_ = f.DeleteStorageClass(framework.ClassOCIUHP)
-		})
-		It("Create UHP PVC and POD for CSI with CMEK and in-transit encryption", func() {
-			checkUhpPrerequisites(f)
-			compartmentId := f.GetCompartmentId(*setupF)
-			if compartmentId == "" {
-				framework.Failf("Compartment Id undefined.")
-			}
-
-			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-cmek-iscsi-in-transit-e2e-tests-uhp")
+			By("Running test: Create UHP PVC and POD for CSI with CMEK and in-transit encryption")
 			scParameter := map[string]string{
 				framework.KmsKey:         setupF.CMEKKMSKey,
 				framework.AttachmentType: framework.AttachmentTypeISCSI,
 				csi_util.VpusPerGB:       "30",
 			}
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIKMS, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
-			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
-			podName := pvcJig.NewPodForCSI("app1", f.Namespace.Name, pvc.Name, setupF.AdLabel)
-
-			ctx := context.Background()
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIKMS + "-1", "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
+			podName = pvcJig.NewPodForCSI("app1", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 			pvcJig.CheckCMEKKey(f.Client.BlockStorage(), pvc.Name, f.Namespace.Name, setupF.CMEKKMSKey)
 			pvcJig.CheckAttachmentTypeAndEncryptionType(f.Client.Compute(), pvc.Name, f.Namespace.Name, podName, framework.AttachmentTypeISCSI)
+			pvcJig.DeleteAndAwaitPodOrFail(f.Namespace.Name, podName)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIKMS)
-		})
-		It("Create UHP and lower performance block volumes on same node", func() {
-			checkUhpPrerequisites(f)
+			_ = f.DeleteStorageClass(scName)
+			By("Completed test: Create UHP PVC and POD for CSI with CMEK and in-transit encryption")
+
+			By("Running test: Create UHP and lower performance block volumes on same node")
 			sc1params := map[string]string{
 				framework.AttachmentType: framework.AttachmentTypeISCSI,
 				csi_util.VpusPerGB:       "30",
@@ -528,47 +496,36 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 				framework.AttachmentType: framework.AttachmentTypeISCSI,
 			}
 			testTwoPVCSetup(f, sc1params, sc2params)
-		})
-		It("Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for iSCSI UHP volume", func() {
-			checkUhpPrerequisites(f)
-			var size = "100Gi"
-			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-pvc-expand-to-100gi-iscsi-uhp")
+			By("Completed test: Create UHP and lower performance block volumes on same node")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIUHP, "blockvolume.csi.oraclecloud.com",
+			By("Running test: Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for iSCSI UHP volume")
+			pvcJig.Name = "csi-uhp-pvc-expand-to-100gi"
+			var size = "100Gi"
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP + "-6", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
-			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
-			podName := pvcJig.NewPodForCSI("expanded-uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
-
+			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
+			podName = pvcJig.NewPodForCSI("expanded-uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			time.Sleep(60 * time.Second) //waiting for pod to up and running
-
 			expandedPvc := pvcJig.UpdateAndAwaitPVCOrFailCSI(pvc, pvc.Namespace, size, nil)
-
-			time.Sleep(120 * time.Second) //waiting for expanded pvc to be functional
-
 			pvcJig.CheckVolumeCapacity("100Gi", expandedPvc.Name, f.Namespace.Name)
 			pvcJig.CheckFileExists(f.Namespace.Name, podName, "/data", "testdata.txt")
 			pvcJig.CheckFileCorruption(f.Namespace.Name, podName, "/data", "testdata.txt")
 			pvcJig.CheckExpandedVolumeReadWrite(f.Namespace.Name, podName)
 			pvcJig.CheckUsableVolumeSizeInsidePod(f.Namespace.Name, podName, "99G")
+			pvcJig.DeleteAndAwaitPodOrFail(f.Namespace.Name, podName)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIUHP)
-		})
-		It("Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for Paravirtualized UHP volume", func() {
-			checkUhpPrerequisites(f)
-			var size = "100Gi"
-			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-pvc-expand-to-100gi-iscsi-uhp")
+			_ = f.DeleteStorageClass(scName)
+			By("Completed test: Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for iSCSI UHP volume")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCIUHP, "blockvolume.csi.oraclecloud.com",
+			By("Running test: Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for Paravirtualized UHP volume")
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP + "-7", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
-			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
-			podName := pvcJig.NewPodForCSI("expanded-uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
-
+			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
+			podName = pvcJig.NewPodForCSI("expanded-uhp-pvc-app", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			time.Sleep(60 * time.Second) //waiting for pod to up and running
-
-			expandedPvc := pvcJig.UpdateAndAwaitPVCOrFailCSI(pvc, pvc.Namespace, size, nil)
-
+			expandedPvc = pvcJig.UpdateAndAwaitPVCOrFailCSI(pvc, pvc.Namespace, size, nil)
 			time.Sleep(120 * time.Second) //waiting for expanded pvc to be functional
 
 			pvcJig.CheckVolumeCapacity("100Gi", expandedPvc.Name, f.Namespace.Name)
@@ -577,12 +534,13 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			pvcJig.CheckExpandedVolumeReadWrite(f.Namespace.Name, podName)
 			pvcJig.CheckUsableVolumeSizeInsidePod(f.Namespace.Name, podName, "99G")
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCIUHP)
+			_ = f.DeleteStorageClass(scName)
+			By("Completed test: Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for Paravirtualized UHP volume")
 		})
 	})
 })
 
-var _ = Describe("CSI UHP Volumes addition e2es", func() {
+var _ = Describe("CSI UHP Volumes additional e2es", func() {
 	f := framework.NewBackupFramework("csi-uhp-additional")
 	Context("[uhp]", func() {
 		It("Create UHP paravirtual volume and lower performance ISCSI block volumes on same node", func() {
@@ -633,7 +591,7 @@ var _ = Describe("CSI Volume Expansion Paravirtualized", func() {
 				framework.KmsKey:         setupF.CMEKKMSKey,
 				framework.AttachmentType: framework.AttachmentTypeParavirtualized,
 			}
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSIExpand,
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name,
 				"blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels,
 				"WaitForFirstConsumer", true, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -651,7 +609,7 @@ var _ = Describe("CSI Volume Expansion Paravirtualized", func() {
 			pvcJig.CheckExpandedVolumeReadWrite(f.Namespace.Name, podName)
 			pvcJig.CheckUsableVolumeSizeInsidePod(f.Namespace.Name, podName, "99G")
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			_ = f.DeleteStorageClass(framework.ClassOCICSIExpand)
+			_ = f.DeleteStorageClass(f.Namespace.Name)
 		})
 	})
 })
@@ -662,7 +620,7 @@ var _ = Describe("CSI Static Volume Creation", func() {
 		It("Static Provisioning CSI", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests-pvc-with-static")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com",
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com",
 				nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 
 			compartmentId := ""
@@ -709,13 +667,13 @@ func TestCMEKAttachmentTypeAndEncryptionType(f *framework.CloudProviderFramework
 		framework.KmsKey:         setupF.CMEKKMSKey,
 		framework.AttachmentType: expectedAttachmentType,
 	}
-	scName := f.CreateStorageClassOrFail(framework.ClassOCIKMS, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+	scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 	pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 	podName := pvcJig.NewPodForCSI("app1", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 	pvcJig.CheckCMEKKey(f.Client.BlockStorage(), pvc.Name, f.Namespace.Name, setupF.CMEKKMSKey)
 	pvcJig.CheckAttachmentTypeAndEncryptionType(f.Client.Compute(), pvc.Name, f.Namespace.Name, podName, expectedAttachmentType)
 	f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-	_ = f.DeleteStorageClass(framework.ClassOCIKMS)
+	_ = f.DeleteStorageClass(f.Namespace.Name)
 }
 
 var _ = Describe("CSI Volume Capabilites", func() {
@@ -724,12 +682,12 @@ var _ = Describe("CSI Volume Capabilites", func() {
 		It("Create volume fails with volumeMode set to block", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeBlock, v1.ReadWriteOnce, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			pvcJig.NewPodForCSIWithoutWait("app1", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcObject := pvcJig.GetPVCByName(pvc.Name, f.Namespace.Name)
-			err := pvcJig.WaitTimeoutForPVCBound(pvcObject.Name, f.Namespace.Name, 10*time.Minute)
+			err := pvcJig.WaitTimeoutForPVCBound(pvcObject.Name, f.Namespace.Name, 8*time.Minute)
 			if err == nil {
 				framework.Failf("PVC volume mode is not in pending status")
 			}
@@ -741,12 +699,12 @@ var _ = Describe("CSI Volume Capabilites", func() {
 		It("Create volume fails with accessMode set to ReadWriteMany", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-tests")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassOCICSI, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			pvc := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteMany, v1.ClaimPending)
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 			pvcJig.NewPodForCSIWithoutWait("app1", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcObject := pvcJig.GetPVCByName(pvc.Name, f.Namespace.Name)
-			err := pvcJig.WaitTimeoutForPVCBound(pvcObject.Name, f.Namespace.Name, 10*time.Minute)
+			err := pvcJig.WaitTimeoutForPVCBound(pvcObject.Name, f.Namespace.Name, 8*time.Minute)
 			if err == nil {
 				framework.Failf("PVC volume mode is not in pending status")
 			}
@@ -763,11 +721,11 @@ var _ = Describe("CSI Volume Creation - Immediate Volume Binding", func() {
 		It("Create PVC without pod and wait to be bound.", func() {
 			pvcJig := framework.NewPVCTestJig(f.ClientSet, "csi-provisioner-e2e-immediate-bind")
 
-			scName := f.CreateStorageClassOrFail(framework.ClassCustom, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "Immediate", true, "Delete", nil)
+			scName := f.CreateStorageClassOrFail(f.Namespace.Name, "blockvolume.csi.oraclecloud.com", nil, pvcJig.Labels, "Immediate", true, "Delete", nil)
 			pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimBound)
-			err := f.DeleteStorageClass(framework.ClassCustom)
+			err := f.DeleteStorageClass(f.Namespace.Name)
 			if err != nil {
-				Fail(fmt.Sprintf("deleting storage class failed %s", framework.ClassCustom))
+				Fail(fmt.Sprintf("deleting storage class failed %s", f.Namespace.Name))
 			}
 		})
 	})
@@ -801,8 +759,11 @@ func testTwoPVCSetup(f *framework.CloudProviderFramework, storageclass1params ma
 		storageclass2params,
 		pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 	pvcTwo := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, lowPerfScName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
-	pvcJig.NewPodWithLabels("pvc-two-app", f.Namespace.Name, pvcTwo.Name, nodeLabels)
+	podName2 := pvcJig.NewPodWithLabels("pvc-two-app", f.Namespace.Name, pvcTwo.Name, nodeLabels)
 
+
+	pvcJig.DeleteAndAwaitPodOrFail(f.Namespace.Name, podName)
+	pvcJig.DeleteAndAwaitPodOrFail(f.Namespace.Name, podName2)
 	f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
 	f.VolumeIds = append(f.VolumeIds, pvcTwo.Spec.VolumeName)
 	_ = f.DeleteStorageClass("storage-class-one")

--- a/test/e2e/cloud-provider-oci/csi_volume_creation.go
+++ b/test/e2e/cloud-provider-oci/csi_volume_creation.go
@@ -23,7 +23,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	csi_util "github.com/oracle/oci-cloud-controller-manager/pkg/csi-util"
-	"github.com/oracle/oci-cloud-controller-manager/pkg/volume/provisioner/plugin"
 	"github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
 )
 
@@ -392,7 +391,8 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			err := pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName); if err != nil {
+			err := pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName)
+			if err != nil {
 				framework.Failf("Error deleting pod: %v", err)
 			}
 			_ = f.DeleteStorageClass(scName)
@@ -407,7 +407,8 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName); if err != nil {
+			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName)
+			if err != nil {
 				framework.Failf("Error deleting pod: %v", err)
 			}
 			_ = f.DeleteStorageClass(scName)
@@ -422,14 +423,15 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			f.VolumeIds = append(f.VolumeIds, pvc.Spec.VolumeName)
-			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName); if err != nil {
+			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName)
+			if err != nil {
 				framework.Failf("Error deleting pod: %v", err)
 			}
 			_ = f.DeleteStorageClass(scName)
 			By("Completed test: Create CSI block volume with UHP Performance Level and xfs file system")
 
 			By("Running test: Static Provisioning CSI UHP")
-			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP + "-4", "blockvolume.csi.oraclecloud.com",
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP+"-4", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 
@@ -439,7 +441,8 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
 
 			pvcJig.CheckVolumeCapacity("50Gi", pvc.Name, f.Namespace.Name)
-			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName); if err != nil {
+			err = pvcJig.DeleteAndAwaitPod(f.Namespace.Name, podName)
+			if err != nil {
 				framework.Failf("Error deleting pod: %v", err)
 			}
 			f.VolumeIds = append(f.VolumeIds, volumeId)
@@ -447,7 +450,7 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			By("Completed test: Static Provisioning CSI UHP")
 
 			By("Running test: Basic Pod Delete UHP")
-			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP + "-5", "blockvolume.csi.oraclecloud.com",
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP+"-5", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -476,7 +479,7 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 				framework.AttachmentType: framework.AttachmentTypeISCSI,
 				csi_util.VpusPerGB:       "30",
 			}
-			scName = f.CreateStorageClassOrFail(framework.ClassOCIKMS + "-1", "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIKMS+"-1", "blockvolume.csi.oraclecloud.com", scParameter, pvcJig.Labels, "WaitForFirstConsumer", false, "Delete", nil)
 			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 			podName = pvcJig.NewPodForCSI("app1", f.Namespace.Name, pvc.Name, setupF.AdLabel)
 			pvcJig.VerifyMultipathEnabled(ctx, f.ComputeClient, pvc.Name, f.Namespace.Name, compartmentId)
@@ -501,7 +504,7 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			By("Running test: Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for iSCSI UHP volume")
 			pvcJig.Name = "csi-uhp-pvc-expand-to-100gi"
 			var size = "100Gi"
-			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP + "-6", "blockvolume.csi.oraclecloud.com",
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP+"-6", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeISCSI, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -519,7 +522,7 @@ var _ = Describe("CSI Ultra High Performance Volumes", func() {
 			By("Completed test: Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for iSCSI UHP volume")
 
 			By("Running test: Expand PVC VolumeSize from 50Gi to 100Gi and asserts size, file existence and file corruptions for Paravirtualized UHP volume")
-			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP + "-7", "blockvolume.csi.oraclecloud.com",
+			scName = f.CreateStorageClassOrFail(framework.ClassOCIUHP+"-7", "blockvolume.csi.oraclecloud.com",
 				map[string]string{framework.AttachmentType: framework.AttachmentTypeParavirtualized, csi_util.VpusPerGB: "30"},
 				pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 			pvc = pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, scName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
@@ -751,8 +754,8 @@ func testTwoPVCSetup(f *framework.CloudProviderFramework, storageclass1params ma
 	nodeHostname := pvcJig.GetNodeHostnameFromPod(podName, f.Namespace.Name)
 
 	nodeLabels := map[string]string{
-		plugin.LabelZoneFailureDomain: setupF.AdLabel,
-		framework.NodeHostnameLabel:   nodeHostname,
+		v1.LabelTopologyZone:        setupF.AdLabel,
+		framework.NodeHostnameLabel: nodeHostname,
 	}
 
 	lowPerfScName := f.CreateStorageClassOrFail("storage-class-two", "blockvolume.csi.oraclecloud.com",
@@ -760,7 +763,6 @@ func testTwoPVCSetup(f *framework.CloudProviderFramework, storageclass1params ma
 		pvcJig.Labels, "WaitForFirstConsumer", true, "Delete", nil)
 	pvcTwo := pvcJig.CreateAndAwaitPVCOrFailCSI(f.Namespace.Name, framework.MinVolumeBlock, lowPerfScName, nil, v1.PersistentVolumeFilesystem, v1.ReadWriteOnce, v1.ClaimPending)
 	podName2 := pvcJig.NewPodWithLabels("pvc-two-app", f.Namespace.Name, pvcTwo.Name, nodeLabels)
-
 
 	pvcJig.DeleteAndAwaitPodOrFail(f.Namespace.Name, podName)
 	pvcJig.DeleteAndAwaitPodOrFail(f.Namespace.Name, podName2)

--- a/test/e2e/cloud-provider-oci/csi_volume_creation.go
+++ b/test/e2e/cloud-provider-oci/csi_volume_creation.go
@@ -44,7 +44,6 @@ var _ = Describe("CSI Volume Creation", func() {
 			// volume name duplicate should not exist
 			for _, volume := range volumes {
 				framework.Logf("volume details %v :", volume)
-				framework.Logf("cluster ocid from setup is %s", setupF.ClusterOcid)
 				if setupF.AddOkeSystemTags && !framework.HasOkeSystemTags(volume.SystemTags) {
 					framework.Failf("the resource %s is expected to have oke system tags", *volume.Id)
 				}

--- a/test/e2e/cloud-provider-oci/load_balancer.go
+++ b/test/e2e/cloud-provider-oci/load_balancer.go
@@ -16,9 +16,10 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"github.com/oracle/oci-go-sdk/v65/core"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -26,6 +27,8 @@ import (
 	. "github.com/onsi/gomega"
 	cloudprovider "github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci"
 	sharedfw "github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
+	"github.com/oracle/oci-go-sdk/v65/containerengine"
+	"github.com/oracle/oci-go-sdk/v65/core"
 
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
@@ -1357,7 +1360,9 @@ var _ = Describe("LB Properties", func() {
 				"lb",
 				map[string]string{
 					cloudprovider.ServiceAnnotationLoadBalancerInternal: "true",
-					cloudprovider.ServiceAnnotationLoadBalancerShape:    "10Mbps",
+					cloudprovider.ServiceAnnotationLoadBalancerShape: "flexible",
+					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMin: "10",
+					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMax: "10",
 				},
 				cloudprovider.ServiceAnnotationLoadBalancerNetworkSecurityGroups,
 			},
@@ -1485,7 +1490,9 @@ var _ = Describe("LB Properties", func() {
 			{
 				"lb",
 				map[string]string{
-					cloudprovider.ServiceAnnotationLoadBalancerShape:  "10Mbps",
+					cloudprovider.ServiceAnnotationLoadBalancerShape: "flexible",
+					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMin: "10",
+					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMax: "10",
 					cloudprovider.ServiceAnnotationLoadBalancerPolicy: cloudprovider.IPHashLoadBalancerPolicy,
 				},
 				map[string]string{
@@ -1595,7 +1602,9 @@ var _ = Describe("LB Properties", func() {
 			{
 				"lb",
 				map[string]string{
-					cloudprovider.ServiceAnnotationLoadBalancerShape: "10Mbps",
+					cloudprovider.ServiceAnnotationLoadBalancerShape: "flexible",
+					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMin: "10",
+					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMax: "10",
 				},
 			},
 			{

--- a/test/e2e/cloud-provider-oci/load_balancer.go
+++ b/test/e2e/cloud-provider-oci/load_balancer.go
@@ -59,7 +59,7 @@ var _ = Describe("Service [Slow]", func() {
 			},
 		},
 	}
-	Context("[cloudprovider][ccm][lb][SL]", func() {
+	Context("[cloudprovider][ccm][lb][SL][system-tags]", func() {
 		It("should be possible to create and mutate a Service type:LoadBalancer (change nodeport) [Canary]", func() {
 			for _, test := range basicTestArray {
 				By("Running test for: " + test.lbType)
@@ -98,6 +98,32 @@ var _ = Describe("Service [Slow]", func() {
 				// Wait for the load balancer to be created asynchronously
 				tcpService = jig.WaitForLoadBalancerOrFail(ns, tcpService.Name, loadBalancerCreateTimeout)
 				jig.SanityCheckService(tcpService, v1.ServiceTypeLoadBalancer)
+
+				By("validating system tags on the loadbalancer")
+				lbName := cloudprovider.GetLoadBalancerName(tcpService)
+				sharedfw.Logf("LB Name is %s", lbName)
+				ctx := context.TODO()
+				compartmentId := ""
+				if setupF.Compartment1 != "" {
+					compartmentId = setupF.Compartment1
+				} else if f.CloudProviderConfig.CompartmentID != "" {
+					compartmentId = f.CloudProviderConfig.CompartmentID
+				} else if f.CloudProviderConfig.Auth.CompartmentID != "" {
+					compartmentId = f.CloudProviderConfig.Auth.CompartmentID
+				} else {
+					sharedfw.Failf("Compartment Id undefined.")
+				}
+				lbType := test.lbType
+				if strings.HasSuffix(test.lbType, "-wris") {
+					lbType = strings.TrimSuffix(test.lbType, "-wris")
+				}
+				loadBalancer, err := f.Client.LoadBalancer(zap.L().Sugar(), lbType, "", nil).GetLoadBalancerByName(ctx, compartmentId, lbName)
+				sharedfw.ExpectNoError(err)
+				sharedfw.Logf("Loadbalancer details %v:", loadBalancer)
+				sharedfw.Logf("cluster ocid from setup is %s", setupF.ClusterOcid)
+				if setupF.AddOkeSystemTags && !sharedfw.HasOkeSystemTags(loadBalancer.SystemTags) {
+					sharedfw.Failf("Loadbalancer is expected to have the system tags")
+				}
 
 				tcpNodePort := int(tcpService.Spec.Ports[0].NodePort)
 				sharedfw.Logf("TCP node port: %d", tcpNodePort)
@@ -1347,8 +1373,8 @@ var _ = Describe("LB Properties", func() {
 			{
 				"lb",
 				map[string]string{
-					cloudprovider.ServiceAnnotationLoadBalancerInternal: "true",
-					cloudprovider.ServiceAnnotationLoadBalancerShape: "flexible",
+					cloudprovider.ServiceAnnotationLoadBalancerInternal:     "true",
+					cloudprovider.ServiceAnnotationLoadBalancerShape:        "flexible",
 					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMin: "10",
 					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMax: "10",
 				},
@@ -1478,10 +1504,10 @@ var _ = Describe("LB Properties", func() {
 			{
 				"lb",
 				map[string]string{
-					cloudprovider.ServiceAnnotationLoadBalancerShape: "flexible",
+					cloudprovider.ServiceAnnotationLoadBalancerShape:        "flexible",
 					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMin: "10",
 					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMax: "10",
-					cloudprovider.ServiceAnnotationLoadBalancerPolicy: cloudprovider.IPHashLoadBalancerPolicy,
+					cloudprovider.ServiceAnnotationLoadBalancerPolicy:       cloudprovider.IPHashLoadBalancerPolicy,
 				},
 				map[string]string{
 					cloudprovider.ServiceAnnotationLoadBalancerPolicy: cloudprovider.LeastConnectionsLoadBalancerPolicy,
@@ -1590,7 +1616,7 @@ var _ = Describe("LB Properties", func() {
 			{
 				"lb",
 				map[string]string{
-					cloudprovider.ServiceAnnotationLoadBalancerShape: "flexible",
+					cloudprovider.ServiceAnnotationLoadBalancerShape:        "flexible",
 					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMin: "10",
 					cloudprovider.ServiceAnnotationLoadBalancerShapeFlexMax: "10",
 				},

--- a/test/e2e/cloud-provider-oci/load_balancer.go
+++ b/test/e2e/cloud-provider-oci/load_balancer.go
@@ -1150,23 +1150,11 @@ var _ = Describe("LB Properties", func() {
 						"10",
 						"100",
 					},
-				},
-			},
-			{
-				"Create and update flexible LB",
-				"flexible",
-				[]struct {
-					shape   string
-					flexMin string
-					flexMax string
-				}{
 					{
 						"flexible",
 						"50",
 						"150",
 					},
-					// Note: We can't go back to fixed shape after converting to flexible shape.
-					// Use Min and Max values to be the same value to get fixed shape LB
 				},
 			},
 		}

--- a/test/e2e/cloud-provider-oci/load_balancer.go
+++ b/test/e2e/cloud-provider-oci/load_balancer.go
@@ -16,10 +16,8 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -27,7 +25,6 @@ import (
 	. "github.com/onsi/gomega"
 	cloudprovider "github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci"
 	sharedfw "github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
-	"github.com/oracle/oci-go-sdk/v65/containerengine"
 	"github.com/oracle/oci-go-sdk/v65/core"
 
 	"go.uber.org/zap"
@@ -120,7 +117,6 @@ var _ = Describe("Service [Slow]", func() {
 				loadBalancer, err := f.Client.LoadBalancer(zap.L().Sugar(), lbType, "", nil).GetLoadBalancerByName(ctx, compartmentId, lbName)
 				sharedfw.ExpectNoError(err)
 				sharedfw.Logf("Loadbalancer details %v:", loadBalancer)
-				sharedfw.Logf("cluster ocid from setup is %s", setupF.ClusterOcid)
 				if setupF.AddOkeSystemTags && !sharedfw.HasOkeSystemTags(loadBalancer.SystemTags) {
 					sharedfw.Failf("Loadbalancer is expected to have the system tags")
 				}
@@ -1702,8 +1698,8 @@ var _ = Describe("LB Properties", func() {
 	})
 })
 
-//ips is the list of private IPs of the nodes, the path is the endpoint at which health is checked,
-//and nodeIndex is the node which has the current pod
+// ips is the list of private IPs of the nodes, the path is the endpoint at which health is checked,
+// and nodeIndex is the node which has the current pod
 func CreateHealthCheckScript(healthCheckNodePort int, ips []string, path string, nodeIndex int) string {
 	script := ""
 

--- a/test/e2e/cloud-provider-oci/setup.go
+++ b/test/e2e/cloud-provider-oci/setup.go
@@ -18,9 +18,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	sharedfw.Logf("CloudProviderFramework Setup")
 	sharedfw.Logf("Running tests with existing cluster.")
 	return nil
-	}, func(data []byte) {
-		setupF = sharedfw.New()
-	},
+}, func(data []byte) {
+	setupF = sharedfw.New()
+},
 )
 
 var _ = ginkgo.SynchronizedAfterSuite(func() {}, func() {

--- a/test/e2e/cloud-provider-oci/setup.go
+++ b/test/e2e/cloud-provider-oci/setup.go
@@ -1,22 +1,12 @@
-// Copyright 2020 Oracle and/or its affiliates. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package e2e
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	sharedfw "github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
+	oke "github.com/oracle/oci-go-sdk/v65/containerengine"
 )
 
 var setupF *sharedfw.Framework
@@ -28,9 +18,12 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	sharedfw.Logf("CloudProviderFramework Setup")
 	sharedfw.Logf("Running tests with existing cluster.")
 	return nil
-}, func(data []byte) {})
+	}, func(data []byte) {
+		setupF = sharedfw.New()
+	},
+)
 
-var _ = ginkgo.SynchronizedAfterSuite(func() {
+var _ = ginkgo.SynchronizedAfterSuite(func() {}, func() {
 	sharedfw.Logf("Running AfterSuite actions on all node")
 	sharedfw.RunCleanupActions()
-}, func() {})
+})

--- a/test/e2e/cloud-provider-oci/setup.go
+++ b/test/e2e/cloud-provider-oci/setup.go
@@ -1,12 +1,22 @@
+// Copyright 2020 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (
-	"time"
-
 	"github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	sharedfw "github.com/oracle/oci-cloud-controller-manager/test/e2e/framework"
-	oke "github.com/oracle/oci-go-sdk/v65/containerengine"
 )
 
 var setupF *sharedfw.Framework

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -15,26 +15,13 @@
 package framework
 
 import (
-	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	imageutils "k8s.io/kubernetes/test/utils/image"
-
-	"github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
-
-	. "github.com/onsi/gomega"
-	"github.com/oracle/oci-go-sdk/v65/common"
-	oke "github.com/oracle/oci-go-sdk/v65/containerengine"
-	"github.com/oracle/oci-go-sdk/v65/core"
-	"github.com/oracle/oci-go-sdk/v65/identity"
-	"gopkg.in/yaml.v2"
 )
 
 const (

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -103,6 +103,7 @@ var (
 	staticSnapshotCompartmentOCID string // Compartment ID for cross compartment snapshot test
 	runUhpE2E                     bool   // Whether to run UHP E2Es, requires Volume Management Plugin enabled on the node and 16+ cores (check blockvolumeperformance public doc for the exact requirements)
 	enableParallelRun			  bool
+	addOkeSystemTags              bool
 )
 
 func init() {
@@ -134,6 +135,7 @@ func init() {
 	flag.StringVar(&staticSnapshotCompartmentOCID, "static-snapshot-compartment-id", "", "Compartment ID for cross compartment snapshot test")
 	flag.BoolVar(&runUhpE2E, "run-uhp-e2e", false, "Run UHP E2Es as well")
 	flag.BoolVar(&enableParallelRun, "enable-parallel-run", true, "Enables parallel running of test suite")
+	flag.BoolVar(&addOkeSystemTags, "add-oke-system-tags", false, "Adds oke system tags to new and existing loadbalancers and storage resources")
 }
 
 // Framework is the context of the text execution.
@@ -167,6 +169,7 @@ type Framework struct {
 	// Compartment ID for cross compartment snapshot test
 	StaticSnapshotCompartmentOcid string
 	RunUhpE2E                     bool
+	AddOkeSystemTags        bool
 }
 
 // New creates a new a framework that holds the context of the test
@@ -191,6 +194,7 @@ func NewWithConfig() *Framework {
 		VolumeHandle:                  volumeHandle,
 		StaticSnapshotCompartmentOcid: staticSnapshotCompartmentOCID,
 		RunUhpE2E:                     runUhpE2E,
+		AddOkeSystemTags:              addOkeSystemTags,
 	}
 
 	f.CloudConfigPath = cloudConfigFile

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -15,13 +15,26 @@
 package framework
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	imageutils "k8s.io/kubernetes/test/utils/image"
+
+	"github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci/config"
+
+	. "github.com/onsi/gomega"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	oke "github.com/oracle/oci-go-sdk/v65/containerengine"
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/oracle/oci-go-sdk/v65/identity"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -81,7 +94,7 @@ var (
 	busyBoxImage                  string // Image for busyBoxImage
 	centos                        string // Image for centos
 	imagePullRepo                 string // Repo to pull images from. Will pull public images if not specified.
-	cmekKMSKey                    string //KMS key for CMEK testing
+	cmekKMSKey                    string // KMS key for CMEK testing
 	nsgOCIDS                      string // Testing CCM NSG feature
 	backendNsgIds                 string // Testing Rule management Backend NSG feature
 	reservedIP                    string // Testing public reserved IP feature
@@ -89,6 +102,7 @@ var (
 	volumeHandle                  string // The FSS mount volume handle
 	staticSnapshotCompartmentOCID string // Compartment ID for cross compartment snapshot test
 	runUhpE2E                     bool   // Whether to run UHP E2Es, requires Volume Management Plugin enabled on the node and 16+ cores (check blockvolumeperformance public doc for the exact requirements)
+	enableParallelRun			  bool
 )
 
 func init() {
@@ -119,6 +133,7 @@ func init() {
 
 	flag.StringVar(&staticSnapshotCompartmentOCID, "static-snapshot-compartment-id", "", "Compartment ID for cross compartment snapshot test")
 	flag.BoolVar(&runUhpE2E, "run-uhp-e2e", false, "Run UHP E2Es as well")
+	flag.BoolVar(&enableParallelRun, "enable-parallel-run", true, "Enables parallel running of test suite")
 }
 
 // Framework is the context of the text execution.

--- a/test/e2e/framework/pod_util.go
+++ b/test/e2e/framework/pod_util.go
@@ -211,12 +211,13 @@ func (j *PVCTestJig) CheckUsableVolumeSizeInsidePod(namespace string, podName st
 			return false, nil
 		}
 		if strings.Fields(strings.TrimSpace(stdout))[1] != capacity {
+			Logf("Expected capacity: %v, got capacity: %v", capacity, strings.Fields(strings.TrimSpace(stdout))[1])
 			return false, nil
 		} else {
 			return true, nil
 		}
 	}); pollErr != nil {
-		Failf("Write Test failed in pod '%v' after expanding pvc", podName)
+		Failf("Check Usable Volume Size Inside Pod Test failed in pod '%v' after expanding pvc", podName)
 	}
 
 }

--- a/test/e2e/framework/pvc_util.go
+++ b/test/e2e/framework/pvc_util.go
@@ -36,11 +36,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+
 	csi_util "github.com/oracle/oci-cloud-controller-manager/pkg/csi-util"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/csi/driver"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/oci/client"
 	"github.com/oracle/oci-cloud-controller-manager/pkg/volume/provisioner/plugin"
-	ocicore "github.com/oracle/oci-go-sdk/v65/core"
 )
 
 const (
@@ -100,7 +101,7 @@ func (j *PVCTestJig) pvcAddLabelSelector(pvc *v1.PersistentVolumeClaim, adLabel 
 	if pvc != nil {
 		pvc.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				plugin.LabelZoneFailureDomain: adLabel,
+				v1.LabelTopologyZone: adLabel,
 			},
 		}
 	}
@@ -686,7 +687,7 @@ func (j *PVCTestJig) NewPodForCSI(name string, namespace string, claimName strin
 	return pod.Name
 }
 
-// NewPodWithLabels returns the default template for this jig,
+// newPODTemplate returns the default template for this jig,
 // creates the Pod. Attaches PVC to the Pod which is created by CSI
 func (j *PVCTestJig) NewPodWithLabels(name string, namespace string, claimName string, labels map[string]string) string {
 	By("Creating a pod with the claiming PVC created by CSI")
@@ -777,7 +778,7 @@ func (j *PVCTestJig) NewPodForCSIClone(name string, namespace string, claimName 
 				},
 			},
 			NodeSelector: map[string]string{
-				plugin.LabelZoneFailureDomain: adLabel,
+				v1.LabelTopologyZone: adLabel,
 			},
 		},
 	}, metav1.CreateOptions{})
@@ -832,7 +833,7 @@ func (j *PVCTestJig) NewPodForCSIWithoutWait(name string, namespace string, clai
 				},
 			},
 			NodeSelector: map[string]string{
-				plugin.LabelZoneFailureDomain: adLabel,
+				v1.LabelTopologyZone: adLabel,
 			},
 		},
 	}, metav1.CreateOptions{})

--- a/test/e2e/framework/system_tags_util.go
+++ b/test/e2e/framework/system_tags_util.go
@@ -1,0 +1,22 @@
+package framework
+
+import (
+	cloudprovider "github.com/oracle/oci-cloud-controller-manager/pkg/cloudprovider/providers/oci"
+)
+
+const (
+	okeSystemTagKey = "Cluster"
+)
+
+func HasOkeSystemTags(systemTags map[string]map[string]interface{}) bool {
+	Logf("actual system tags on the resource: %v", systemTags)
+	if systemTags != nil {
+		if okeSystemTag, okeSystemTagNsExists := systemTags[cloudprovider.OkeSystemTagNamesapce]; okeSystemTagNsExists {
+			if _, okeSystemTagKeyExists := okeSystemTag[okeSystemTagKey]; okeSystemTagKeyExists {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}

--- a/test/e2e/framework/system_tags_util.go
+++ b/test/e2e/framework/system_tags_util.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package framework
 
 import (

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/add_on_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/add_on_options.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddOnOptions The properties that define options for supported add-ons.
+type AddOnOptions struct {
+
+	// Whether or not to enable the Kubernetes Dashboard add-on.
+	IsKubernetesDashboardEnabled *bool `mandatory:"false" json:"isKubernetesDashboardEnabled"`
+
+	// Whether or not to enable the Tiller add-on.
+	IsTillerEnabled *bool `mandatory:"false" json:"isTillerEnabled"`
+}
+
+func (m AddOnOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddOnOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Addon The properties that define an addon.
+type Addon struct {
+
+	// The name of the addon.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The state of the addon.
+	LifecycleState AddonLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// selected addon version, or null indicates autoUpdate
+	Version *string `mandatory:"false" json:"version"`
+
+	// current installed version of the addon
+	CurrentInstalledVersion *string `mandatory:"false" json:"currentInstalledVersion"`
+
+	// The time the cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Addon configuration details.
+	Configurations []AddonConfiguration `mandatory:"false" json:"configurations"`
+
+	// The error info of the addon.
+	AddonError *AddonError `mandatory:"false" json:"addonError"`
+}
+
+func (m Addon) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m Addon) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAddonLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetAddonLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_configuration.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonConfiguration Defines the configuration of available addons for a cluster
+type AddonConfiguration struct {
+
+	// configuration key name
+	Key *string `mandatory:"false" json:"key"`
+
+	// configuration value name
+	Value *string `mandatory:"false" json:"value"`
+}
+
+func (m AddonConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_error.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonError The error info of the addon.
+type AddonError struct {
+
+	// A short error code that defines the upstream error, meant for programmatic parsing. See API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+	Code *string `mandatory:"false" json:"code"`
+
+	// A human-readable error string of the upstream error.
+	Message *string `mandatory:"false" json:"message"`
+
+	// The status of the HTTP response encountered in the upstream error.
+	Status *string `mandatory:"false" json:"status"`
+}
+
+func (m AddonError) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonError) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_lifecycle_state.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// AddonLifecycleStateEnum Enum with underlying type: string
+type AddonLifecycleStateEnum string
+
+// Set of constants representing the allowable values for AddonLifecycleStateEnum
+const (
+	AddonLifecycleStateCreating       AddonLifecycleStateEnum = "CREATING"
+	AddonLifecycleStateActive         AddonLifecycleStateEnum = "ACTIVE"
+	AddonLifecycleStateDeleting       AddonLifecycleStateEnum = "DELETING"
+	AddonLifecycleStateDeleted        AddonLifecycleStateEnum = "DELETED"
+	AddonLifecycleStateUpdating       AddonLifecycleStateEnum = "UPDATING"
+	AddonLifecycleStateNeedsAttention AddonLifecycleStateEnum = "NEEDS_ATTENTION"
+	AddonLifecycleStateFailed         AddonLifecycleStateEnum = "FAILED"
+)
+
+var mappingAddonLifecycleStateEnum = map[string]AddonLifecycleStateEnum{
+	"CREATING":        AddonLifecycleStateCreating,
+	"ACTIVE":          AddonLifecycleStateActive,
+	"DELETING":        AddonLifecycleStateDeleting,
+	"DELETED":         AddonLifecycleStateDeleted,
+	"UPDATING":        AddonLifecycleStateUpdating,
+	"NEEDS_ATTENTION": AddonLifecycleStateNeedsAttention,
+	"FAILED":          AddonLifecycleStateFailed,
+}
+
+var mappingAddonLifecycleStateEnumLowerCase = map[string]AddonLifecycleStateEnum{
+	"creating":        AddonLifecycleStateCreating,
+	"active":          AddonLifecycleStateActive,
+	"deleting":        AddonLifecycleStateDeleting,
+	"deleted":         AddonLifecycleStateDeleted,
+	"updating":        AddonLifecycleStateUpdating,
+	"needs_attention": AddonLifecycleStateNeedsAttention,
+	"failed":          AddonLifecycleStateFailed,
+}
+
+// GetAddonLifecycleStateEnumValues Enumerates the set of values for AddonLifecycleStateEnum
+func GetAddonLifecycleStateEnumValues() []AddonLifecycleStateEnum {
+	values := make([]AddonLifecycleStateEnum, 0)
+	for _, v := range mappingAddonLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAddonLifecycleStateEnumStringValues Enumerates the set of values in String for AddonLifecycleStateEnum
+func GetAddonLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"DELETING",
+		"DELETED",
+		"UPDATING",
+		"NEEDS_ATTENTION",
+		"FAILED",
+	}
+}
+
+// GetMappingAddonLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAddonLifecycleStateEnum(val string) (AddonLifecycleStateEnum, bool) {
+	enum, ok := mappingAddonLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_option_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_option_summary.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonOptionSummary The properties that define addon summary.
+type AddonOptionSummary struct {
+
+	// Name of the addon and it would be unique.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The life cycle state of the addon.
+	LifecycleState AddonOptionSummaryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// Is it an essential addon for cluster operation or not.
+	IsEssential *bool `mandatory:"true" json:"isEssential"`
+
+	// The resources this work request affects.
+	Versions []AddonVersions `mandatory:"true" json:"versions"`
+
+	// Addon definition schema version to validate addon.
+	AddonSchemaVersion *string `mandatory:"false" json:"addonSchemaVersion"`
+
+	// Addon group info, a namespace concept that groups addons with similar functionalities.
+	AddonGroup *string `mandatory:"false" json:"addonGroup"`
+
+	// Description on the addon.
+	Description *string `mandatory:"false" json:"description"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// The time the work request was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+}
+
+func (m AddonOptionSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonOptionSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAddonOptionSummaryLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetAddonOptionSummaryLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// AddonOptionSummaryLifecycleStateEnum Enum with underlying type: string
+type AddonOptionSummaryLifecycleStateEnum string
+
+// Set of constants representing the allowable values for AddonOptionSummaryLifecycleStateEnum
+const (
+	AddonOptionSummaryLifecycleStateActive   AddonOptionSummaryLifecycleStateEnum = "ACTIVE"
+	AddonOptionSummaryLifecycleStateInactive AddonOptionSummaryLifecycleStateEnum = "INACTIVE"
+)
+
+var mappingAddonOptionSummaryLifecycleStateEnum = map[string]AddonOptionSummaryLifecycleStateEnum{
+	"ACTIVE":   AddonOptionSummaryLifecycleStateActive,
+	"INACTIVE": AddonOptionSummaryLifecycleStateInactive,
+}
+
+var mappingAddonOptionSummaryLifecycleStateEnumLowerCase = map[string]AddonOptionSummaryLifecycleStateEnum{
+	"active":   AddonOptionSummaryLifecycleStateActive,
+	"inactive": AddonOptionSummaryLifecycleStateInactive,
+}
+
+// GetAddonOptionSummaryLifecycleStateEnumValues Enumerates the set of values for AddonOptionSummaryLifecycleStateEnum
+func GetAddonOptionSummaryLifecycleStateEnumValues() []AddonOptionSummaryLifecycleStateEnum {
+	values := make([]AddonOptionSummaryLifecycleStateEnum, 0)
+	for _, v := range mappingAddonOptionSummaryLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAddonOptionSummaryLifecycleStateEnumStringValues Enumerates the set of values in String for AddonOptionSummaryLifecycleStateEnum
+func GetAddonOptionSummaryLifecycleStateEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"INACTIVE",
+	}
+}
+
+// GetMappingAddonOptionSummaryLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAddonOptionSummaryLifecycleStateEnum(val string) (AddonOptionSummaryLifecycleStateEnum, bool) {
+	enum, ok := mappingAddonOptionSummaryLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_summary.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonSummary The properties that define an addon summary.
+type AddonSummary struct {
+
+	// The name of the addon.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The state of the addon.
+	LifecycleState AddonLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// selected addon version, or null indicates autoUpdate
+	Version *string `mandatory:"false" json:"version"`
+
+	// current installed version of the addon
+	CurrentInstalledVersion *string `mandatory:"false" json:"currentInstalledVersion"`
+
+	// The time the cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The error info of the addon.
+	AddonError *AddonError `mandatory:"false" json:"addonError"`
+}
+
+func (m AddonSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingAddonLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetAddonLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_version_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_version_configuration.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonVersionConfiguration Addon version configuration details.
+type AddonVersionConfiguration struct {
+
+	// If the the configuration is required or not.
+	IsRequired *bool `mandatory:"false" json:"isRequired"`
+
+	// Addon configuration key
+	Key *string `mandatory:"false" json:"key"`
+
+	// Addon configuration value
+	Value *string `mandatory:"false" json:"value"`
+
+	// Display name of addon version.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Information about the addon version configuration.
+	Description *string `mandatory:"false" json:"description"`
+}
+
+func (m AddonVersionConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonVersionConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_versions.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/addon_versions.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AddonVersions The properties that define a work request resource.
+type AddonVersions struct {
+
+	// Current state of the addon, only active will be visible to customer, visibility of versions in other status will be filtered  based on limits property.
+	Status AddonVersionsStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// Version number, need be comparable within an addon.
+	VersionNumber *string `mandatory:"false" json:"versionNumber"`
+
+	// Information about the addon version.
+	Description *string `mandatory:"false" json:"description"`
+
+	// The range of kubernetes versions an addon can be configured.
+	KubernetesVersionFilters *KubernetesVersionsFilters `mandatory:"false" json:"kubernetesVersionFilters"`
+
+	// Addon version configuration details.
+	Configurations []AddonVersionConfiguration `mandatory:"false" json:"configurations"`
+}
+
+func (m AddonVersions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AddonVersions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingAddonVersionsStatusEnum(string(m.Status)); !ok && m.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", m.Status, strings.Join(GetAddonVersionsStatusEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// AddonVersionsStatusEnum Enum with underlying type: string
+type AddonVersionsStatusEnum string
+
+// Set of constants representing the allowable values for AddonVersionsStatusEnum
+const (
+	AddonVersionsStatusActive     AddonVersionsStatusEnum = "ACTIVE"
+	AddonVersionsStatusDeprecated AddonVersionsStatusEnum = "DEPRECATED"
+	AddonVersionsStatusPreview    AddonVersionsStatusEnum = "PREVIEW"
+	AddonVersionsStatusRecalled   AddonVersionsStatusEnum = "RECALLED"
+)
+
+var mappingAddonVersionsStatusEnum = map[string]AddonVersionsStatusEnum{
+	"ACTIVE":     AddonVersionsStatusActive,
+	"DEPRECATED": AddonVersionsStatusDeprecated,
+	"PREVIEW":    AddonVersionsStatusPreview,
+	"RECALLED":   AddonVersionsStatusRecalled,
+}
+
+var mappingAddonVersionsStatusEnumLowerCase = map[string]AddonVersionsStatusEnum{
+	"active":     AddonVersionsStatusActive,
+	"deprecated": AddonVersionsStatusDeprecated,
+	"preview":    AddonVersionsStatusPreview,
+	"recalled":   AddonVersionsStatusRecalled,
+}
+
+// GetAddonVersionsStatusEnumValues Enumerates the set of values for AddonVersionsStatusEnum
+func GetAddonVersionsStatusEnumValues() []AddonVersionsStatusEnum {
+	values := make([]AddonVersionsStatusEnum, 0)
+	for _, v := range mappingAddonVersionsStatusEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetAddonVersionsStatusEnumStringValues Enumerates the set of values in String for AddonVersionsStatusEnum
+func GetAddonVersionsStatusEnumStringValues() []string {
+	return []string{
+		"ACTIVE",
+		"DEPRECATED",
+		"PREVIEW",
+		"RECALLED",
+	}
+}
+
+// GetMappingAddonVersionsStatusEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingAddonVersionsStatusEnum(val string) (AddonVersionsStatusEnum, bool) {
+	enum, ok := mappingAddonVersionsStatusEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/admission_controller_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/admission_controller_options.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// AdmissionControllerOptions The properties that define supported admission controllers.
+type AdmissionControllerOptions struct {
+
+	// Whether or not to enable the Pod Security Policy admission controller.
+	IsPodSecurityPolicyEnabled *bool `mandatory:"false" json:"isPodSecurityPolicyEnabled"`
+}
+
+func (m AdmissionControllerOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m AdmissionControllerOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Cluster A Kubernetes cluster. Avoid entering confidential information.
+type Cluster struct {
+
+	// The OCID of the cluster.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The name of the cluster.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The OCID of the compartment in which the cluster exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The network configuration for access to the Cluster control plane.
+	EndpointConfig *ClusterEndpointConfig `mandatory:"false" json:"endpointConfig"`
+
+	// The OCID of the virtual cloud network (VCN) in which the cluster exists.
+	VcnId *string `mandatory:"false" json:"vcnId"`
+
+	// The version of Kubernetes running on the cluster masters.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// Optional attributes for the cluster.
+	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
+
+	// Metadata about the cluster.
+	Metadata *ClusterMetadata `mandatory:"false" json:"metadata"`
+
+	// The state of the cluster masters.
+	LifecycleState ClusterLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the cluster masters.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Endpoints served up by the cluster masters.
+	Endpoints *ClusterEndpoints `mandatory:"false" json:"endpoints"`
+
+	// Available Kubernetes versions to which the clusters masters may be upgraded.
+	AvailableKubernetesUpgrades []string `mandatory:"false" json:"availableKubernetesUpgrades"`
+
+	// The image verification policy for signature validation.
+	ImagePolicyConfig *ImagePolicyConfig `mandatory:"false" json:"imagePolicyConfig"`
+
+	// Available CNIs and network options for existing and new node pools of the cluster
+	ClusterPodNetworkOptions []ClusterPodNetworkOptionDetails `mandatory:"false" json:"clusterPodNetworkOptions"`
+
+	// Type of cluster
+	Type ClusterTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m Cluster) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m Cluster) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingClusterLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetClusterLifecycleStateEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingClusterTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetClusterTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *Cluster) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                          *string                           `json:"id"`
+		Name                        *string                           `json:"name"`
+		CompartmentId               *string                           `json:"compartmentId"`
+		EndpointConfig              *ClusterEndpointConfig            `json:"endpointConfig"`
+		VcnId                       *string                           `json:"vcnId"`
+		KubernetesVersion           *string                           `json:"kubernetesVersion"`
+		KmsKeyId                    *string                           `json:"kmsKeyId"`
+		FreeformTags                map[string]string                 `json:"freeformTags"`
+		DefinedTags                 map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags                  map[string]map[string]interface{} `json:"systemTags"`
+		Options                     *ClusterCreateOptions             `json:"options"`
+		Metadata                    *ClusterMetadata                  `json:"metadata"`
+		LifecycleState              ClusterLifecycleStateEnum         `json:"lifecycleState"`
+		LifecycleDetails            *string                           `json:"lifecycleDetails"`
+		Endpoints                   *ClusterEndpoints                 `json:"endpoints"`
+		AvailableKubernetesUpgrades []string                          `json:"availableKubernetesUpgrades"`
+		ImagePolicyConfig           *ImagePolicyConfig                `json:"imagePolicyConfig"`
+		ClusterPodNetworkOptions    []clusterpodnetworkoptiondetails  `json:"clusterPodNetworkOptions"`
+		Type                        ClusterTypeEnum                   `json:"type"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Id = model.Id
+
+	m.Name = model.Name
+
+	m.CompartmentId = model.CompartmentId
+
+	m.EndpointConfig = model.EndpointConfig
+
+	m.VcnId = model.VcnId
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.KmsKeyId = model.KmsKeyId
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.Options = model.Options
+
+	m.Metadata = model.Metadata
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.Endpoints = model.Endpoints
+
+	m.AvailableKubernetesUpgrades = make([]string, len(model.AvailableKubernetesUpgrades))
+	copy(m.AvailableKubernetesUpgrades, model.AvailableKubernetesUpgrades)
+	m.ImagePolicyConfig = model.ImagePolicyConfig
+
+	m.ClusterPodNetworkOptions = make([]ClusterPodNetworkOptionDetails, len(model.ClusterPodNetworkOptions))
+	for i, n := range model.ClusterPodNetworkOptions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ClusterPodNetworkOptions[i] = nn.(ClusterPodNetworkOptionDetails)
+		} else {
+			m.ClusterPodNetworkOptions[i] = nil
+		}
+	}
+	m.Type = model.Type
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_create_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_create_options.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterCreateOptions The properties that define extra options for a cluster.
+type ClusterCreateOptions struct {
+
+	// The OCIDs of the subnets used for Kubernetes services load balancers.
+	ServiceLbSubnetIds []string `mandatory:"false" json:"serviceLbSubnetIds"`
+
+	// Network configuration for Kubernetes.
+	KubernetesNetworkConfig *KubernetesNetworkConfig `mandatory:"false" json:"kubernetesNetworkConfig"`
+
+	// Configurable cluster add-ons
+	AddOns *AddOnOptions `mandatory:"false" json:"addOns"`
+
+	// Configurable cluster admission controllers
+	AdmissionControllerOptions *AdmissionControllerOptions `mandatory:"false" json:"admissionControllerOptions"`
+
+	PersistentVolumeConfig *PersistentVolumeConfigDetails `mandatory:"false" json:"persistentVolumeConfig"`
+
+	ServiceLbConfig *ServiceLbConfigDetails `mandatory:"false" json:"serviceLbConfig"`
+}
+
+func (m ClusterCreateOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterCreateOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_endpoint_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_endpoint_config.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterEndpointConfig The properties that define the network configuration for the Cluster endpoint.
+type ClusterEndpointConfig struct {
+
+	// The OCID of the regional subnet in which to place the Cluster endpoint.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+	IsPublicIpEnabled *bool `mandatory:"false" json:"isPublicIpEnabled"`
+}
+
+func (m ClusterEndpointConfig) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterEndpointConfig) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_endpoints.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_endpoints.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterEndpoints The properties that define endpoints for a cluster.
+type ClusterEndpoints struct {
+
+	// The non-native networking Kubernetes API server endpoint.
+	Kubernetes *string `mandatory:"false" json:"kubernetes"`
+
+	// The public native networking Kubernetes API server endpoint, if one was requested.
+	PublicEndpoint *string `mandatory:"false" json:"publicEndpoint"`
+
+	// The private native networking Kubernetes API server endpoint.
+	PrivateEndpoint *string `mandatory:"false" json:"privateEndpoint"`
+
+	// The FQDN assigned to the Kubernetes API private endpoint.
+	// Example: 'https://yourVcnHostnameEndpoint'
+	VcnHostnameEndpoint *string `mandatory:"false" json:"vcnHostnameEndpoint"`
+}
+
+func (m ClusterEndpoints) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterEndpoints) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_lifecycle_state.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// ClusterLifecycleStateEnum Enum with underlying type: string
+type ClusterLifecycleStateEnum string
+
+// Set of constants representing the allowable values for ClusterLifecycleStateEnum
+const (
+	ClusterLifecycleStateCreating ClusterLifecycleStateEnum = "CREATING"
+	ClusterLifecycleStateActive   ClusterLifecycleStateEnum = "ACTIVE"
+	ClusterLifecycleStateFailed   ClusterLifecycleStateEnum = "FAILED"
+	ClusterLifecycleStateDeleting ClusterLifecycleStateEnum = "DELETING"
+	ClusterLifecycleStateDeleted  ClusterLifecycleStateEnum = "DELETED"
+	ClusterLifecycleStateUpdating ClusterLifecycleStateEnum = "UPDATING"
+)
+
+var mappingClusterLifecycleStateEnum = map[string]ClusterLifecycleStateEnum{
+	"CREATING": ClusterLifecycleStateCreating,
+	"ACTIVE":   ClusterLifecycleStateActive,
+	"FAILED":   ClusterLifecycleStateFailed,
+	"DELETING": ClusterLifecycleStateDeleting,
+	"DELETED":  ClusterLifecycleStateDeleted,
+	"UPDATING": ClusterLifecycleStateUpdating,
+}
+
+var mappingClusterLifecycleStateEnumLowerCase = map[string]ClusterLifecycleStateEnum{
+	"creating": ClusterLifecycleStateCreating,
+	"active":   ClusterLifecycleStateActive,
+	"failed":   ClusterLifecycleStateFailed,
+	"deleting": ClusterLifecycleStateDeleting,
+	"deleted":  ClusterLifecycleStateDeleted,
+	"updating": ClusterLifecycleStateUpdating,
+}
+
+// GetClusterLifecycleStateEnumValues Enumerates the set of values for ClusterLifecycleStateEnum
+func GetClusterLifecycleStateEnumValues() []ClusterLifecycleStateEnum {
+	values := make([]ClusterLifecycleStateEnum, 0)
+	for _, v := range mappingClusterLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetClusterLifecycleStateEnumStringValues Enumerates the set of values in String for ClusterLifecycleStateEnum
+func GetClusterLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"FAILED",
+		"DELETING",
+		"DELETED",
+		"UPDATING",
+	}
+}
+
+// GetMappingClusterLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingClusterLifecycleStateEnum(val string) (ClusterLifecycleStateEnum, bool) {
+	enum, ok := mappingClusterLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_metadata.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_metadata.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterMetadata The properties that define meta data for a cluster.
+type ClusterMetadata struct {
+
+	// The time the cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The user who created the cluster.
+	CreatedByUserId *string `mandatory:"false" json:"createdByUserId"`
+
+	// The OCID of the work request which created the cluster.
+	CreatedByWorkRequestId *string `mandatory:"false" json:"createdByWorkRequestId"`
+
+	// The time the cluster was deleted.
+	TimeDeleted *common.SDKTime `mandatory:"false" json:"timeDeleted"`
+
+	// The user who deleted the cluster.
+	DeletedByUserId *string `mandatory:"false" json:"deletedByUserId"`
+
+	// The OCID of the work request which deleted the cluster.
+	DeletedByWorkRequestId *string `mandatory:"false" json:"deletedByWorkRequestId"`
+
+	// The time the cluster was updated.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// The user who updated the cluster.
+	UpdatedByUserId *string `mandatory:"false" json:"updatedByUserId"`
+
+	// The OCID of the work request which updated the cluster.
+	UpdatedByWorkRequestId *string `mandatory:"false" json:"updatedByWorkRequestId"`
+
+	// The time until which the cluster credential is valid.
+	TimeCredentialExpiration *common.SDKTime `mandatory:"false" json:"timeCredentialExpiration"`
+}
+
+func (m ClusterMetadata) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterMetadata) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterMigrateToNativeVcnDetails The properties that define a request to migrate a cluster to Native VCN.
+type ClusterMigrateToNativeVcnDetails struct {
+
+	// The network configuration for access to the Cluster control plane.
+	EndpointConfig *ClusterEndpointConfig `mandatory:"true" json:"endpointConfig"`
+
+	// The optional override of the non-native endpoint decommission time after migration is complete. Defaults to 30 days.
+	DecommissionDelayDuration *string `mandatory:"false" json:"decommissionDelayDuration"`
+}
+
+func (m ClusterMigrateToNativeVcnDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterMigrateToNativeVcnDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ClusterMigrateToNativeVcnRequest wrapper for the ClusterMigrateToNativeVcn operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ClusterMigrateToNativeVcn.go.html to see an example of how to use ClusterMigrateToNativeVcnRequest.
+type ClusterMigrateToNativeVcnRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details for the cluster's migration to native VCN.
+	ClusterMigrateToNativeVcnDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ClusterMigrateToNativeVcnRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ClusterMigrateToNativeVcnRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ClusterMigrateToNativeVcnRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ClusterMigrateToNativeVcnRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ClusterMigrateToNativeVcnRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ClusterMigrateToNativeVcnResponse wrapper for the ClusterMigrateToNativeVcn operation
+type ClusterMigrateToNativeVcnResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ClusterMigrateToNativeVcnResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ClusterMigrateToNativeVcnResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_migrate_to_native_vcn_status.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterMigrateToNativeVcnStatus Information regarding a cluster's move to Native VCN.
+type ClusterMigrateToNativeVcnStatus struct {
+
+	// The current migration status of the cluster.
+	State ClusterMigrateToNativeVcnStatusStateEnum `mandatory:"true" json:"state"`
+
+	// The date and time the non-native VCN is due to be decommissioned.
+	TimeDecommissionScheduled *common.SDKTime `mandatory:"false" json:"timeDecommissionScheduled"`
+}
+
+func (m ClusterMigrateToNativeVcnStatus) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterMigrateToNativeVcnStatus) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingClusterMigrateToNativeVcnStatusStateEnum(string(m.State)); !ok && m.State != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for State: %s. Supported values are: %s.", m.State, strings.Join(GetClusterMigrateToNativeVcnStatusStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ClusterMigrateToNativeVcnStatusStateEnum Enum with underlying type: string
+type ClusterMigrateToNativeVcnStatusStateEnum string
+
+// Set of constants representing the allowable values for ClusterMigrateToNativeVcnStatusStateEnum
+const (
+	ClusterMigrateToNativeVcnStatusStateNotStarted          ClusterMigrateToNativeVcnStatusStateEnum = "NOT_STARTED"
+	ClusterMigrateToNativeVcnStatusStateRequested           ClusterMigrateToNativeVcnStatusStateEnum = "REQUESTED"
+	ClusterMigrateToNativeVcnStatusStateInProgress          ClusterMigrateToNativeVcnStatusStateEnum = "IN_PROGRESS"
+	ClusterMigrateToNativeVcnStatusStatePendingDecommission ClusterMigrateToNativeVcnStatusStateEnum = "PENDING_DECOMMISSION"
+	ClusterMigrateToNativeVcnStatusStateCompleted           ClusterMigrateToNativeVcnStatusStateEnum = "COMPLETED"
+)
+
+var mappingClusterMigrateToNativeVcnStatusStateEnum = map[string]ClusterMigrateToNativeVcnStatusStateEnum{
+	"NOT_STARTED":          ClusterMigrateToNativeVcnStatusStateNotStarted,
+	"REQUESTED":            ClusterMigrateToNativeVcnStatusStateRequested,
+	"IN_PROGRESS":          ClusterMigrateToNativeVcnStatusStateInProgress,
+	"PENDING_DECOMMISSION": ClusterMigrateToNativeVcnStatusStatePendingDecommission,
+	"COMPLETED":            ClusterMigrateToNativeVcnStatusStateCompleted,
+}
+
+var mappingClusterMigrateToNativeVcnStatusStateEnumLowerCase = map[string]ClusterMigrateToNativeVcnStatusStateEnum{
+	"not_started":          ClusterMigrateToNativeVcnStatusStateNotStarted,
+	"requested":            ClusterMigrateToNativeVcnStatusStateRequested,
+	"in_progress":          ClusterMigrateToNativeVcnStatusStateInProgress,
+	"pending_decommission": ClusterMigrateToNativeVcnStatusStatePendingDecommission,
+	"completed":            ClusterMigrateToNativeVcnStatusStateCompleted,
+}
+
+// GetClusterMigrateToNativeVcnStatusStateEnumValues Enumerates the set of values for ClusterMigrateToNativeVcnStatusStateEnum
+func GetClusterMigrateToNativeVcnStatusStateEnumValues() []ClusterMigrateToNativeVcnStatusStateEnum {
+	values := make([]ClusterMigrateToNativeVcnStatusStateEnum, 0)
+	for _, v := range mappingClusterMigrateToNativeVcnStatusStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetClusterMigrateToNativeVcnStatusStateEnumStringValues Enumerates the set of values in String for ClusterMigrateToNativeVcnStatusStateEnum
+func GetClusterMigrateToNativeVcnStatusStateEnumStringValues() []string {
+	return []string{
+		"NOT_STARTED",
+		"REQUESTED",
+		"IN_PROGRESS",
+		"PENDING_DECOMMISSION",
+		"COMPLETED",
+	}
+}
+
+// GetMappingClusterMigrateToNativeVcnStatusStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingClusterMigrateToNativeVcnStatusStateEnum(val string) (ClusterMigrateToNativeVcnStatusStateEnum, bool) {
+	enum, ok := mappingClusterMigrateToNativeVcnStatusStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_options.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterOptions Options for creating or updating clusters.
+type ClusterOptions struct {
+
+	// Available Kubernetes versions.
+	KubernetesVersions []string `mandatory:"false" json:"kubernetesVersions"`
+
+	// Available CNIs and network options for existing and new node pools of the cluster
+	ClusterPodNetworkOptions []ClusterPodNetworkOptionDetails `mandatory:"false" json:"clusterPodNetworkOptions"`
+}
+
+func (m ClusterOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ClusterOptions) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		KubernetesVersions       []string                         `json:"kubernetesVersions"`
+		ClusterPodNetworkOptions []clusterpodnetworkoptiondetails `json:"clusterPodNetworkOptions"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.KubernetesVersions = make([]string, len(model.KubernetesVersions))
+	copy(m.KubernetesVersions, model.KubernetesVersions)
+	m.ClusterPodNetworkOptions = make([]ClusterPodNetworkOptionDetails, len(model.ClusterPodNetworkOptions))
+	for i, n := range model.ClusterPodNetworkOptions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ClusterPodNetworkOptions[i] = nn.(ClusterPodNetworkOptionDetails)
+		} else {
+			m.ClusterPodNetworkOptions[i] = nil
+		}
+	}
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_pod_network_option_details.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterPodNetworkOptionDetails The CNI type and relevant network details potentially applicable to the node pools of the cluster
+type ClusterPodNetworkOptionDetails interface {
+}
+
+type clusterpodnetworkoptiondetails struct {
+	JsonData []byte
+	CniType  string `json:"cniType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *clusterpodnetworkoptiondetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerclusterpodnetworkoptiondetails clusterpodnetworkoptiondetails
+	s := struct {
+		Model Unmarshalerclusterpodnetworkoptiondetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CniType = s.Model.CniType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *clusterpodnetworkoptiondetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.CniType {
+	case "FLANNEL_OVERLAY":
+		mm := FlannelOverlayClusterPodNetworkOptionDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "OCI_VCN_IP_NATIVE":
+		mm := OciVcnIpNativeClusterPodNetworkOptionDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for ClusterPodNetworkOptionDetails: %s.", m.CniType)
+		return *m, nil
+	}
+}
+
+func (m clusterpodnetworkoptiondetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m clusterpodnetworkoptiondetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ClusterPodNetworkOptionDetailsCniTypeEnum Enum with underlying type: string
+type ClusterPodNetworkOptionDetailsCniTypeEnum string
+
+// Set of constants representing the allowable values for ClusterPodNetworkOptionDetailsCniTypeEnum
+const (
+	ClusterPodNetworkOptionDetailsCniTypeOciVcnIpNative ClusterPodNetworkOptionDetailsCniTypeEnum = "OCI_VCN_IP_NATIVE"
+	ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay ClusterPodNetworkOptionDetailsCniTypeEnum = "FLANNEL_OVERLAY"
+)
+
+var mappingClusterPodNetworkOptionDetailsCniTypeEnum = map[string]ClusterPodNetworkOptionDetailsCniTypeEnum{
+	"OCI_VCN_IP_NATIVE": ClusterPodNetworkOptionDetailsCniTypeOciVcnIpNative,
+	"FLANNEL_OVERLAY":   ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay,
+}
+
+var mappingClusterPodNetworkOptionDetailsCniTypeEnumLowerCase = map[string]ClusterPodNetworkOptionDetailsCniTypeEnum{
+	"oci_vcn_ip_native": ClusterPodNetworkOptionDetailsCniTypeOciVcnIpNative,
+	"flannel_overlay":   ClusterPodNetworkOptionDetailsCniTypeFlannelOverlay,
+}
+
+// GetClusterPodNetworkOptionDetailsCniTypeEnumValues Enumerates the set of values for ClusterPodNetworkOptionDetailsCniTypeEnum
+func GetClusterPodNetworkOptionDetailsCniTypeEnumValues() []ClusterPodNetworkOptionDetailsCniTypeEnum {
+	values := make([]ClusterPodNetworkOptionDetailsCniTypeEnum, 0)
+	for _, v := range mappingClusterPodNetworkOptionDetailsCniTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetClusterPodNetworkOptionDetailsCniTypeEnumStringValues Enumerates the set of values in String for ClusterPodNetworkOptionDetailsCniTypeEnum
+func GetClusterPodNetworkOptionDetailsCniTypeEnumStringValues() []string {
+	return []string{
+		"OCI_VCN_IP_NATIVE",
+		"FLANNEL_OVERLAY",
+	}
+}
+
+// GetMappingClusterPodNetworkOptionDetailsCniTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingClusterPodNetworkOptionDetailsCniTypeEnum(val string) (ClusterPodNetworkOptionDetailsCniTypeEnum, bool) {
+	enum, ok := mappingClusterPodNetworkOptionDetailsCniTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_summary.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ClusterSummary The properties that define a cluster summary.
+type ClusterSummary struct {
+
+	// The OCID of the cluster.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The name of the cluster.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The OCID of the compartment in which the cluster exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The network configuration for access to the Cluster control plane.
+	EndpointConfig *ClusterEndpointConfig `mandatory:"false" json:"endpointConfig"`
+
+	// The OCID of the virtual cloud network (VCN) in which the cluster exists
+	VcnId *string `mandatory:"false" json:"vcnId"`
+
+	// The version of Kubernetes running on the cluster masters.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// Optional attributes for the cluster.
+	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
+
+	// Metadata about the cluster.
+	Metadata *ClusterMetadata `mandatory:"false" json:"metadata"`
+
+	// The state of the cluster masters.
+	LifecycleState ClusterLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the cluster masters.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// Endpoints served up by the cluster masters.
+	Endpoints *ClusterEndpoints `mandatory:"false" json:"endpoints"`
+
+	// Available Kubernetes versions to which the clusters masters may be upgraded.
+	AvailableKubernetesUpgrades []string `mandatory:"false" json:"availableKubernetesUpgrades"`
+
+	// The image verification policy for signature validation.
+	ImagePolicyConfig *ImagePolicyConfig `mandatory:"false" json:"imagePolicyConfig"`
+
+	// Available CNIs and network options for existing and new node pools of the cluster
+	ClusterPodNetworkOptions []ClusterPodNetworkOptionDetails `mandatory:"false" json:"clusterPodNetworkOptions"`
+
+	// Type of cluster. Values can be BASIC_CLUSTER or ENHANCED_CLUSTER. For more information, see Cluster Types (https://docs.cloud.oracle.com/Content/ContEng/Tasks/contengcomparingenhancedwithbasicclusters_topic.htm)
+	Type ClusterTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m ClusterSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ClusterSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingClusterLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetClusterLifecycleStateEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingClusterTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetClusterTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ClusterSummary) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                          *string                           `json:"id"`
+		Name                        *string                           `json:"name"`
+		CompartmentId               *string                           `json:"compartmentId"`
+		EndpointConfig              *ClusterEndpointConfig            `json:"endpointConfig"`
+		VcnId                       *string                           `json:"vcnId"`
+		KubernetesVersion           *string                           `json:"kubernetesVersion"`
+		FreeformTags                map[string]string                 `json:"freeformTags"`
+		DefinedTags                 map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags                  map[string]map[string]interface{} `json:"systemTags"`
+		Options                     *ClusterCreateOptions             `json:"options"`
+		Metadata                    *ClusterMetadata                  `json:"metadata"`
+		LifecycleState              ClusterLifecycleStateEnum         `json:"lifecycleState"`
+		LifecycleDetails            *string                           `json:"lifecycleDetails"`
+		Endpoints                   *ClusterEndpoints                 `json:"endpoints"`
+		AvailableKubernetesUpgrades []string                          `json:"availableKubernetesUpgrades"`
+		ImagePolicyConfig           *ImagePolicyConfig                `json:"imagePolicyConfig"`
+		ClusterPodNetworkOptions    []clusterpodnetworkoptiondetails  `json:"clusterPodNetworkOptions"`
+		Type                        ClusterTypeEnum                   `json:"type"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Id = model.Id
+
+	m.Name = model.Name
+
+	m.CompartmentId = model.CompartmentId
+
+	m.EndpointConfig = model.EndpointConfig
+
+	m.VcnId = model.VcnId
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.Options = model.Options
+
+	m.Metadata = model.Metadata
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.Endpoints = model.Endpoints
+
+	m.AvailableKubernetesUpgrades = make([]string, len(model.AvailableKubernetesUpgrades))
+	copy(m.AvailableKubernetesUpgrades, model.AvailableKubernetesUpgrades)
+	m.ImagePolicyConfig = model.ImagePolicyConfig
+
+	m.ClusterPodNetworkOptions = make([]ClusterPodNetworkOptionDetails, len(model.ClusterPodNetworkOptions))
+	for i, n := range model.ClusterPodNetworkOptions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ClusterPodNetworkOptions[i] = nn.(ClusterPodNetworkOptionDetails)
+		} else {
+			m.ClusterPodNetworkOptions[i] = nil
+		}
+	}
+	m.Type = model.Type
+
+	return
+}
+
+// ClusterSummaryLifecycleStateEnum is an alias to type: ClusterLifecycleStateEnum
+// Consider using ClusterLifecycleStateEnum instead
+// Deprecated
+type ClusterSummaryLifecycleStateEnum = ClusterLifecycleStateEnum
+
+// Set of constants representing the allowable values for ClusterLifecycleStateEnum
+// Deprecated
+const (
+	ClusterSummaryLifecycleStateCreating ClusterLifecycleStateEnum = "CREATING"
+	ClusterSummaryLifecycleStateActive   ClusterLifecycleStateEnum = "ACTIVE"
+	ClusterSummaryLifecycleStateFailed   ClusterLifecycleStateEnum = "FAILED"
+	ClusterSummaryLifecycleStateDeleting ClusterLifecycleStateEnum = "DELETING"
+	ClusterSummaryLifecycleStateDeleted  ClusterLifecycleStateEnum = "DELETED"
+	ClusterSummaryLifecycleStateUpdating ClusterLifecycleStateEnum = "UPDATING"
+)
+
+// GetClusterSummaryLifecycleStateEnumValues Enumerates the set of values for ClusterLifecycleStateEnum
+// Consider using GetClusterLifecycleStateEnumValue
+// Deprecated
+var GetClusterSummaryLifecycleStateEnumValues = GetClusterLifecycleStateEnumValues

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/cluster_type.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// ClusterTypeEnum Enum with underlying type: string
+type ClusterTypeEnum string
+
+// Set of constants representing the allowable values for ClusterTypeEnum
+const (
+	ClusterTypeBasicCluster    ClusterTypeEnum = "BASIC_CLUSTER"
+	ClusterTypeEnhancedCluster ClusterTypeEnum = "ENHANCED_CLUSTER"
+)
+
+var mappingClusterTypeEnum = map[string]ClusterTypeEnum{
+	"BASIC_CLUSTER":    ClusterTypeBasicCluster,
+	"ENHANCED_CLUSTER": ClusterTypeEnhancedCluster,
+}
+
+var mappingClusterTypeEnumLowerCase = map[string]ClusterTypeEnum{
+	"basic_cluster":    ClusterTypeBasicCluster,
+	"enhanced_cluster": ClusterTypeEnhancedCluster,
+}
+
+// GetClusterTypeEnumValues Enumerates the set of values for ClusterTypeEnum
+func GetClusterTypeEnumValues() []ClusterTypeEnum {
+	values := make([]ClusterTypeEnum, 0)
+	for _, v := range mappingClusterTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetClusterTypeEnumStringValues Enumerates the set of values in String for ClusterTypeEnum
+func GetClusterTypeEnumStringValues() []string {
+	return []string{
+		"BASIC_CLUSTER",
+		"ENHANCED_CLUSTER",
+	}
+}
+
+// GetMappingClusterTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingClusterTypeEnum(val string) (ClusterTypeEnum, bool) {
+	enum, ok := mappingClusterTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/complete_credential_rotation_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/complete_credential_rotation_request_response.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CompleteCredentialRotationRequest wrapper for the CompleteCredentialRotation operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CompleteCredentialRotation.go.html to see an example of how to use CompleteCredentialRotationRequest.
+type CompleteCredentialRotationRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CompleteCredentialRotationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CompleteCredentialRotationRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CompleteCredentialRotationRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CompleteCredentialRotationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CompleteCredentialRotationRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CompleteCredentialRotationResponse wrapper for the CompleteCredentialRotation operation
+type CompleteCredentialRotationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CompleteCredentialRotationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CompleteCredentialRotationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/containerengine_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/containerengine_client.go
@@ -1,0 +1,2680 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"context"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
+	"net/http"
+)
+
+// ContainerEngineClient a client for ContainerEngine
+type ContainerEngineClient struct {
+	common.BaseClient
+	config *common.ConfigurationProvider
+}
+
+// NewContainerEngineClientWithConfigurationProvider Creates a new default ContainerEngine client with the given configuration provider.
+// the configuration provider will be used for the default signer as well as reading the region
+func NewContainerEngineClientWithConfigurationProvider(configProvider common.ConfigurationProvider) (client ContainerEngineClient, err error) {
+	if enabled := common.CheckForEnabledServices("containerengine"); !enabled {
+		return client, fmt.Errorf("the Developer Tool configuration disabled this service, this behavior is controlled by OciSdkEnabledServicesMap variables. Please check if your local developer-tool-configuration.json file configured the service you're targeting or contact the cloud provider on the availability of this service")
+	}
+	provider, err := auth.GetGenericConfigurationProvider(configProvider)
+	if err != nil {
+		return client, err
+	}
+	baseClient, e := common.NewClientWithConfig(provider)
+	if e != nil {
+		return client, e
+	}
+	return newContainerEngineClientFromBaseClient(baseClient, provider)
+}
+
+// NewContainerEngineClientWithOboToken Creates a new default ContainerEngine client with the given configuration provider.
+// The obotoken will be added to default headers and signed; the configuration provider will be used for the signer
+//
+//	as well as reading the region
+func NewContainerEngineClientWithOboToken(configProvider common.ConfigurationProvider, oboToken string) (client ContainerEngineClient, err error) {
+	baseClient, err := common.NewClientWithOboToken(configProvider, oboToken)
+	if err != nil {
+		return client, err
+	}
+
+	return newContainerEngineClientFromBaseClient(baseClient, configProvider)
+}
+
+func newContainerEngineClientFromBaseClient(baseClient common.BaseClient, configProvider common.ConfigurationProvider) (client ContainerEngineClient, err error) {
+	// ContainerEngine service default circuit breaker is enabled
+	baseClient.Configuration.CircuitBreaker = common.NewCircuitBreaker(common.DefaultCircuitBreakerSettingWithServiceName("ContainerEngine"))
+	common.ConfigCircuitBreakerFromEnvVar(&baseClient)
+	common.ConfigCircuitBreakerFromGlobalVar(&baseClient)
+
+	client = ContainerEngineClient{BaseClient: baseClient}
+	client.BasePath = "20180222"
+	err = client.setConfigurationProvider(configProvider)
+	return
+}
+
+// SetRegion overrides the region of this client.
+func (client *ContainerEngineClient) SetRegion(region string) {
+	client.Host = common.StringToRegion(region).EndpointForTemplate("containerengine", "https://containerengine.{region}.oci.{secondLevelDomain}")
+}
+
+// SetConfigurationProvider sets the configuration provider including the region, returns an error if is not valid
+func (client *ContainerEngineClient) setConfigurationProvider(configProvider common.ConfigurationProvider) error {
+	if ok, err := common.IsConfigurationProviderValid(configProvider); !ok {
+		return err
+	}
+
+	// Error has been checked already
+	region, _ := configProvider.Region()
+	client.SetRegion(region)
+	if client.Host == "" {
+		return fmt.Errorf("invalid region or Host. Endpoint cannot be constructed without endpointServiceName or serviceEndpointTemplate for a dotted region")
+	}
+	client.config = &configProvider
+	return nil
+}
+
+// ConfigurationProvider the ConfigurationProvider used in this client, or null if none set
+func (client *ContainerEngineClient) ConfigurationProvider() *common.ConfigurationProvider {
+	return client.config
+}
+
+// ClusterMigrateToNativeVcn Initiates cluster migration to use native VCN.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ClusterMigrateToNativeVcn.go.html to see an example of how to use ClusterMigrateToNativeVcn API.
+// A default retry strategy applies to this operation ClusterMigrateToNativeVcn()
+func (client ContainerEngineClient) ClusterMigrateToNativeVcn(ctx context.Context, request ClusterMigrateToNativeVcnRequest) (response ClusterMigrateToNativeVcnResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.clusterMigrateToNativeVcn, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ClusterMigrateToNativeVcnResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ClusterMigrateToNativeVcnResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ClusterMigrateToNativeVcnResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ClusterMigrateToNativeVcnResponse")
+	}
+	return
+}
+
+// clusterMigrateToNativeVcn implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) clusterMigrateToNativeVcn(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/actions/migrateToNativeVcn", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ClusterMigrateToNativeVcnResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/ClusterMigrateToNativeVcn"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ClusterMigrateToNativeVcn", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CompleteCredentialRotation Complete cluster credential rotation. Retire old credentials from kubernetes components.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CompleteCredentialRotation.go.html to see an example of how to use CompleteCredentialRotation API.
+// A default retry strategy applies to this operation CompleteCredentialRotation()
+func (client ContainerEngineClient) CompleteCredentialRotation(ctx context.Context, request CompleteCredentialRotationRequest) (response CompleteCredentialRotationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.completeCredentialRotation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CompleteCredentialRotationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CompleteCredentialRotationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CompleteCredentialRotationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CompleteCredentialRotationResponse")
+	}
+	return
+}
+
+// completeCredentialRotation implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) completeCredentialRotation(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/actions/completeCredentialRotation", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CompleteCredentialRotationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/CompleteCredentialRotation"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CompleteCredentialRotation", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateCluster Create a new cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateCluster.go.html to see an example of how to use CreateCluster API.
+// A default retry strategy applies to this operation CreateCluster()
+func (client ContainerEngineClient) CreateCluster(ctx context.Context, request CreateClusterRequest) (response CreateClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateClusterResponse")
+	}
+	return
+}
+
+// createCluster implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/CreateCluster"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateCluster", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateKubeconfig Create the Kubeconfig YAML for a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateKubeconfig.go.html to see an example of how to use CreateKubeconfig API.
+// A default retry strategy applies to this operation CreateKubeconfig()
+func (client ContainerEngineClient) CreateKubeconfig(ctx context.Context, request CreateKubeconfigRequest) (response CreateKubeconfigResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.createKubeconfig, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateKubeconfigResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateKubeconfigResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateKubeconfigResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateKubeconfigResponse")
+	}
+	return
+}
+
+// createKubeconfig implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createKubeconfig(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/kubeconfig/content", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateKubeconfigResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/CreateKubeconfig"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateKubeconfig", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateNodePool Create a new node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateNodePool.go.html to see an example of how to use CreateNodePool API.
+// A default retry strategy applies to this operation CreateNodePool()
+func (client ContainerEngineClient) CreateNodePool(ctx context.Context, request CreateNodePoolRequest) (response CreateNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateNodePoolResponse")
+	}
+	return
+}
+
+// createNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/nodePools", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/CreateNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateVirtualNodePool Create a new virtual node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateVirtualNodePool.go.html to see an example of how to use CreateVirtualNodePool API.
+// A default retry strategy applies to this operation CreateVirtualNodePool()
+func (client ContainerEngineClient) CreateVirtualNodePool(ctx context.Context, request CreateVirtualNodePoolRequest) (response CreateVirtualNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createVirtualNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateVirtualNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateVirtualNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateVirtualNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateVirtualNodePoolResponse")
+	}
+	return
+}
+
+// createVirtualNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createVirtualNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/virtualNodePools", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateVirtualNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/CreateVirtualNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateVirtualNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateWorkloadMapping Create the specified workloadMapping for a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateWorkloadMapping.go.html to see an example of how to use CreateWorkloadMapping API.
+// A default retry strategy applies to this operation CreateWorkloadMapping()
+func (client ContainerEngineClient) CreateWorkloadMapping(ctx context.Context, request CreateWorkloadMappingRequest) (response CreateWorkloadMappingResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createWorkloadMapping, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateWorkloadMappingResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateWorkloadMappingResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateWorkloadMappingResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateWorkloadMappingResponse")
+	}
+	return
+}
+
+// createWorkloadMapping implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) createWorkloadMapping(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/workloadMappings", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateWorkloadMappingResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkloadMapping/CreateWorkloadMapping"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "CreateWorkloadMapping", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteCluster Delete a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteCluster.go.html to see an example of how to use DeleteCluster API.
+// A default retry strategy applies to this operation DeleteCluster()
+func (client ContainerEngineClient) DeleteCluster(ctx context.Context, request DeleteClusterRequest) (response DeleteClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteClusterResponse")
+	}
+	return
+}
+
+// deleteCluster implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/clusters/{clusterId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/DeleteCluster"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteCluster", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteNode Delete node.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteNode.go.html to see an example of how to use DeleteNode API.
+// A default retry strategy applies to this operation DeleteNode()
+func (client ContainerEngineClient) DeleteNode(ctx context.Context, request DeleteNodeRequest) (response DeleteNodeResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteNode, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteNodeResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteNodeResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteNodeResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteNodeResponse")
+	}
+	return
+}
+
+// deleteNode implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteNode(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/nodePools/{nodePoolId}/node/{nodeId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteNodeResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/DeleteNode"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteNode", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteNodePool Delete a node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteNodePool.go.html to see an example of how to use DeleteNodePool API.
+// A default retry strategy applies to this operation DeleteNodePool()
+func (client ContainerEngineClient) DeleteNodePool(ctx context.Context, request DeleteNodePoolRequest) (response DeleteNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteNodePoolResponse")
+	}
+	return
+}
+
+// deleteNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/nodePools/{nodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/DeleteNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteVirtualNodePool Delete a virtual node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteVirtualNodePool.go.html to see an example of how to use DeleteVirtualNodePool API.
+// A default retry strategy applies to this operation DeleteVirtualNodePool()
+func (client ContainerEngineClient) DeleteVirtualNodePool(ctx context.Context, request DeleteVirtualNodePoolRequest) (response DeleteVirtualNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteVirtualNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteVirtualNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteVirtualNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteVirtualNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteVirtualNodePoolResponse")
+	}
+	return
+}
+
+// deleteVirtualNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteVirtualNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/virtualNodePools/{virtualNodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteVirtualNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/DeleteVirtualNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteVirtualNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteWorkRequest Cancel a work request that has not started.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteWorkRequest.go.html to see an example of how to use DeleteWorkRequest API.
+// A default retry strategy applies to this operation DeleteWorkRequest()
+func (client ContainerEngineClient) DeleteWorkRequest(ctx context.Context, request DeleteWorkRequestRequest) (response DeleteWorkRequestResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteWorkRequest, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteWorkRequestResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteWorkRequestResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteWorkRequestResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteWorkRequestResponse")
+	}
+	return
+}
+
+// deleteWorkRequest implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteWorkRequest(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/workRequests/{workRequestId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteWorkRequestResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequest/DeleteWorkRequest"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteWorkRequest", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteWorkloadMapping Delete workloadMapping for a provisioned cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteWorkloadMapping.go.html to see an example of how to use DeleteWorkloadMapping API.
+// A default retry strategy applies to this operation DeleteWorkloadMapping()
+func (client ContainerEngineClient) DeleteWorkloadMapping(ctx context.Context, request DeleteWorkloadMappingRequest) (response DeleteWorkloadMappingResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteWorkloadMapping, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteWorkloadMappingResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteWorkloadMappingResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteWorkloadMappingResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteWorkloadMappingResponse")
+	}
+	return
+}
+
+// deleteWorkloadMapping implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) deleteWorkloadMapping(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/clusters/{clusterId}/workloadMappings/{workloadMappingId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteWorkloadMappingResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkloadMapping/DeleteWorkloadMapping"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DeleteWorkloadMapping", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DisableAddon Disable addon for a provisioned cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DisableAddon.go.html to see an example of how to use DisableAddon API.
+// A default retry strategy applies to this operation DisableAddon()
+func (client ContainerEngineClient) DisableAddon(ctx context.Context, request DisableAddonRequest) (response DisableAddonResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.disableAddon, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DisableAddonResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DisableAddonResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DisableAddonResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DisableAddonResponse")
+	}
+	return
+}
+
+// disableAddon implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) disableAddon(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/clusters/{clusterId}/addons/{addonName}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response DisableAddonResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/DisableAddon"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "DisableAddon", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetAddon Get the specified addon for a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetAddon.go.html to see an example of how to use GetAddon API.
+// A default retry strategy applies to this operation GetAddon()
+func (client ContainerEngineClient) GetAddon(ctx context.Context, request GetAddonRequest) (response GetAddonResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getAddon, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetAddonResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetAddonResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetAddonResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetAddonResponse")
+	}
+	return
+}
+
+// getAddon implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getAddon(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/addons/{addonName}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetAddonResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/GetAddon"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetAddon", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetCluster Get the details of a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetCluster.go.html to see an example of how to use GetCluster API.
+// A default retry strategy applies to this operation GetCluster()
+func (client ContainerEngineClient) GetCluster(ctx context.Context, request GetClusterRequest) (response GetClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetClusterResponse")
+	}
+	return
+}
+
+// getCluster implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/GetCluster"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetCluster", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetClusterMigrateToNativeVcnStatus Get details on a cluster's migration to native VCN.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetClusterMigrateToNativeVcnStatus.go.html to see an example of how to use GetClusterMigrateToNativeVcnStatus API.
+// A default retry strategy applies to this operation GetClusterMigrateToNativeVcnStatus()
+func (client ContainerEngineClient) GetClusterMigrateToNativeVcnStatus(ctx context.Context, request GetClusterMigrateToNativeVcnStatusRequest) (response GetClusterMigrateToNativeVcnStatusResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getClusterMigrateToNativeVcnStatus, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetClusterMigrateToNativeVcnStatusResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetClusterMigrateToNativeVcnStatusResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetClusterMigrateToNativeVcnStatusResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetClusterMigrateToNativeVcnStatusResponse")
+	}
+	return
+}
+
+// getClusterMigrateToNativeVcnStatus implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getClusterMigrateToNativeVcnStatus(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/migrateToNativeVcnStatus", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetClusterMigrateToNativeVcnStatusResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/ClusterMigrateToNativeVcnStatus/GetClusterMigrateToNativeVcnStatus"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetClusterMigrateToNativeVcnStatus", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetClusterOptions Get options available for clusters.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetClusterOptions.go.html to see an example of how to use GetClusterOptions API.
+// A default retry strategy applies to this operation GetClusterOptions()
+func (client ContainerEngineClient) GetClusterOptions(ctx context.Context, request GetClusterOptionsRequest) (response GetClusterOptionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getClusterOptions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetClusterOptionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetClusterOptionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetClusterOptionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetClusterOptionsResponse")
+	}
+	return
+}
+
+// getClusterOptions implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getClusterOptions(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusterOptions/{clusterOptionId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetClusterOptionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/ClusterOptions/GetClusterOptions"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetClusterOptions", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetCredentialRotationStatus Get cluster credential rotation status.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetCredentialRotationStatus.go.html to see an example of how to use GetCredentialRotationStatus API.
+// A default retry strategy applies to this operation GetCredentialRotationStatus()
+func (client ContainerEngineClient) GetCredentialRotationStatus(ctx context.Context, request GetCredentialRotationStatusRequest) (response GetCredentialRotationStatusResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getCredentialRotationStatus, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetCredentialRotationStatusResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetCredentialRotationStatusResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetCredentialRotationStatusResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetCredentialRotationStatusResponse")
+	}
+	return
+}
+
+// getCredentialRotationStatus implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getCredentialRotationStatus(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/credentialRotationStatus", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetCredentialRotationStatusResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/CredentialRotationStatus/GetCredentialRotationStatus"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetCredentialRotationStatus", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetNodePool Get the details of a node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetNodePool.go.html to see an example of how to use GetNodePool API.
+// A default retry strategy applies to this operation GetNodePool()
+func (client ContainerEngineClient) GetNodePool(ctx context.Context, request GetNodePoolRequest) (response GetNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetNodePoolResponse")
+	}
+	return
+}
+
+// getNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/nodePools/{nodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/GetNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetNodePoolOptions Get options available for node pools.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetNodePoolOptions.go.html to see an example of how to use GetNodePoolOptions API.
+// A default retry strategy applies to this operation GetNodePoolOptions()
+func (client ContainerEngineClient) GetNodePoolOptions(ctx context.Context, request GetNodePoolOptionsRequest) (response GetNodePoolOptionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getNodePoolOptions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetNodePoolOptionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetNodePoolOptionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetNodePoolOptionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetNodePoolOptionsResponse")
+	}
+	return
+}
+
+// getNodePoolOptions implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getNodePoolOptions(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/nodePoolOptions/{nodePoolOptionId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetNodePoolOptionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePoolOptions/GetNodePoolOptions"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetNodePoolOptions", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetVirtualNode Get the details of a virtual node.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetVirtualNode.go.html to see an example of how to use GetVirtualNode API.
+// A default retry strategy applies to this operation GetVirtualNode()
+func (client ContainerEngineClient) GetVirtualNode(ctx context.Context, request GetVirtualNodeRequest) (response GetVirtualNodeResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getVirtualNode, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetVirtualNodeResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetVirtualNodeResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetVirtualNodeResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetVirtualNodeResponse")
+	}
+	return
+}
+
+// getVirtualNode implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getVirtualNode(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/virtualNodePools/{virtualNodePoolId}/virtualNodes/{virtualNodeId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetVirtualNodeResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/GetVirtualNode"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetVirtualNode", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetVirtualNodePool Get the details of a virtual node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetVirtualNodePool.go.html to see an example of how to use GetVirtualNodePool API.
+// A default retry strategy applies to this operation GetVirtualNodePool()
+func (client ContainerEngineClient) GetVirtualNodePool(ctx context.Context, request GetVirtualNodePoolRequest) (response GetVirtualNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getVirtualNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetVirtualNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetVirtualNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetVirtualNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetVirtualNodePoolResponse")
+	}
+	return
+}
+
+// getVirtualNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getVirtualNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/virtualNodePools/{virtualNodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetVirtualNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/GetVirtualNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetVirtualNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetWorkRequest Get the details of a work request.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetWorkRequest.go.html to see an example of how to use GetWorkRequest API.
+// A default retry strategy applies to this operation GetWorkRequest()
+func (client ContainerEngineClient) GetWorkRequest(ctx context.Context, request GetWorkRequestRequest) (response GetWorkRequestResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWorkRequest, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetWorkRequestResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetWorkRequestResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWorkRequestResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWorkRequestResponse")
+	}
+	return
+}
+
+// getWorkRequest implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getWorkRequest(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWorkRequestResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequest/GetWorkRequest"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetWorkRequest", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetWorkloadMapping Get the specified workloadMapping for a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetWorkloadMapping.go.html to see an example of how to use GetWorkloadMapping API.
+// A default retry strategy applies to this operation GetWorkloadMapping()
+func (client ContainerEngineClient) GetWorkloadMapping(ctx context.Context, request GetWorkloadMappingRequest) (response GetWorkloadMappingResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getWorkloadMapping, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetWorkloadMappingResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetWorkloadMappingResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetWorkloadMappingResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetWorkloadMappingResponse")
+	}
+	return
+}
+
+// getWorkloadMapping implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) getWorkloadMapping(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/workloadMappings/{workloadMappingId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetWorkloadMappingResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkloadMapping/GetWorkloadMapping"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "GetWorkloadMapping", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// InstallAddon Install the specified addon for a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/InstallAddon.go.html to see an example of how to use InstallAddon API.
+// A default retry strategy applies to this operation InstallAddon()
+func (client ContainerEngineClient) InstallAddon(ctx context.Context, request InstallAddonRequest) (response InstallAddonResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.installAddon, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = InstallAddonResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = InstallAddonResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(InstallAddonResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into InstallAddonResponse")
+	}
+	return
+}
+
+// installAddon implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) installAddon(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/addons", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response InstallAddonResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/InstallAddon"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "InstallAddon", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListAddonOptions Get list of supported addons for a specific kubernetes version.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListAddonOptions.go.html to see an example of how to use ListAddonOptions API.
+// A default retry strategy applies to this operation ListAddonOptions()
+func (client ContainerEngineClient) ListAddonOptions(ctx context.Context, request ListAddonOptionsRequest) (response ListAddonOptionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listAddonOptions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListAddonOptionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListAddonOptionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListAddonOptionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListAddonOptionsResponse")
+	}
+	return
+}
+
+// listAddonOptions implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listAddonOptions(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/addonOptions", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListAddonOptionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/AddonOptionSummary/ListAddonOptions"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListAddonOptions", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListAddons List addon for a provisioned cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListAddons.go.html to see an example of how to use ListAddons API.
+// A default retry strategy applies to this operation ListAddons()
+func (client ContainerEngineClient) ListAddons(ctx context.Context, request ListAddonsRequest) (response ListAddonsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listAddons, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListAddonsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListAddonsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListAddonsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListAddonsResponse")
+	}
+	return
+}
+
+// listAddons implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listAddons(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/addons", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListAddonsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/ListAddons"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListAddons", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListClusters List all the cluster objects in a compartment.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListClusters.go.html to see an example of how to use ListClusters API.
+// A default retry strategy applies to this operation ListClusters()
+func (client ContainerEngineClient) ListClusters(ctx context.Context, request ListClustersRequest) (response ListClustersResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listClusters, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListClustersResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListClustersResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListClustersResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListClustersResponse")
+	}
+	return
+}
+
+// listClusters implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listClusters(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListClustersResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/ClusterSummary/ListClusters"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListClusters", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListNodePools List all the node pools in a compartment, and optionally filter by cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListNodePools.go.html to see an example of how to use ListNodePools API.
+// A default retry strategy applies to this operation ListNodePools()
+func (client ContainerEngineClient) ListNodePools(ctx context.Context, request ListNodePoolsRequest) (response ListNodePoolsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listNodePools, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListNodePoolsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListNodePoolsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListNodePoolsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListNodePoolsResponse")
+	}
+	return
+}
+
+// listNodePools implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listNodePools(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/nodePools", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListNodePoolsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePoolSummary/ListNodePools"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListNodePools", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListPodShapes List all the Pod Shapes in a compartment.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListPodShapes.go.html to see an example of how to use ListPodShapes API.
+// A default retry strategy applies to this operation ListPodShapes()
+func (client ContainerEngineClient) ListPodShapes(ctx context.Context, request ListPodShapesRequest) (response ListPodShapesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listPodShapes, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListPodShapesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListPodShapesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListPodShapesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListPodShapesResponse")
+	}
+	return
+}
+
+// listPodShapes implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listPodShapes(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/podShapes", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListPodShapesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/PodShapeSummary/ListPodShapes"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListPodShapes", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListVirtualNodePools List all the virtual node pools in a compartment, and optionally filter by cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListVirtualNodePools.go.html to see an example of how to use ListVirtualNodePools API.
+// A default retry strategy applies to this operation ListVirtualNodePools()
+func (client ContainerEngineClient) ListVirtualNodePools(ctx context.Context, request ListVirtualNodePoolsRequest) (response ListVirtualNodePoolsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listVirtualNodePools, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListVirtualNodePoolsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListVirtualNodePoolsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListVirtualNodePoolsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListVirtualNodePoolsResponse")
+	}
+	return
+}
+
+// listVirtualNodePools implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listVirtualNodePools(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/virtualNodePools", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListVirtualNodePoolsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePoolSummary/ListVirtualNodePools"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListVirtualNodePools", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListVirtualNodes List virtual nodes in a virtual node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListVirtualNodes.go.html to see an example of how to use ListVirtualNodes API.
+// A default retry strategy applies to this operation ListVirtualNodes()
+func (client ContainerEngineClient) ListVirtualNodes(ctx context.Context, request ListVirtualNodesRequest) (response ListVirtualNodesResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listVirtualNodes, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListVirtualNodesResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListVirtualNodesResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListVirtualNodesResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListVirtualNodesResponse")
+	}
+	return
+}
+
+// listVirtualNodes implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listVirtualNodes(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/virtualNodePools/{virtualNodePoolId}/virtualNodes", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListVirtualNodesResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/ListVirtualNodes"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListVirtualNodes", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestErrors Get the errors of a work request.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequestErrors.go.html to see an example of how to use ListWorkRequestErrors API.
+// A default retry strategy applies to this operation ListWorkRequestErrors()
+func (client ContainerEngineClient) ListWorkRequestErrors(ctx context.Context, request ListWorkRequestErrorsRequest) (response ListWorkRequestErrorsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestErrors, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestErrorsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestErrorsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestErrorsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestErrorsResponse")
+	}
+	return
+}
+
+// listWorkRequestErrors implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listWorkRequestErrors(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/errors", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestErrorsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequestError/ListWorkRequestErrors"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListWorkRequestErrors", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequestLogs Get the logs of a work request.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequestLogs.go.html to see an example of how to use ListWorkRequestLogs API.
+// A default retry strategy applies to this operation ListWorkRequestLogs()
+func (client ContainerEngineClient) ListWorkRequestLogs(ctx context.Context, request ListWorkRequestLogsRequest) (response ListWorkRequestLogsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequestLogs, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestLogsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestLogsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestLogsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestLogsResponse")
+	}
+	return
+}
+
+// listWorkRequestLogs implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listWorkRequestLogs(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests/{workRequestId}/logs", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestLogsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequestLogEntry/ListWorkRequestLogs"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListWorkRequestLogs", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkRequests List all work requests in a compartment.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequests.go.html to see an example of how to use ListWorkRequests API.
+// A default retry strategy applies to this operation ListWorkRequests()
+func (client ContainerEngineClient) ListWorkRequests(ctx context.Context, request ListWorkRequestsRequest) (response ListWorkRequestsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkRequests, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkRequestsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkRequestsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkRequestsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkRequestsResponse")
+	}
+	return
+}
+
+// listWorkRequests implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listWorkRequests(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/workRequests", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkRequestsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkRequestSummary/ListWorkRequests"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListWorkRequests", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListWorkloadMappings List workloadMappings for a provisioned cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkloadMappings.go.html to see an example of how to use ListWorkloadMappings API.
+// A default retry strategy applies to this operation ListWorkloadMappings()
+func (client ContainerEngineClient) ListWorkloadMappings(ctx context.Context, request ListWorkloadMappingsRequest) (response ListWorkloadMappingsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listWorkloadMappings, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListWorkloadMappingsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListWorkloadMappingsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListWorkloadMappingsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListWorkloadMappingsResponse")
+	}
+	return
+}
+
+// listWorkloadMappings implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) listWorkloadMappings(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/clusters/{clusterId}/workloadMappings", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListWorkloadMappingsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkloadMappingSummary/ListWorkloadMappings"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "ListWorkloadMappings", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// StartCredentialRotation Start cluster credential rotation by adding new credentials, old credentials will still work after this operation.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/StartCredentialRotation.go.html to see an example of how to use StartCredentialRotation API.
+// A default retry strategy applies to this operation StartCredentialRotation()
+func (client ContainerEngineClient) StartCredentialRotation(ctx context.Context, request StartCredentialRotationRequest) (response StartCredentialRotationResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.startCredentialRotation, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = StartCredentialRotationResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = StartCredentialRotationResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(StartCredentialRotationResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into StartCredentialRotationResponse")
+	}
+	return
+}
+
+// startCredentialRotation implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) startCredentialRotation(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/actions/startCredentialRotation", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response StartCredentialRotationResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/StartCredentialRotation"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "StartCredentialRotation", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateAddon Update addon details for a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateAddon.go.html to see an example of how to use UpdateAddon API.
+// A default retry strategy applies to this operation UpdateAddon()
+func (client ContainerEngineClient) UpdateAddon(ctx context.Context, request UpdateAddonRequest) (response UpdateAddonResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateAddon, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateAddonResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateAddonResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateAddonResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateAddonResponse")
+	}
+	return
+}
+
+// updateAddon implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateAddon(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/clusters/{clusterId}/addons/{addonName}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateAddonResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/UpdateAddon"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateAddon", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateCluster Update the details of a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateCluster.go.html to see an example of how to use UpdateCluster API.
+// A default retry strategy applies to this operation UpdateCluster()
+func (client ContainerEngineClient) UpdateCluster(ctx context.Context, request UpdateClusterRequest) (response UpdateClusterResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateCluster, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateClusterResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateClusterResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateClusterResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateClusterResponse")
+	}
+	return
+}
+
+// updateCluster implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateCluster(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/clusters/{clusterId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateClusterResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/UpdateCluster"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateCluster", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateClusterEndpointConfig Update the details of the cluster endpoint configuration.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateClusterEndpointConfig.go.html to see an example of how to use UpdateClusterEndpointConfig API.
+// A default retry strategy applies to this operation UpdateClusterEndpointConfig()
+func (client ContainerEngineClient) UpdateClusterEndpointConfig(ctx context.Context, request UpdateClusterEndpointConfigRequest) (response UpdateClusterEndpointConfigResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateClusterEndpointConfig, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateClusterEndpointConfigResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateClusterEndpointConfigResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateClusterEndpointConfigResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateClusterEndpointConfigResponse")
+	}
+	return
+}
+
+// updateClusterEndpointConfig implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateClusterEndpointConfig(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/clusters/{clusterId}/actions/updateEndpointConfig", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateClusterEndpointConfigResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/Cluster/UpdateClusterEndpointConfig"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateClusterEndpointConfig", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateNodePool Update the details of a node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateNodePool.go.html to see an example of how to use UpdateNodePool API.
+// A default retry strategy applies to this operation UpdateNodePool()
+func (client ContainerEngineClient) UpdateNodePool(ctx context.Context, request UpdateNodePoolRequest) (response UpdateNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateNodePoolResponse")
+	}
+	return
+}
+
+// updateNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/nodePools/{nodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/NodePool/UpdateNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateVirtualNodePool Update the details of a virtual node pool.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateVirtualNodePool.go.html to see an example of how to use UpdateVirtualNodePool API.
+// A default retry strategy applies to this operation UpdateVirtualNodePool()
+func (client ContainerEngineClient) UpdateVirtualNodePool(ctx context.Context, request UpdateVirtualNodePoolRequest) (response UpdateVirtualNodePoolResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateVirtualNodePool, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateVirtualNodePoolResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateVirtualNodePoolResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateVirtualNodePoolResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateVirtualNodePoolResponse")
+	}
+	return
+}
+
+// updateVirtualNodePool implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateVirtualNodePool(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/virtualNodePools/{virtualNodePoolId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateVirtualNodePoolResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/VirtualNodePool/UpdateVirtualNodePool"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateVirtualNodePool", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateWorkloadMapping Update workloadMapping details for a cluster.
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateWorkloadMapping.go.html to see an example of how to use UpdateWorkloadMapping API.
+// A default retry strategy applies to this operation UpdateWorkloadMapping()
+func (client ContainerEngineClient) UpdateWorkloadMapping(ctx context.Context, request UpdateWorkloadMappingRequest) (response UpdateWorkloadMappingResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.DefaultRetryPolicy()
+	if client.RetryPolicy() != nil {
+		policy = *client.RetryPolicy()
+	}
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateWorkloadMapping, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateWorkloadMappingResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateWorkloadMappingResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateWorkloadMappingResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateWorkloadMappingResponse")
+	}
+	return
+}
+
+// updateWorkloadMapping implements the OCIOperation interface (enables retrying operations)
+func (client ContainerEngineClient) updateWorkloadMapping(ctx context.Context, request common.OCIRequest, binaryReqBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (common.OCIResponse, error) {
+
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/clusters/{clusterId}/workloadMappings/{workloadMappingId}", binaryReqBody, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateWorkloadMappingResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		apiReferenceLink := "https://docs.oracle.com/iaas/api/#/en/containerengine/20180222/WorkloadMapping/UpdateWorkloadMapping"
+		err = common.PostProcessServiceError(err, "ContainerEngine", "UpdateWorkloadMapping", apiReferenceLink)
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_details.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateClusterDetails The properties that define a request to create a cluster.
+type CreateClusterDetails struct {
+
+	// The name of the cluster. Avoid entering confidential information.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The OCID of the compartment in which to create the cluster.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID of the virtual cloud network (VCN) in which to create the cluster.
+	VcnId *string `mandatory:"true" json:"vcnId"`
+
+	// The version of Kubernetes to install into the cluster masters.
+	KubernetesVersion *string `mandatory:"true" json:"kubernetesVersion"`
+
+	// The network configuration for access to the Cluster control plane.
+	EndpointConfig *CreateClusterEndpointConfigDetails `mandatory:"false" json:"endpointConfig"`
+
+	// The OCID of the KMS key to be used as the master encryption key for Kubernetes secret encryption.
+	// When used, `kubernetesVersion` must be at least `v1.13.0`.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Optional attributes for the cluster.
+	Options *ClusterCreateOptions `mandatory:"false" json:"options"`
+
+	// The image verification policy for signature validation. Once a policy is created and enabled with
+	// one or more kms keys, the policy will ensure all images deployed has been signed with the key(s)
+	// attached to the policy.
+	ImagePolicyConfig *CreateImagePolicyConfigDetails `mandatory:"false" json:"imagePolicyConfig"`
+
+	// Available CNIs and network options for existing and new node pools of the cluster
+	ClusterPodNetworkOptions []ClusterPodNetworkOptionDetails `mandatory:"false" json:"clusterPodNetworkOptions"`
+
+	// Type of cluster
+	Type ClusterTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m CreateClusterDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateClusterDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingClusterTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetClusterTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateClusterDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		EndpointConfig           *CreateClusterEndpointConfigDetails `json:"endpointConfig"`
+		KmsKeyId                 *string                             `json:"kmsKeyId"`
+		FreeformTags             map[string]string                   `json:"freeformTags"`
+		DefinedTags              map[string]map[string]interface{}   `json:"definedTags"`
+		Options                  *ClusterCreateOptions               `json:"options"`
+		ImagePolicyConfig        *CreateImagePolicyConfigDetails     `json:"imagePolicyConfig"`
+		ClusterPodNetworkOptions []clusterpodnetworkoptiondetails    `json:"clusterPodNetworkOptions"`
+		Type                     ClusterTypeEnum                     `json:"type"`
+		Name                     *string                             `json:"name"`
+		CompartmentId            *string                             `json:"compartmentId"`
+		VcnId                    *string                             `json:"vcnId"`
+		KubernetesVersion        *string                             `json:"kubernetesVersion"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.EndpointConfig = model.EndpointConfig
+
+	m.KmsKeyId = model.KmsKeyId
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.Options = model.Options
+
+	m.ImagePolicyConfig = model.ImagePolicyConfig
+
+	m.ClusterPodNetworkOptions = make([]ClusterPodNetworkOptionDetails, len(model.ClusterPodNetworkOptions))
+	for i, n := range model.ClusterPodNetworkOptions {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.ClusterPodNetworkOptions[i] = nn.(ClusterPodNetworkOptionDetails)
+		} else {
+			m.ClusterPodNetworkOptions[i] = nil
+		}
+	}
+	m.Type = model.Type
+
+	m.Name = model.Name
+
+	m.CompartmentId = model.CompartmentId
+
+	m.VcnId = model.VcnId
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_endpoint_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_endpoint_config_details.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateClusterEndpointConfigDetails The properties that define the network configuration for the Cluster endpoint.
+type CreateClusterEndpointConfigDetails struct {
+
+	// The OCID of the regional subnet in which to place the Cluster endpoint.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+	IsPublicIpEnabled *bool `mandatory:"false" json:"isPublicIpEnabled"`
+}
+
+func (m CreateClusterEndpointConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateClusterEndpointConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_kubeconfig_content_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_kubeconfig_content_details.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateClusterKubeconfigContentDetails The properties that define a request to create a cluster kubeconfig.
+type CreateClusterKubeconfigContentDetails struct {
+
+	// The version of the kubeconfig token. Supported value 2.0.0
+	TokenVersion *string `mandatory:"false" json:"tokenVersion"`
+
+	// Deprecated. This field is no longer used.
+	Expiration *int `mandatory:"false" json:"expiration"`
+
+	// The endpoint to target. A cluster may have multiple endpoints exposed but the kubeconfig can only target one at a time.
+	Endpoint CreateClusterKubeconfigContentDetailsEndpointEnum `mandatory:"false" json:"endpoint,omitempty"`
+}
+
+func (m CreateClusterKubeconfigContentDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateClusterKubeconfigContentDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingCreateClusterKubeconfigContentDetailsEndpointEnum(string(m.Endpoint)); !ok && m.Endpoint != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Endpoint: %s. Supported values are: %s.", m.Endpoint, strings.Join(GetCreateClusterKubeconfigContentDetailsEndpointEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateClusterKubeconfigContentDetailsEndpointEnum Enum with underlying type: string
+type CreateClusterKubeconfigContentDetailsEndpointEnum string
+
+// Set of constants representing the allowable values for CreateClusterKubeconfigContentDetailsEndpointEnum
+const (
+	CreateClusterKubeconfigContentDetailsEndpointLegacyKubernetes CreateClusterKubeconfigContentDetailsEndpointEnum = "LEGACY_KUBERNETES"
+	CreateClusterKubeconfigContentDetailsEndpointPublicEndpoint   CreateClusterKubeconfigContentDetailsEndpointEnum = "PUBLIC_ENDPOINT"
+	CreateClusterKubeconfigContentDetailsEndpointPrivateEndpoint  CreateClusterKubeconfigContentDetailsEndpointEnum = "PRIVATE_ENDPOINT"
+	CreateClusterKubeconfigContentDetailsEndpointVcnHostname      CreateClusterKubeconfigContentDetailsEndpointEnum = "VCN_HOSTNAME"
+)
+
+var mappingCreateClusterKubeconfigContentDetailsEndpointEnum = map[string]CreateClusterKubeconfigContentDetailsEndpointEnum{
+	"LEGACY_KUBERNETES": CreateClusterKubeconfigContentDetailsEndpointLegacyKubernetes,
+	"PUBLIC_ENDPOINT":   CreateClusterKubeconfigContentDetailsEndpointPublicEndpoint,
+	"PRIVATE_ENDPOINT":  CreateClusterKubeconfigContentDetailsEndpointPrivateEndpoint,
+	"VCN_HOSTNAME":      CreateClusterKubeconfigContentDetailsEndpointVcnHostname,
+}
+
+var mappingCreateClusterKubeconfigContentDetailsEndpointEnumLowerCase = map[string]CreateClusterKubeconfigContentDetailsEndpointEnum{
+	"legacy_kubernetes": CreateClusterKubeconfigContentDetailsEndpointLegacyKubernetes,
+	"public_endpoint":   CreateClusterKubeconfigContentDetailsEndpointPublicEndpoint,
+	"private_endpoint":  CreateClusterKubeconfigContentDetailsEndpointPrivateEndpoint,
+	"vcn_hostname":      CreateClusterKubeconfigContentDetailsEndpointVcnHostname,
+}
+
+// GetCreateClusterKubeconfigContentDetailsEndpointEnumValues Enumerates the set of values for CreateClusterKubeconfigContentDetailsEndpointEnum
+func GetCreateClusterKubeconfigContentDetailsEndpointEnumValues() []CreateClusterKubeconfigContentDetailsEndpointEnum {
+	values := make([]CreateClusterKubeconfigContentDetailsEndpointEnum, 0)
+	for _, v := range mappingCreateClusterKubeconfigContentDetailsEndpointEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetCreateClusterKubeconfigContentDetailsEndpointEnumStringValues Enumerates the set of values in String for CreateClusterKubeconfigContentDetailsEndpointEnum
+func GetCreateClusterKubeconfigContentDetailsEndpointEnumStringValues() []string {
+	return []string{
+		"LEGACY_KUBERNETES",
+		"PUBLIC_ENDPOINT",
+		"PRIVATE_ENDPOINT",
+		"VCN_HOSTNAME",
+	}
+}
+
+// GetMappingCreateClusterKubeconfigContentDetailsEndpointEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingCreateClusterKubeconfigContentDetailsEndpointEnum(val string) (CreateClusterKubeconfigContentDetailsEndpointEnum, bool) {
+	enum, ok := mappingCreateClusterKubeconfigContentDetailsEndpointEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_cluster_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateClusterRequest wrapper for the CreateCluster operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateCluster.go.html to see an example of how to use CreateClusterRequest.
+type CreateClusterRequest struct {
+
+	// The details of the cluster to create.
+	CreateClusterDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateClusterRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateClusterResponse wrapper for the CreateCluster operation
+type CreateClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_image_policy_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_image_policy_config_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateImagePolicyConfigDetails The properties that define a image verification policy.
+type CreateImagePolicyConfigDetails struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m CreateImagePolicyConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateImagePolicyConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_kubeconfig_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_kubeconfig_request_response.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// CreateKubeconfigRequest wrapper for the CreateKubeconfig operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateKubeconfig.go.html to see an example of how to use CreateKubeconfigRequest.
+type CreateKubeconfigRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The details of the cluster kubeconfig to create.
+	CreateClusterKubeconfigContentDetails `contributesTo:"body"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateKubeconfigRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateKubeconfigRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateKubeconfigRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateKubeconfigRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateKubeconfigRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateKubeconfigResponse wrapper for the CreateKubeconfig operation
+type CreateKubeconfigResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The io.ReadCloser instance
+	Content io.ReadCloser `presentIn:"body" encoding:"binary"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateKubeconfigResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateKubeconfigResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_details.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNodePoolDetails The properties that define a request to create a node pool.
+type CreateNodePoolDetails struct {
+
+	// The OCID of the compartment in which the node pool exists.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID of the cluster to which this node pool is attached.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// The name of the node pool. Avoid entering confidential information.
+	Name *string `mandatory:"true" json:"name"`
+
+	// The name of the node shape of the nodes in the node pool.
+	NodeShape *string `mandatory:"true" json:"nodeShape"`
+
+	// The version of Kubernetes to install on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+	NodeMetadata map[string]string `mandatory:"false" json:"nodeMetadata"`
+
+	// Deprecated. Use `nodeSourceDetails` instead.
+	// If you specify values for both, this value is ignored.
+	// The name of the image running on the nodes in the node pool.
+	NodeImageName *string `mandatory:"false" json:"nodeImageName"`
+
+	// Specify the source to use to launch nodes in the node pool. Currently, image is the only supported source.
+	NodeSourceDetails NodeSourceDetails `mandatory:"false" json:"nodeSourceDetails"`
+
+	// Specify the configuration of the shape to launch nodes in the node pool.
+	NodeShapeConfig *CreateNodeShapeConfigDetails `mandatory:"false" json:"nodeShapeConfig"`
+
+	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
+
+	// The SSH public key on each node in the node pool on launch.
+	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
+
+	// Optional, default to 1. The number of nodes to create in each subnet specified in subnetIds property.
+	// When used, subnetIds is required. This property is deprecated, use nodeConfigDetails instead.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool. When used, quantityPerSubnet
+	// can be provided. This property is deprecated, use nodeConfigDetails. Exactly one of the
+	// subnetIds or nodeConfigDetails properties must be specified.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool. Exactly one of the
+	// subnetIds or nodeConfigDetails properties must be specified.
+	NodeConfigDetails *CreateNodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings `mandatory:"false" json:"nodeEvictionNodePoolSettings"`
+
+	NodePoolCyclingDetails *NodePoolCyclingDetails `mandatory:"false" json:"nodePoolCyclingDetails"`
+}
+
+func (m CreateNodePoolDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateNodePoolDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateNodePoolDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		KubernetesVersion            *string                           `json:"kubernetesVersion"`
+		NodeMetadata                 map[string]string                 `json:"nodeMetadata"`
+		NodeImageName                *string                           `json:"nodeImageName"`
+		NodeSourceDetails            nodesourcedetails                 `json:"nodeSourceDetails"`
+		NodeShapeConfig              *CreateNodeShapeConfigDetails     `json:"nodeShapeConfig"`
+		InitialNodeLabels            []KeyValue                        `json:"initialNodeLabels"`
+		SshPublicKey                 *string                           `json:"sshPublicKey"`
+		QuantityPerSubnet            *int                              `json:"quantityPerSubnet"`
+		SubnetIds                    []string                          `json:"subnetIds"`
+		NodeConfigDetails            *CreateNodePoolNodeConfigDetails  `json:"nodeConfigDetails"`
+		FreeformTags                 map[string]string                 `json:"freeformTags"`
+		DefinedTags                  map[string]map[string]interface{} `json:"definedTags"`
+		NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings     `json:"nodeEvictionNodePoolSettings"`
+		NodePoolCyclingDetails       *NodePoolCyclingDetails           `json:"nodePoolCyclingDetails"`
+		CompartmentId                *string                           `json:"compartmentId"`
+		ClusterId                    *string                           `json:"clusterId"`
+		Name                         *string                           `json:"name"`
+		NodeShape                    *string                           `json:"nodeShape"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.NodeMetadata = model.NodeMetadata
+
+	m.NodeImageName = model.NodeImageName
+
+	nn, e = model.NodeSourceDetails.UnmarshalPolymorphicJSON(model.NodeSourceDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSourceDetails = nn.(NodeSourceDetails)
+	} else {
+		m.NodeSourceDetails = nil
+	}
+
+	m.NodeShapeConfig = model.NodeShapeConfig
+
+	m.InitialNodeLabels = make([]KeyValue, len(model.InitialNodeLabels))
+	copy(m.InitialNodeLabels, model.InitialNodeLabels)
+	m.SshPublicKey = model.SshPublicKey
+
+	m.QuantityPerSubnet = model.QuantityPerSubnet
+
+	m.SubnetIds = make([]string, len(model.SubnetIds))
+	copy(m.SubnetIds, model.SubnetIds)
+	m.NodeConfigDetails = model.NodeConfigDetails
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.NodeEvictionNodePoolSettings = model.NodeEvictionNodePoolSettings
+
+	m.NodePoolCyclingDetails = model.NodePoolCyclingDetails
+
+	m.CompartmentId = model.CompartmentId
+
+	m.ClusterId = model.ClusterId
+
+	m.Name = model.Name
+
+	m.NodeShape = model.NodeShape
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_node_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_node_config_details.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type CreateNodePoolNodeConfigDetails struct {
+
+	// The number of nodes that should be in the node pool.
+	Size *int `mandatory:"true" json:"size"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"true" json:"placementConfigs"`
+
+	// The OCIDs of the Network Security Group(s) to associate nodes for this node pool with. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The OCID of the Key Management Service key assigned to the boot volume.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The CNI related configuration of pods in the node pool.
+	NodePoolPodNetworkOptionDetails NodePoolPodNetworkOptionDetails `mandatory:"false" json:"nodePoolPodNetworkOptionDetails"`
+}
+
+func (m CreateNodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateNodePoolNodeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateNodePoolNodeConfigDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		NsgIds                          []string                          `json:"nsgIds"`
+		KmsKeyId                        *string                           `json:"kmsKeyId"`
+		IsPvEncryptionInTransitEnabled  *bool                             `json:"isPvEncryptionInTransitEnabled"`
+		FreeformTags                    map[string]string                 `json:"freeformTags"`
+		DefinedTags                     map[string]map[string]interface{} `json:"definedTags"`
+		NodePoolPodNetworkOptionDetails nodepoolpodnetworkoptiondetails   `json:"nodePoolPodNetworkOptionDetails"`
+		Size                            *int                              `json:"size"`
+		PlacementConfigs                []NodePoolPlacementConfigDetails  `json:"placementConfigs"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.NsgIds = make([]string, len(model.NsgIds))
+	copy(m.NsgIds, model.NsgIds)
+	m.KmsKeyId = model.KmsKeyId
+
+	m.IsPvEncryptionInTransitEnabled = model.IsPvEncryptionInTransitEnabled
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	nn, e = model.NodePoolPodNetworkOptionDetails.UnmarshalPolymorphicJSON(model.NodePoolPodNetworkOptionDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodePoolPodNetworkOptionDetails = nn.(NodePoolPodNetworkOptionDetails)
+	} else {
+		m.NodePoolPodNetworkOptionDetails = nil
+	}
+
+	m.Size = model.Size
+
+	m.PlacementConfigs = make([]NodePoolPlacementConfigDetails, len(model.PlacementConfigs))
+	copy(m.PlacementConfigs, model.PlacementConfigs)
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_pool_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateNodePoolRequest wrapper for the CreateNodePool operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateNodePool.go.html to see an example of how to use CreateNodePoolRequest.
+type CreateNodePoolRequest struct {
+
+	// The details of the node pool to create.
+	CreateNodePoolDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateNodePoolResponse wrapper for the CreateNodePool operation
+type CreateNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_node_shape_config_details.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateNodeShapeConfigDetails The shape configuration of the nodes.
+type CreateNodeShapeConfigDetails struct {
+
+	// The total number of OCPUs available to each node in the node pool.
+	// See here (https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/) for details.
+	Ocpus *float32 `mandatory:"false" json:"ocpus"`
+
+	// The total amount of memory available to each node, in gigabytes.
+	MemoryInGBs *float32 `mandatory:"false" json:"memoryInGBs"`
+}
+
+func (m CreateNodeShapeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateNodeShapeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_virtual_node_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_virtual_node_pool_details.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateVirtualNodePoolDetails The properties that define a request to create a virtual node pool.
+type CreateVirtualNodePoolDetails struct {
+
+	// Compartment of the virtual node pool.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The cluster the virtual node pool is associated with. A virtual node pool can only be associated with one cluster.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// Display name of the virtual node pool. This is a non-unique value.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The list of placement configurations which determines where Virtual Nodes will be provisioned across as it relates to the subnet and availability domains. The size attribute determines how many we evenly spread across these placement configurations
+	PlacementConfigurations []PlacementConfiguration `mandatory:"true" json:"placementConfigurations"`
+
+	// Initial labels that will be added to the Kubernetes Virtual Node object when it registers.
+	InitialVirtualNodeLabels []InitialVirtualNodeLabel `mandatory:"false" json:"initialVirtualNodeLabels"`
+
+	// A taint is a collection of <key, value, effect>. These taints will be applied to the Virtual Nodes of this Virtual Node Pool for Kubernetes scheduling.
+	Taints []Taint `mandatory:"false" json:"taints"`
+
+	// The number of Virtual Nodes that should be in the Virtual Node Pool. The placement configurations determine where these virtual nodes are placed.
+	Size *int `mandatory:"false" json:"size"`
+
+	// List of network security group id's applied to the Virtual Node VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The pod configuration for pods run on virtual nodes of this virtual node pool.
+	PodConfiguration *PodConfiguration `mandatory:"false" json:"podConfiguration"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	VirtualNodeTags *VirtualNodeTags `mandatory:"false" json:"virtualNodeTags"`
+}
+
+func (m CreateVirtualNodePoolDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateVirtualNodePoolDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_virtual_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_virtual_node_pool_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateVirtualNodePoolRequest wrapper for the CreateVirtualNodePool operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateVirtualNodePool.go.html to see an example of how to use CreateVirtualNodePoolRequest.
+type CreateVirtualNodePoolRequest struct {
+
+	// The details of the virtual node pool to create.
+	CreateVirtualNodePoolDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateVirtualNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateVirtualNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateVirtualNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateVirtualNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateVirtualNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateVirtualNodePoolResponse wrapper for the CreateVirtualNodePool operation
+type CreateVirtualNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateVirtualNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateVirtualNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_workload_mapping_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_workload_mapping_details.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CreateWorkloadMappingDetails The properties that define a workloadMapping
+type CreateWorkloadMappingDetails struct {
+
+	// The namespace of the workloadMapping.
+	Namespace *string `mandatory:"true" json:"namespace"`
+
+	// The OCID of the mapped customer compartment.
+	MappedCompartmentId *string `mandatory:"true" json:"mappedCompartmentId"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateWorkloadMappingDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CreateWorkloadMappingDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_workload_mapping_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/create_workload_mapping_request_response.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// CreateWorkloadMappingRequest wrapper for the CreateWorkloadMapping operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/CreateWorkloadMapping.go.html to see an example of how to use CreateWorkloadMappingRequest.
+type CreateWorkloadMappingRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details of the workloadMapping to be create.
+	CreateWorkloadMappingDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateWorkloadMappingRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateWorkloadMappingRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request CreateWorkloadMappingRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateWorkloadMappingRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request CreateWorkloadMappingRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CreateWorkloadMappingResponse wrapper for the CreateWorkloadMapping operation
+type CreateWorkloadMappingResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WorkloadMapping instance
+	WorkloadMapping `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateWorkloadMappingResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateWorkloadMappingResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/credential_rotation_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/credential_rotation_status.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// CredentialRotationStatus Information regarding cluster's credential rotation.
+type CredentialRotationStatus struct {
+
+	// Credential rotation status of a kubernetes cluster
+	// IN_PROGRESS: Issuing new credentials to kubernetes cluster control plane and worker nodes or retiring old credentials from kubernetes cluster control plane and worker nodes.
+	// WAITING: Waiting for customer to invoke the complete rotation action or the automcatic complete rotation action.
+	// COMPLETED: New credentials are functional on kuberentes cluster.
+	Status CredentialRotationStatusStatusEnum `mandatory:"true" json:"status"`
+
+	// Details of a kuberenetes cluster credential rotation status:
+	// ISSUING_NEW_CREDENTIALS: Credential rotation is in progress. Starting to issue new credentials to kubernetes cluster control plane and worker nodes.
+	// NEW_CREDENTIALS_ISSUED: New credentials are added. At this stage cluster has both old and new credentials and is awaiting old credentials retirement.
+	// RETIRING_OLD_CREDENTIALS: Retirement of old credentials is in progress. Starting to remove old credentials from kubernetes cluster control plane and worker nodes.
+	// COMPLETED: Credential rotation is complete. Old credentials are retired.
+	StatusDetails CredentialRotationStatusStatusDetailsEnum `mandatory:"true" json:"statusDetails"`
+
+	// The time by which retirement of old credentials should start.
+	TimeAutoCompletionScheduled *common.SDKTime `mandatory:"false" json:"timeAutoCompletionScheduled"`
+}
+
+func (m CredentialRotationStatus) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m CredentialRotationStatus) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingCredentialRotationStatusStatusEnum(string(m.Status)); !ok && m.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", m.Status, strings.Join(GetCredentialRotationStatusStatusEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingCredentialRotationStatusStatusDetailsEnum(string(m.StatusDetails)); !ok && m.StatusDetails != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for StatusDetails: %s. Supported values are: %s.", m.StatusDetails, strings.Join(GetCredentialRotationStatusStatusDetailsEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// CredentialRotationStatusStatusEnum Enum with underlying type: string
+type CredentialRotationStatusStatusEnum string
+
+// Set of constants representing the allowable values for CredentialRotationStatusStatusEnum
+const (
+	CredentialRotationStatusStatusInProgress CredentialRotationStatusStatusEnum = "IN_PROGRESS"
+	CredentialRotationStatusStatusWaiting    CredentialRotationStatusStatusEnum = "WAITING"
+	CredentialRotationStatusStatusCompleted  CredentialRotationStatusStatusEnum = "COMPLETED"
+)
+
+var mappingCredentialRotationStatusStatusEnum = map[string]CredentialRotationStatusStatusEnum{
+	"IN_PROGRESS": CredentialRotationStatusStatusInProgress,
+	"WAITING":     CredentialRotationStatusStatusWaiting,
+	"COMPLETED":   CredentialRotationStatusStatusCompleted,
+}
+
+var mappingCredentialRotationStatusStatusEnumLowerCase = map[string]CredentialRotationStatusStatusEnum{
+	"in_progress": CredentialRotationStatusStatusInProgress,
+	"waiting":     CredentialRotationStatusStatusWaiting,
+	"completed":   CredentialRotationStatusStatusCompleted,
+}
+
+// GetCredentialRotationStatusStatusEnumValues Enumerates the set of values for CredentialRotationStatusStatusEnum
+func GetCredentialRotationStatusStatusEnumValues() []CredentialRotationStatusStatusEnum {
+	values := make([]CredentialRotationStatusStatusEnum, 0)
+	for _, v := range mappingCredentialRotationStatusStatusEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetCredentialRotationStatusStatusEnumStringValues Enumerates the set of values in String for CredentialRotationStatusStatusEnum
+func GetCredentialRotationStatusStatusEnumStringValues() []string {
+	return []string{
+		"IN_PROGRESS",
+		"WAITING",
+		"COMPLETED",
+	}
+}
+
+// GetMappingCredentialRotationStatusStatusEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingCredentialRotationStatusStatusEnum(val string) (CredentialRotationStatusStatusEnum, bool) {
+	enum, ok := mappingCredentialRotationStatusStatusEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// CredentialRotationStatusStatusDetailsEnum Enum with underlying type: string
+type CredentialRotationStatusStatusDetailsEnum string
+
+// Set of constants representing the allowable values for CredentialRotationStatusStatusDetailsEnum
+const (
+	CredentialRotationStatusStatusDetailsIssuingNewCredentials  CredentialRotationStatusStatusDetailsEnum = "ISSUING_NEW_CREDENTIALS"
+	CredentialRotationStatusStatusDetailsNewCredentialsIssued   CredentialRotationStatusStatusDetailsEnum = "NEW_CREDENTIALS_ISSUED"
+	CredentialRotationStatusStatusDetailsRetiringOldCredentials CredentialRotationStatusStatusDetailsEnum = "RETIRING_OLD_CREDENTIALS"
+	CredentialRotationStatusStatusDetailsCompleted              CredentialRotationStatusStatusDetailsEnum = "COMPLETED"
+)
+
+var mappingCredentialRotationStatusStatusDetailsEnum = map[string]CredentialRotationStatusStatusDetailsEnum{
+	"ISSUING_NEW_CREDENTIALS":  CredentialRotationStatusStatusDetailsIssuingNewCredentials,
+	"NEW_CREDENTIALS_ISSUED":   CredentialRotationStatusStatusDetailsNewCredentialsIssued,
+	"RETIRING_OLD_CREDENTIALS": CredentialRotationStatusStatusDetailsRetiringOldCredentials,
+	"COMPLETED":                CredentialRotationStatusStatusDetailsCompleted,
+}
+
+var mappingCredentialRotationStatusStatusDetailsEnumLowerCase = map[string]CredentialRotationStatusStatusDetailsEnum{
+	"issuing_new_credentials":  CredentialRotationStatusStatusDetailsIssuingNewCredentials,
+	"new_credentials_issued":   CredentialRotationStatusStatusDetailsNewCredentialsIssued,
+	"retiring_old_credentials": CredentialRotationStatusStatusDetailsRetiringOldCredentials,
+	"completed":                CredentialRotationStatusStatusDetailsCompleted,
+}
+
+// GetCredentialRotationStatusStatusDetailsEnumValues Enumerates the set of values for CredentialRotationStatusStatusDetailsEnum
+func GetCredentialRotationStatusStatusDetailsEnumValues() []CredentialRotationStatusStatusDetailsEnum {
+	values := make([]CredentialRotationStatusStatusDetailsEnum, 0)
+	for _, v := range mappingCredentialRotationStatusStatusDetailsEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetCredentialRotationStatusStatusDetailsEnumStringValues Enumerates the set of values in String for CredentialRotationStatusStatusDetailsEnum
+func GetCredentialRotationStatusStatusDetailsEnumStringValues() []string {
+	return []string{
+		"ISSUING_NEW_CREDENTIALS",
+		"NEW_CREDENTIALS_ISSUED",
+		"RETIRING_OLD_CREDENTIALS",
+		"COMPLETED",
+	}
+}
+
+// GetMappingCredentialRotationStatusStatusDetailsEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingCredentialRotationStatusStatusDetailsEnum(val string) (CredentialRotationStatusStatusDetailsEnum, bool) {
+	enum, ok := mappingCredentialRotationStatusStatusDetailsEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_cluster_request_response.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteClusterRequest wrapper for the DeleteCluster operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteCluster.go.html to see an example of how to use DeleteClusterRequest.
+type DeleteClusterRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteClusterRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteClusterResponse wrapper for the DeleteCluster operation
+type DeleteClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_node_pool_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteNodePoolRequest wrapper for the DeleteNodePool operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteNodePool.go.html to see an example of how to use DeleteNodePoolRequest.
+type DeleteNodePoolRequest struct {
+
+	// The OCID of the node pool.
+	NodePoolId *string `mandatory:"true" contributesTo:"path" name:"nodePoolId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Duration after which OKE will give up eviction of the pods on the node.
+	// PT0M will indicate you want to delete the node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	OverrideEvictionGraceDuration *string `mandatory:"false" contributesTo:"query" name:"overrideEvictionGraceDuration"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeletionAfterOverrideGraceDuration *bool `mandatory:"false" contributesTo:"query" name:"isForceDeletionAfterOverrideGraceDuration"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteNodePoolResponse wrapper for the DeleteNodePool operation
+type DeleteNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_node_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_node_request_response.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteNodeRequest wrapper for the DeleteNode operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteNode.go.html to see an example of how to use DeleteNodeRequest.
+type DeleteNodeRequest struct {
+
+	// The OCID of the node pool.
+	NodePoolId *string `mandatory:"true" contributesTo:"path" name:"nodePoolId"`
+
+	// The OCID of the compute instance.
+	NodeId *string `mandatory:"true" contributesTo:"path" name:"nodeId"`
+
+	// If the nodepool should be scaled down after the node is deleted.
+	IsDecrementSize *bool `mandatory:"false" contributesTo:"query" name:"isDecrementSize"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Duration after which OKE will give up eviction of the pods on the node.
+	// PT0M will indicate you want to delete the node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	OverrideEvictionGraceDuration *string `mandatory:"false" contributesTo:"query" name:"overrideEvictionGraceDuration"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeletionAfterOverrideGraceDuration *bool `mandatory:"false" contributesTo:"query" name:"isForceDeletionAfterOverrideGraceDuration"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteNodeRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteNodeRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteNodeRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteNodeRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteNodeRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteNodeResponse wrapper for the DeleteNode operation
+type DeleteNodeResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteNodeResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteNodeResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_virtual_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_virtual_node_pool_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteVirtualNodePoolRequest wrapper for the DeleteVirtualNodePool operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteVirtualNodePool.go.html to see an example of how to use DeleteVirtualNodePoolRequest.
+type DeleteVirtualNodePoolRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Duration after which Sk8s will give up eviction of the pods on the node.
+	// PT0M will indicate you want to delete the virtual node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	OverrideEvictionGraceDurationVnp *string `mandatory:"false" contributesTo:"query" name:"overrideEvictionGraceDurationVnp"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeletionAfterOverrideGraceDurationVnp *bool `mandatory:"false" contributesTo:"query" name:"isForceDeletionAfterOverrideGraceDurationVnp"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteVirtualNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteVirtualNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteVirtualNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteVirtualNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteVirtualNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteVirtualNodePoolResponse wrapper for the DeleteVirtualNodePool operation
+type DeleteVirtualNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteVirtualNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteVirtualNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_work_request_request_response.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteWorkRequestRequest wrapper for the DeleteWorkRequest operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteWorkRequest.go.html to see an example of how to use DeleteWorkRequestRequest.
+type DeleteWorkRequestRequest struct {
+
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteWorkRequestRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteWorkRequestRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteWorkRequestRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteWorkRequestRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteWorkRequestRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteWorkRequestResponse wrapper for the DeleteWorkRequest operation
+type DeleteWorkRequestResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteWorkRequestResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteWorkRequestResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_workload_mapping_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/delete_workload_mapping_request_response.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DeleteWorkloadMappingRequest wrapper for the DeleteWorkloadMapping operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DeleteWorkloadMapping.go.html to see an example of how to use DeleteWorkloadMappingRequest.
+type DeleteWorkloadMappingRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The OCID of the workloadMapping.
+	WorkloadMappingId *string `mandatory:"true" contributesTo:"path" name:"workloadMappingId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteWorkloadMappingRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteWorkloadMappingRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DeleteWorkloadMappingRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteWorkloadMappingRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DeleteWorkloadMappingRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DeleteWorkloadMappingResponse wrapper for the DeleteWorkloadMapping operation
+type DeleteWorkloadMappingResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteWorkloadMappingResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteWorkloadMappingResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/disable_addon_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/disable_addon_request_response.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// DisableAddonRequest wrapper for the DisableAddon operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/DisableAddon.go.html to see an example of how to use DisableAddonRequest.
+type DisableAddonRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The name of the addon.
+	AddonName *string `mandatory:"true" contributesTo:"path" name:"addonName"`
+
+	// Whether existing addon resources should be deleted or not. True would remove the underlying resources completely.
+	IsRemoveExistingAddOn *bool `mandatory:"true" contributesTo:"query" name:"isRemoveExistingAddOn"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DisableAddonRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DisableAddonRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request DisableAddonRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DisableAddonRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request DisableAddonRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// DisableAddonResponse wrapper for the DisableAddon operation
+type DisableAddonResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DisableAddonResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DisableAddonResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/flannel_overlay_cluster_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/flannel_overlay_cluster_pod_network_option_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// FlannelOverlayClusterPodNetworkOptionDetails Network options specific to using the flannel (FLANNEL_OVERLAY) CNI
+type FlannelOverlayClusterPodNetworkOptionDetails struct {
+}
+
+func (m FlannelOverlayClusterPodNetworkOptionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m FlannelOverlayClusterPodNetworkOptionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m FlannelOverlayClusterPodNetworkOptionDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeFlannelOverlayClusterPodNetworkOptionDetails FlannelOverlayClusterPodNetworkOptionDetails
+	s := struct {
+		DiscriminatorParam string `json:"cniType"`
+		MarshalTypeFlannelOverlayClusterPodNetworkOptionDetails
+	}{
+		"FLANNEL_OVERLAY",
+		(MarshalTypeFlannelOverlayClusterPodNetworkOptionDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/flannel_overlay_node_pool_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/flannel_overlay_node_pool_pod_network_option_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// FlannelOverlayNodePoolPodNetworkOptionDetails Network options specific to using the flannel (FLANNEL_OVERLAY) CNI
+type FlannelOverlayNodePoolPodNetworkOptionDetails struct {
+}
+
+func (m FlannelOverlayNodePoolPodNetworkOptionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m FlannelOverlayNodePoolPodNetworkOptionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m FlannelOverlayNodePoolPodNetworkOptionDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeFlannelOverlayNodePoolPodNetworkOptionDetails FlannelOverlayNodePoolPodNetworkOptionDetails
+	s := struct {
+		DiscriminatorParam string `json:"cniType"`
+		MarshalTypeFlannelOverlayNodePoolPodNetworkOptionDetails
+	}{
+		"FLANNEL_OVERLAY",
+		(MarshalTypeFlannelOverlayNodePoolPodNetworkOptionDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_addon_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_addon_request_response.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetAddonRequest wrapper for the GetAddon operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetAddon.go.html to see an example of how to use GetAddonRequest.
+type GetAddonRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The name of the addon.
+	AddonName *string `mandatory:"true" contributesTo:"path" name:"addonName"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetAddonRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetAddonRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetAddonRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetAddonRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetAddonRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetAddonResponse wrapper for the GetAddon operation
+type GetAddonResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Addon instance
+	Addon `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetAddonResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetAddonResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_migrate_to_native_vcn_status_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_migrate_to_native_vcn_status_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetClusterMigrateToNativeVcnStatusRequest wrapper for the GetClusterMigrateToNativeVcnStatus operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetClusterMigrateToNativeVcnStatus.go.html to see an example of how to use GetClusterMigrateToNativeVcnStatusRequest.
+type GetClusterMigrateToNativeVcnStatusRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetClusterMigrateToNativeVcnStatusRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetClusterMigrateToNativeVcnStatusRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetClusterMigrateToNativeVcnStatusRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetClusterMigrateToNativeVcnStatusRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetClusterMigrateToNativeVcnStatusRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetClusterMigrateToNativeVcnStatusResponse wrapper for the GetClusterMigrateToNativeVcnStatus operation
+type GetClusterMigrateToNativeVcnStatusResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ClusterMigrateToNativeVcnStatus instance
+	ClusterMigrateToNativeVcnStatus `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetClusterMigrateToNativeVcnStatusResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetClusterMigrateToNativeVcnStatusResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_options_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetClusterOptionsRequest wrapper for the GetClusterOptions operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetClusterOptions.go.html to see an example of how to use GetClusterOptionsRequest.
+type GetClusterOptionsRequest struct {
+
+	// The id of the option set to retrieve. Use "all" get all options, or use a cluster ID to get options specific to the provided cluster.
+	ClusterOptionId *string `mandatory:"true" contributesTo:"path" name:"clusterOptionId"`
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetClusterOptionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetClusterOptionsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetClusterOptionsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetClusterOptionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetClusterOptionsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetClusterOptionsResponse wrapper for the GetClusterOptions operation
+type GetClusterOptionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ClusterOptions instance
+	ClusterOptions `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetClusterOptionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetClusterOptionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_cluster_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetClusterRequest wrapper for the GetCluster operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetCluster.go.html to see an example of how to use GetClusterRequest.
+type GetClusterRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetClusterRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetClusterResponse wrapper for the GetCluster operation
+type GetClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Cluster instance
+	Cluster `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_credential_rotation_status_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_credential_rotation_status_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetCredentialRotationStatusRequest wrapper for the GetCredentialRotationStatus operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetCredentialRotationStatus.go.html to see an example of how to use GetCredentialRotationStatusRequest.
+type GetCredentialRotationStatusRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetCredentialRotationStatusRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetCredentialRotationStatusRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetCredentialRotationStatusRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetCredentialRotationStatusRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetCredentialRotationStatusRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetCredentialRotationStatusResponse wrapper for the GetCredentialRotationStatus operation
+type GetCredentialRotationStatusResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The CredentialRotationStatus instance
+	CredentialRotationStatus `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetCredentialRotationStatusResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetCredentialRotationStatusResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_node_pool_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_node_pool_options_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetNodePoolOptionsRequest wrapper for the GetNodePoolOptions operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetNodePoolOptions.go.html to see an example of how to use GetNodePoolOptionsRequest.
+type GetNodePoolOptionsRequest struct {
+
+	// The id of the option set to retrieve. Use "all" get all options, or use a cluster ID to get options specific to the provided cluster.
+	NodePoolOptionId *string `mandatory:"true" contributesTo:"path" name:"nodePoolOptionId"`
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetNodePoolOptionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetNodePoolOptionsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetNodePoolOptionsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetNodePoolOptionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetNodePoolOptionsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetNodePoolOptionsResponse wrapper for the GetNodePoolOptions operation
+type GetNodePoolOptionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The NodePoolOptions instance
+	NodePoolOptions `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetNodePoolOptionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetNodePoolOptionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_node_pool_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetNodePoolRequest wrapper for the GetNodePool operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetNodePool.go.html to see an example of how to use GetNodePoolRequest.
+type GetNodePoolRequest struct {
+
+	// The OCID of the node pool.
+	NodePoolId *string `mandatory:"true" contributesTo:"path" name:"nodePoolId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetNodePoolResponse wrapper for the GetNodePool operation
+type GetNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The NodePool instance
+	NodePool `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_virtual_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_virtual_node_pool_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetVirtualNodePoolRequest wrapper for the GetVirtualNodePool operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetVirtualNodePool.go.html to see an example of how to use GetVirtualNodePoolRequest.
+type GetVirtualNodePoolRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetVirtualNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetVirtualNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetVirtualNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetVirtualNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetVirtualNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetVirtualNodePoolResponse wrapper for the GetVirtualNodePool operation
+type GetVirtualNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VirtualNodePool instance
+	VirtualNodePool `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetVirtualNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetVirtualNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_virtual_node_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_virtual_node_request_response.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetVirtualNodeRequest wrapper for the GetVirtualNode operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetVirtualNode.go.html to see an example of how to use GetVirtualNodeRequest.
+type GetVirtualNodeRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// The OCID of the virtual node.
+	VirtualNodeId *string `mandatory:"true" contributesTo:"path" name:"virtualNodeId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetVirtualNodeRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetVirtualNodeRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetVirtualNodeRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetVirtualNodeRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetVirtualNodeRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetVirtualNodeResponse wrapper for the GetVirtualNode operation
+type GetVirtualNodeResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The VirtualNode instance
+	VirtualNode `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetVirtualNodeResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetVirtualNodeResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_work_request_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_work_request_request_response.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetWorkRequestRequest wrapper for the GetWorkRequest operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetWorkRequest.go.html to see an example of how to use GetWorkRequestRequest.
+type GetWorkRequestRequest struct {
+
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWorkRequestRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWorkRequestRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetWorkRequestRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWorkRequestRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetWorkRequestRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetWorkRequestResponse wrapper for the GetWorkRequest operation
+type GetWorkRequestResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WorkRequest instance
+	WorkRequest `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// the number of seconds to should wait before polling this endpoint again
+	RetryAfter *int `presentIn:"header" name:"retry-after"`
+}
+
+func (response GetWorkRequestResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWorkRequestResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_workload_mapping_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/get_workload_mapping_request_response.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// GetWorkloadMappingRequest wrapper for the GetWorkloadMapping operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/GetWorkloadMapping.go.html to see an example of how to use GetWorkloadMappingRequest.
+type GetWorkloadMappingRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The OCID of the workloadMapping.
+	WorkloadMappingId *string `mandatory:"true" contributesTo:"path" name:"workloadMappingId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetWorkloadMappingRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetWorkloadMappingRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request GetWorkloadMappingRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetWorkloadMappingRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request GetWorkloadMappingRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// GetWorkloadMappingResponse wrapper for the GetWorkloadMapping operation
+type GetWorkloadMappingResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WorkloadMapping instance
+	WorkloadMapping `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetWorkloadMappingResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetWorkloadMappingResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/image_policy_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/image_policy_config.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ImagePolicyConfig The properties that define a image verification policy.
+type ImagePolicyConfig struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m ImagePolicyConfig) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ImagePolicyConfig) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/initial_virtual_node_label.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/initial_virtual_node_label.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// InitialVirtualNodeLabel The properties that define a key value pair.
+type InitialVirtualNodeLabel struct {
+
+	// The key of the pair.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The value of the pair.
+	Value *string `mandatory:"false" json:"value"`
+}
+
+func (m InitialVirtualNodeLabel) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m InitialVirtualNodeLabel) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/install_addon_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/install_addon_details.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// InstallAddonDetails The properties that define to install/enable addon on a cluster
+type InstallAddonDetails struct {
+
+	// The name of the addon.
+	AddonName *string `mandatory:"true" json:"addonName"`
+
+	// The version of addon to be installed.
+	Version *string `mandatory:"false" json:"version"`
+
+	// Addon configuration details.
+	Configurations []AddonConfiguration `mandatory:"false" json:"configurations"`
+}
+
+func (m InstallAddonDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m InstallAddonDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/install_addon_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/install_addon_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// InstallAddonRequest wrapper for the InstallAddon operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/InstallAddon.go.html to see an example of how to use InstallAddonRequest.
+type InstallAddonRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details of the addon to be installed.
+	InstallAddonDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request InstallAddonRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request InstallAddonRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request InstallAddonRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request InstallAddonRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request InstallAddonRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// InstallAddonResponse wrapper for the InstallAddon operation
+type InstallAddonResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response InstallAddonResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response InstallAddonResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/key_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/key_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// KeyDetails The properties that define the kms keys used by OKE for Image Signature verification.
+type KeyDetails struct {
+
+	// The OCIDs of the KMS key that will be used to verify whether the images are signed by an approved source.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+}
+
+func (m KeyDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m KeyDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/key_value.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/key_value.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// KeyValue The properties that define a key value pair.
+type KeyValue struct {
+
+	// The key of the pair.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The value of the pair.
+	Value *string `mandatory:"false" json:"value"`
+}
+
+func (m KeyValue) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m KeyValue) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/kubernetes_network_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/kubernetes_network_config.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// KubernetesNetworkConfig The properties that define the network configuration for Kubernetes.
+type KubernetesNetworkConfig struct {
+
+	// The CIDR block for Kubernetes pods. Optional, defaults to 10.244.0.0/16.
+	PodsCidr *string `mandatory:"false" json:"podsCidr"`
+
+	// The CIDR block for Kubernetes services. Optional, defaults to 10.96.0.0/16.
+	ServicesCidr *string `mandatory:"false" json:"servicesCidr"`
+}
+
+func (m KubernetesNetworkConfig) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m KubernetesNetworkConfig) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/kubernetes_versions_filters.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/kubernetes_versions_filters.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// KubernetesVersionsFilters The range of kubernetes versions an addon can be configured.
+type KubernetesVersionsFilters struct {
+
+	// The earliest kubernetes version.
+	MinimalVersion *string `mandatory:"false" json:"minimalVersion"`
+
+	// The latest kubernetes version.
+	MaximumVersion *string `mandatory:"false" json:"maximumVersion"`
+
+	// The exact version of kubernetes that are compatible.
+	ExactKubernetesVersions []string `mandatory:"false" json:"exactKubernetesVersions"`
+}
+
+func (m KubernetesVersionsFilters) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m KubernetesVersionsFilters) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_addon_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_addon_options_request_response.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListAddonOptionsRequest wrapper for the ListAddonOptions operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListAddonOptions.go.html to see an example of how to use ListAddonOptionsRequest.
+type ListAddonOptionsRequest struct {
+
+	// The kubernetes version to fetch the addons.
+	KubernetesVersion *string `mandatory:"true" contributesTo:"query" name:"kubernetesVersion"`
+
+	// The name of the addon.
+	AddonName *string `mandatory:"false" contributesTo:"query" name:"addonName"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListAddonOptionsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListAddonOptionsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListAddonOptionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListAddonOptionsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListAddonOptionsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListAddonOptionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListAddonOptionsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListAddonOptionsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListAddonOptionsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListAddonOptionsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListAddonOptionsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListAddonOptionsResponse wrapper for the ListAddonOptions operation
+type ListAddonOptionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []AddonOptionSummary instances
+	Items []AddonOptionSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListAddonOptionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListAddonOptionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListAddonOptionsSortOrderEnum Enum with underlying type: string
+type ListAddonOptionsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListAddonOptionsSortOrderEnum
+const (
+	ListAddonOptionsSortOrderAsc  ListAddonOptionsSortOrderEnum = "ASC"
+	ListAddonOptionsSortOrderDesc ListAddonOptionsSortOrderEnum = "DESC"
+)
+
+var mappingListAddonOptionsSortOrderEnum = map[string]ListAddonOptionsSortOrderEnum{
+	"ASC":  ListAddonOptionsSortOrderAsc,
+	"DESC": ListAddonOptionsSortOrderDesc,
+}
+
+var mappingListAddonOptionsSortOrderEnumLowerCase = map[string]ListAddonOptionsSortOrderEnum{
+	"asc":  ListAddonOptionsSortOrderAsc,
+	"desc": ListAddonOptionsSortOrderDesc,
+}
+
+// GetListAddonOptionsSortOrderEnumValues Enumerates the set of values for ListAddonOptionsSortOrderEnum
+func GetListAddonOptionsSortOrderEnumValues() []ListAddonOptionsSortOrderEnum {
+	values := make([]ListAddonOptionsSortOrderEnum, 0)
+	for _, v := range mappingListAddonOptionsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAddonOptionsSortOrderEnumStringValues Enumerates the set of values in String for ListAddonOptionsSortOrderEnum
+func GetListAddonOptionsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListAddonOptionsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAddonOptionsSortOrderEnum(val string) (ListAddonOptionsSortOrderEnum, bool) {
+	enum, ok := mappingListAddonOptionsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListAddonOptionsSortByEnum Enum with underlying type: string
+type ListAddonOptionsSortByEnum string
+
+// Set of constants representing the allowable values for ListAddonOptionsSortByEnum
+const (
+	ListAddonOptionsSortByName        ListAddonOptionsSortByEnum = "NAME"
+	ListAddonOptionsSortByTimeCreated ListAddonOptionsSortByEnum = "TIME_CREATED"
+)
+
+var mappingListAddonOptionsSortByEnum = map[string]ListAddonOptionsSortByEnum{
+	"NAME":         ListAddonOptionsSortByName,
+	"TIME_CREATED": ListAddonOptionsSortByTimeCreated,
+}
+
+var mappingListAddonOptionsSortByEnumLowerCase = map[string]ListAddonOptionsSortByEnum{
+	"name":         ListAddonOptionsSortByName,
+	"time_created": ListAddonOptionsSortByTimeCreated,
+}
+
+// GetListAddonOptionsSortByEnumValues Enumerates the set of values for ListAddonOptionsSortByEnum
+func GetListAddonOptionsSortByEnumValues() []ListAddonOptionsSortByEnum {
+	values := make([]ListAddonOptionsSortByEnum, 0)
+	for _, v := range mappingListAddonOptionsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAddonOptionsSortByEnumStringValues Enumerates the set of values in String for ListAddonOptionsSortByEnum
+func GetListAddonOptionsSortByEnumStringValues() []string {
+	return []string{
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListAddonOptionsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAddonOptionsSortByEnum(val string) (ListAddonOptionsSortByEnum, bool) {
+	enum, ok := mappingListAddonOptionsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_addons_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_addons_request_response.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListAddonsRequest wrapper for the ListAddons operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListAddons.go.html to see an example of how to use ListAddonsRequest.
+type ListAddonsRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListAddonsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListAddonsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListAddonsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListAddonsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListAddonsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListAddonsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListAddonsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListAddonsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListAddonsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListAddonsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListAddonsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListAddonsResponse wrapper for the ListAddons operation
+type ListAddonsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []AddonSummary instances
+	Items []AddonSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListAddonsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListAddonsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListAddonsSortOrderEnum Enum with underlying type: string
+type ListAddonsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListAddonsSortOrderEnum
+const (
+	ListAddonsSortOrderAsc  ListAddonsSortOrderEnum = "ASC"
+	ListAddonsSortOrderDesc ListAddonsSortOrderEnum = "DESC"
+)
+
+var mappingListAddonsSortOrderEnum = map[string]ListAddonsSortOrderEnum{
+	"ASC":  ListAddonsSortOrderAsc,
+	"DESC": ListAddonsSortOrderDesc,
+}
+
+var mappingListAddonsSortOrderEnumLowerCase = map[string]ListAddonsSortOrderEnum{
+	"asc":  ListAddonsSortOrderAsc,
+	"desc": ListAddonsSortOrderDesc,
+}
+
+// GetListAddonsSortOrderEnumValues Enumerates the set of values for ListAddonsSortOrderEnum
+func GetListAddonsSortOrderEnumValues() []ListAddonsSortOrderEnum {
+	values := make([]ListAddonsSortOrderEnum, 0)
+	for _, v := range mappingListAddonsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAddonsSortOrderEnumStringValues Enumerates the set of values in String for ListAddonsSortOrderEnum
+func GetListAddonsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListAddonsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAddonsSortOrderEnum(val string) (ListAddonsSortOrderEnum, bool) {
+	enum, ok := mappingListAddonsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListAddonsSortByEnum Enum with underlying type: string
+type ListAddonsSortByEnum string
+
+// Set of constants representing the allowable values for ListAddonsSortByEnum
+const (
+	ListAddonsSortByName        ListAddonsSortByEnum = "NAME"
+	ListAddonsSortByTimeCreated ListAddonsSortByEnum = "TIME_CREATED"
+)
+
+var mappingListAddonsSortByEnum = map[string]ListAddonsSortByEnum{
+	"NAME":         ListAddonsSortByName,
+	"TIME_CREATED": ListAddonsSortByTimeCreated,
+}
+
+var mappingListAddonsSortByEnumLowerCase = map[string]ListAddonsSortByEnum{
+	"name":         ListAddonsSortByName,
+	"time_created": ListAddonsSortByTimeCreated,
+}
+
+// GetListAddonsSortByEnumValues Enumerates the set of values for ListAddonsSortByEnum
+func GetListAddonsSortByEnumValues() []ListAddonsSortByEnum {
+	values := make([]ListAddonsSortByEnum, 0)
+	for _, v := range mappingListAddonsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListAddonsSortByEnumStringValues Enumerates the set of values in String for ListAddonsSortByEnum
+func GetListAddonsSortByEnumStringValues() []string {
+	return []string{
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListAddonsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListAddonsSortByEnum(val string) (ListAddonsSortByEnum, bool) {
+	enum, ok := mappingListAddonsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_clusters_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_clusters_request_response.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListClustersRequest wrapper for the ListClusters operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListClusters.go.html to see an example of how to use ListClustersRequest.
+type ListClustersRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// A cluster lifecycle state to filter on. Can have multiple parameters of this name.
+	LifecycleState []ClusterLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListClustersSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListClustersSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListClustersRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListClustersRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListClustersRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListClustersRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListClustersRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingClusterLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetClusterLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if _, ok := GetMappingListClustersSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListClustersSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListClustersSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListClustersSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListClustersResponse wrapper for the ListClusters operation
+type ListClustersResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ClusterSummary instances
+	Items []ClusterSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListClustersResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListClustersResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListClustersSortOrderEnum Enum with underlying type: string
+type ListClustersSortOrderEnum string
+
+// Set of constants representing the allowable values for ListClustersSortOrderEnum
+const (
+	ListClustersSortOrderAsc  ListClustersSortOrderEnum = "ASC"
+	ListClustersSortOrderDesc ListClustersSortOrderEnum = "DESC"
+)
+
+var mappingListClustersSortOrderEnum = map[string]ListClustersSortOrderEnum{
+	"ASC":  ListClustersSortOrderAsc,
+	"DESC": ListClustersSortOrderDesc,
+}
+
+var mappingListClustersSortOrderEnumLowerCase = map[string]ListClustersSortOrderEnum{
+	"asc":  ListClustersSortOrderAsc,
+	"desc": ListClustersSortOrderDesc,
+}
+
+// GetListClustersSortOrderEnumValues Enumerates the set of values for ListClustersSortOrderEnum
+func GetListClustersSortOrderEnumValues() []ListClustersSortOrderEnum {
+	values := make([]ListClustersSortOrderEnum, 0)
+	for _, v := range mappingListClustersSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListClustersSortOrderEnumStringValues Enumerates the set of values in String for ListClustersSortOrderEnum
+func GetListClustersSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListClustersSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListClustersSortOrderEnum(val string) (ListClustersSortOrderEnum, bool) {
+	enum, ok := mappingListClustersSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListClustersSortByEnum Enum with underlying type: string
+type ListClustersSortByEnum string
+
+// Set of constants representing the allowable values for ListClustersSortByEnum
+const (
+	ListClustersSortById          ListClustersSortByEnum = "ID"
+	ListClustersSortByName        ListClustersSortByEnum = "NAME"
+	ListClustersSortByTimeCreated ListClustersSortByEnum = "TIME_CREATED"
+)
+
+var mappingListClustersSortByEnum = map[string]ListClustersSortByEnum{
+	"ID":           ListClustersSortById,
+	"NAME":         ListClustersSortByName,
+	"TIME_CREATED": ListClustersSortByTimeCreated,
+}
+
+var mappingListClustersSortByEnumLowerCase = map[string]ListClustersSortByEnum{
+	"id":           ListClustersSortById,
+	"name":         ListClustersSortByName,
+	"time_created": ListClustersSortByTimeCreated,
+}
+
+// GetListClustersSortByEnumValues Enumerates the set of values for ListClustersSortByEnum
+func GetListClustersSortByEnumValues() []ListClustersSortByEnum {
+	values := make([]ListClustersSortByEnum, 0)
+	for _, v := range mappingListClustersSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListClustersSortByEnumStringValues Enumerates the set of values in String for ListClustersSortByEnum
+func GetListClustersSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListClustersSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListClustersSortByEnum(val string) (ListClustersSortByEnum, bool) {
+	enum, ok := mappingListClustersSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_node_pools_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_node_pools_request_response.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListNodePoolsRequest wrapper for the ListNodePools operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListNodePools.go.html to see an example of how to use ListNodePoolsRequest.
+type ListNodePoolsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"false" contributesTo:"query" name:"clusterId"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListNodePoolsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListNodePoolsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A list of nodepool lifecycle states on which to filter on, matching any of the list items (OR logic). eg. [ACTIVE, DELETING]
+	LifecycleState []NodePoolLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListNodePoolsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListNodePoolsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListNodePoolsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListNodePoolsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListNodePoolsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListNodePoolsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListNodePoolsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListNodePoolsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListNodePoolsSortByEnumStringValues(), ",")))
+	}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingNodePoolLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetNodePoolLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListNodePoolsResponse wrapper for the ListNodePools operation
+type ListNodePoolsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []NodePoolSummary instances
+	Items []NodePoolSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListNodePoolsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListNodePoolsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListNodePoolsSortOrderEnum Enum with underlying type: string
+type ListNodePoolsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListNodePoolsSortOrderEnum
+const (
+	ListNodePoolsSortOrderAsc  ListNodePoolsSortOrderEnum = "ASC"
+	ListNodePoolsSortOrderDesc ListNodePoolsSortOrderEnum = "DESC"
+)
+
+var mappingListNodePoolsSortOrderEnum = map[string]ListNodePoolsSortOrderEnum{
+	"ASC":  ListNodePoolsSortOrderAsc,
+	"DESC": ListNodePoolsSortOrderDesc,
+}
+
+var mappingListNodePoolsSortOrderEnumLowerCase = map[string]ListNodePoolsSortOrderEnum{
+	"asc":  ListNodePoolsSortOrderAsc,
+	"desc": ListNodePoolsSortOrderDesc,
+}
+
+// GetListNodePoolsSortOrderEnumValues Enumerates the set of values for ListNodePoolsSortOrderEnum
+func GetListNodePoolsSortOrderEnumValues() []ListNodePoolsSortOrderEnum {
+	values := make([]ListNodePoolsSortOrderEnum, 0)
+	for _, v := range mappingListNodePoolsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListNodePoolsSortOrderEnumStringValues Enumerates the set of values in String for ListNodePoolsSortOrderEnum
+func GetListNodePoolsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListNodePoolsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListNodePoolsSortOrderEnum(val string) (ListNodePoolsSortOrderEnum, bool) {
+	enum, ok := mappingListNodePoolsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListNodePoolsSortByEnum Enum with underlying type: string
+type ListNodePoolsSortByEnum string
+
+// Set of constants representing the allowable values for ListNodePoolsSortByEnum
+const (
+	ListNodePoolsSortById          ListNodePoolsSortByEnum = "ID"
+	ListNodePoolsSortByName        ListNodePoolsSortByEnum = "NAME"
+	ListNodePoolsSortByTimeCreated ListNodePoolsSortByEnum = "TIME_CREATED"
+)
+
+var mappingListNodePoolsSortByEnum = map[string]ListNodePoolsSortByEnum{
+	"ID":           ListNodePoolsSortById,
+	"NAME":         ListNodePoolsSortByName,
+	"TIME_CREATED": ListNodePoolsSortByTimeCreated,
+}
+
+var mappingListNodePoolsSortByEnumLowerCase = map[string]ListNodePoolsSortByEnum{
+	"id":           ListNodePoolsSortById,
+	"name":         ListNodePoolsSortByName,
+	"time_created": ListNodePoolsSortByTimeCreated,
+}
+
+// GetListNodePoolsSortByEnumValues Enumerates the set of values for ListNodePoolsSortByEnum
+func GetListNodePoolsSortByEnumValues() []ListNodePoolsSortByEnum {
+	values := make([]ListNodePoolsSortByEnum, 0)
+	for _, v := range mappingListNodePoolsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListNodePoolsSortByEnumStringValues Enumerates the set of values in String for ListNodePoolsSortByEnum
+func GetListNodePoolsSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListNodePoolsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListNodePoolsSortByEnum(val string) (ListNodePoolsSortByEnum, bool) {
+	enum, ok := mappingListNodePoolsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_pod_shapes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_pod_shapes_request_response.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListPodShapesRequest wrapper for the ListPodShapes operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListPodShapes.go.html to see an example of how to use ListPodShapesRequest.
+type ListPodShapesRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The availability domain of the pod shape.
+	AvailabilityDomain *string `mandatory:"false" contributesTo:"query" name:"availabilityDomain"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListPodShapesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListPodShapesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListPodShapesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListPodShapesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListPodShapesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListPodShapesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListPodShapesRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListPodShapesSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListPodShapesSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListPodShapesSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListPodShapesSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListPodShapesResponse wrapper for the ListPodShapes operation
+type ListPodShapesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []PodShapeSummary instances
+	Items []PodShapeSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListPodShapesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListPodShapesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListPodShapesSortOrderEnum Enum with underlying type: string
+type ListPodShapesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListPodShapesSortOrderEnum
+const (
+	ListPodShapesSortOrderAsc  ListPodShapesSortOrderEnum = "ASC"
+	ListPodShapesSortOrderDesc ListPodShapesSortOrderEnum = "DESC"
+)
+
+var mappingListPodShapesSortOrderEnum = map[string]ListPodShapesSortOrderEnum{
+	"ASC":  ListPodShapesSortOrderAsc,
+	"DESC": ListPodShapesSortOrderDesc,
+}
+
+var mappingListPodShapesSortOrderEnumLowerCase = map[string]ListPodShapesSortOrderEnum{
+	"asc":  ListPodShapesSortOrderAsc,
+	"desc": ListPodShapesSortOrderDesc,
+}
+
+// GetListPodShapesSortOrderEnumValues Enumerates the set of values for ListPodShapesSortOrderEnum
+func GetListPodShapesSortOrderEnumValues() []ListPodShapesSortOrderEnum {
+	values := make([]ListPodShapesSortOrderEnum, 0)
+	for _, v := range mappingListPodShapesSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListPodShapesSortOrderEnumStringValues Enumerates the set of values in String for ListPodShapesSortOrderEnum
+func GetListPodShapesSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListPodShapesSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListPodShapesSortOrderEnum(val string) (ListPodShapesSortOrderEnum, bool) {
+	enum, ok := mappingListPodShapesSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListPodShapesSortByEnum Enum with underlying type: string
+type ListPodShapesSortByEnum string
+
+// Set of constants representing the allowable values for ListPodShapesSortByEnum
+const (
+	ListPodShapesSortById          ListPodShapesSortByEnum = "ID"
+	ListPodShapesSortByName        ListPodShapesSortByEnum = "NAME"
+	ListPodShapesSortByTimeCreated ListPodShapesSortByEnum = "TIME_CREATED"
+)
+
+var mappingListPodShapesSortByEnum = map[string]ListPodShapesSortByEnum{
+	"ID":           ListPodShapesSortById,
+	"NAME":         ListPodShapesSortByName,
+	"TIME_CREATED": ListPodShapesSortByTimeCreated,
+}
+
+var mappingListPodShapesSortByEnumLowerCase = map[string]ListPodShapesSortByEnum{
+	"id":           ListPodShapesSortById,
+	"name":         ListPodShapesSortByName,
+	"time_created": ListPodShapesSortByTimeCreated,
+}
+
+// GetListPodShapesSortByEnumValues Enumerates the set of values for ListPodShapesSortByEnum
+func GetListPodShapesSortByEnumValues() []ListPodShapesSortByEnum {
+	values := make([]ListPodShapesSortByEnum, 0)
+	for _, v := range mappingListPodShapesSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListPodShapesSortByEnumStringValues Enumerates the set of values in String for ListPodShapesSortByEnum
+func GetListPodShapesSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListPodShapesSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListPodShapesSortByEnum(val string) (ListPodShapesSortByEnum, bool) {
+	enum, ok := mappingListPodShapesSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_virtual_node_pools_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_virtual_node_pools_request_response.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListVirtualNodePoolsRequest wrapper for the ListVirtualNodePools operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListVirtualNodePools.go.html to see an example of how to use ListVirtualNodePoolsRequest.
+type ListVirtualNodePoolsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"false" contributesTo:"query" name:"clusterId"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListVirtualNodePoolsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListVirtualNodePoolsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// A virtual node pool lifecycle state to filter on. Can have multiple parameters of this name.
+	LifecycleState []VirtualNodePoolLifecycleStateEnum `contributesTo:"query" name:"lifecycleState" omitEmpty:"true" collectionFormat:"multi"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListVirtualNodePoolsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListVirtualNodePoolsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListVirtualNodePoolsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListVirtualNodePoolsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListVirtualNodePoolsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListVirtualNodePoolsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListVirtualNodePoolsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListVirtualNodePoolsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListVirtualNodePoolsSortByEnumStringValues(), ",")))
+	}
+	for _, val := range request.LifecycleState {
+		if _, ok := GetMappingVirtualNodePoolLifecycleStateEnum(string(val)); !ok && val != "" {
+			errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", val, strings.Join(GetVirtualNodePoolLifecycleStateEnumStringValues(), ",")))
+		}
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListVirtualNodePoolsResponse wrapper for the ListVirtualNodePools operation
+type ListVirtualNodePoolsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []VirtualNodePoolSummary instances
+	Items []VirtualNodePoolSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListVirtualNodePoolsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListVirtualNodePoolsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListVirtualNodePoolsSortOrderEnum Enum with underlying type: string
+type ListVirtualNodePoolsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListVirtualNodePoolsSortOrderEnum
+const (
+	ListVirtualNodePoolsSortOrderAsc  ListVirtualNodePoolsSortOrderEnum = "ASC"
+	ListVirtualNodePoolsSortOrderDesc ListVirtualNodePoolsSortOrderEnum = "DESC"
+)
+
+var mappingListVirtualNodePoolsSortOrderEnum = map[string]ListVirtualNodePoolsSortOrderEnum{
+	"ASC":  ListVirtualNodePoolsSortOrderAsc,
+	"DESC": ListVirtualNodePoolsSortOrderDesc,
+}
+
+var mappingListVirtualNodePoolsSortOrderEnumLowerCase = map[string]ListVirtualNodePoolsSortOrderEnum{
+	"asc":  ListVirtualNodePoolsSortOrderAsc,
+	"desc": ListVirtualNodePoolsSortOrderDesc,
+}
+
+// GetListVirtualNodePoolsSortOrderEnumValues Enumerates the set of values for ListVirtualNodePoolsSortOrderEnum
+func GetListVirtualNodePoolsSortOrderEnumValues() []ListVirtualNodePoolsSortOrderEnum {
+	values := make([]ListVirtualNodePoolsSortOrderEnum, 0)
+	for _, v := range mappingListVirtualNodePoolsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListVirtualNodePoolsSortOrderEnumStringValues Enumerates the set of values in String for ListVirtualNodePoolsSortOrderEnum
+func GetListVirtualNodePoolsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListVirtualNodePoolsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListVirtualNodePoolsSortOrderEnum(val string) (ListVirtualNodePoolsSortOrderEnum, bool) {
+	enum, ok := mappingListVirtualNodePoolsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListVirtualNodePoolsSortByEnum Enum with underlying type: string
+type ListVirtualNodePoolsSortByEnum string
+
+// Set of constants representing the allowable values for ListVirtualNodePoolsSortByEnum
+const (
+	ListVirtualNodePoolsSortById          ListVirtualNodePoolsSortByEnum = "ID"
+	ListVirtualNodePoolsSortByName        ListVirtualNodePoolsSortByEnum = "NAME"
+	ListVirtualNodePoolsSortByTimeCreated ListVirtualNodePoolsSortByEnum = "TIME_CREATED"
+)
+
+var mappingListVirtualNodePoolsSortByEnum = map[string]ListVirtualNodePoolsSortByEnum{
+	"ID":           ListVirtualNodePoolsSortById,
+	"NAME":         ListVirtualNodePoolsSortByName,
+	"TIME_CREATED": ListVirtualNodePoolsSortByTimeCreated,
+}
+
+var mappingListVirtualNodePoolsSortByEnumLowerCase = map[string]ListVirtualNodePoolsSortByEnum{
+	"id":           ListVirtualNodePoolsSortById,
+	"name":         ListVirtualNodePoolsSortByName,
+	"time_created": ListVirtualNodePoolsSortByTimeCreated,
+}
+
+// GetListVirtualNodePoolsSortByEnumValues Enumerates the set of values for ListVirtualNodePoolsSortByEnum
+func GetListVirtualNodePoolsSortByEnumValues() []ListVirtualNodePoolsSortByEnum {
+	values := make([]ListVirtualNodePoolsSortByEnum, 0)
+	for _, v := range mappingListVirtualNodePoolsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListVirtualNodePoolsSortByEnumStringValues Enumerates the set of values in String for ListVirtualNodePoolsSortByEnum
+func GetListVirtualNodePoolsSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListVirtualNodePoolsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListVirtualNodePoolsSortByEnum(val string) (ListVirtualNodePoolsSortByEnum, bool) {
+	enum, ok := mappingListVirtualNodePoolsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_virtual_nodes_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_virtual_nodes_request_response.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListVirtualNodesRequest wrapper for the ListVirtualNodes operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListVirtualNodes.go.html to see an example of how to use ListVirtualNodesRequest.
+type ListVirtualNodesRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// The name to filter on.
+	Name *string `mandatory:"false" contributesTo:"query" name:"name"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListVirtualNodesSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListVirtualNodesSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListVirtualNodesRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListVirtualNodesRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListVirtualNodesRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListVirtualNodesRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListVirtualNodesRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListVirtualNodesSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListVirtualNodesSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListVirtualNodesSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListVirtualNodesSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListVirtualNodesResponse wrapper for the ListVirtualNodes operation
+type ListVirtualNodesResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []VirtualNodeSummary instances
+	Items []VirtualNodeSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListVirtualNodesResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListVirtualNodesResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListVirtualNodesSortOrderEnum Enum with underlying type: string
+type ListVirtualNodesSortOrderEnum string
+
+// Set of constants representing the allowable values for ListVirtualNodesSortOrderEnum
+const (
+	ListVirtualNodesSortOrderAsc  ListVirtualNodesSortOrderEnum = "ASC"
+	ListVirtualNodesSortOrderDesc ListVirtualNodesSortOrderEnum = "DESC"
+)
+
+var mappingListVirtualNodesSortOrderEnum = map[string]ListVirtualNodesSortOrderEnum{
+	"ASC":  ListVirtualNodesSortOrderAsc,
+	"DESC": ListVirtualNodesSortOrderDesc,
+}
+
+var mappingListVirtualNodesSortOrderEnumLowerCase = map[string]ListVirtualNodesSortOrderEnum{
+	"asc":  ListVirtualNodesSortOrderAsc,
+	"desc": ListVirtualNodesSortOrderDesc,
+}
+
+// GetListVirtualNodesSortOrderEnumValues Enumerates the set of values for ListVirtualNodesSortOrderEnum
+func GetListVirtualNodesSortOrderEnumValues() []ListVirtualNodesSortOrderEnum {
+	values := make([]ListVirtualNodesSortOrderEnum, 0)
+	for _, v := range mappingListVirtualNodesSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListVirtualNodesSortOrderEnumStringValues Enumerates the set of values in String for ListVirtualNodesSortOrderEnum
+func GetListVirtualNodesSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListVirtualNodesSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListVirtualNodesSortOrderEnum(val string) (ListVirtualNodesSortOrderEnum, bool) {
+	enum, ok := mappingListVirtualNodesSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListVirtualNodesSortByEnum Enum with underlying type: string
+type ListVirtualNodesSortByEnum string
+
+// Set of constants representing the allowable values for ListVirtualNodesSortByEnum
+const (
+	ListVirtualNodesSortById          ListVirtualNodesSortByEnum = "ID"
+	ListVirtualNodesSortByName        ListVirtualNodesSortByEnum = "NAME"
+	ListVirtualNodesSortByTimeCreated ListVirtualNodesSortByEnum = "TIME_CREATED"
+)
+
+var mappingListVirtualNodesSortByEnum = map[string]ListVirtualNodesSortByEnum{
+	"ID":           ListVirtualNodesSortById,
+	"NAME":         ListVirtualNodesSortByName,
+	"TIME_CREATED": ListVirtualNodesSortByTimeCreated,
+}
+
+var mappingListVirtualNodesSortByEnumLowerCase = map[string]ListVirtualNodesSortByEnum{
+	"id":           ListVirtualNodesSortById,
+	"name":         ListVirtualNodesSortByName,
+	"time_created": ListVirtualNodesSortByTimeCreated,
+}
+
+// GetListVirtualNodesSortByEnumValues Enumerates the set of values for ListVirtualNodesSortByEnum
+func GetListVirtualNodesSortByEnumValues() []ListVirtualNodesSortByEnum {
+	values := make([]ListVirtualNodesSortByEnum, 0)
+	for _, v := range mappingListVirtualNodesSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListVirtualNodesSortByEnumStringValues Enumerates the set of values in String for ListVirtualNodesSortByEnum
+func GetListVirtualNodesSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"NAME",
+		"TIME_CREATED",
+	}
+}
+
+// GetMappingListVirtualNodesSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListVirtualNodesSortByEnum(val string) (ListVirtualNodesSortByEnum, bool) {
+	enum, ok := mappingListVirtualNodesSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_request_errors_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_request_errors_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestErrorsRequest wrapper for the ListWorkRequestErrors operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequestErrors.go.html to see an example of how to use ListWorkRequestErrorsRequest.
+type ListWorkRequestErrorsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestErrorsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestErrorsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestErrorsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestErrorsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestErrorsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestErrorsResponse wrapper for the ListWorkRequestErrors operation
+type ListWorkRequestErrorsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The []WorkRequestError instance
+	Items []WorkRequestError `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestErrorsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestErrorsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_request_logs_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_request_logs_request_response.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestLogsRequest wrapper for the ListWorkRequestLogs operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequestLogs.go.html to see an example of how to use ListWorkRequestLogsRequest.
+type ListWorkRequestLogsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID of the work request.
+	WorkRequestId *string `mandatory:"true" contributesTo:"path" name:"workRequestId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestLogsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestLogsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestLogsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestLogsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestLogsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestLogsResponse wrapper for the ListWorkRequestLogs operation
+type ListWorkRequestLogsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The []WorkRequestLogEntry instance
+	Items []WorkRequestLogEntry `presentIn:"body"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestLogsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestLogsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_requests_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_work_requests_request_response.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkRequestsRequest wrapper for the ListWorkRequests operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkRequests.go.html to see an example of how to use ListWorkRequestsRequest.
+type ListWorkRequestsRequest struct {
+
+	// The OCID of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"false" contributesTo:"query" name:"clusterId"`
+
+	// The OCID of the resource associated with a work request
+	ResourceId *string `mandatory:"false" contributesTo:"query" name:"resourceId"`
+
+	// Type of the resource associated with a work request
+	ResourceType ListWorkRequestsResourceTypeEnum `mandatory:"false" contributesTo:"query" name:"resourceType" omitEmpty:"true"`
+
+	// A work request status to filter on. Can have multiple parameters of this name.
+	Status []string `contributesTo:"query" name:"status" collectionFormat:"multi"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListWorkRequestsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListWorkRequestsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkRequestsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkRequestsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkRequestsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkRequestsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkRequestsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListWorkRequestsResourceTypeEnum(string(request.ResourceType)); !ok && request.ResourceType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ResourceType: %s. Supported values are: %s.", request.ResourceType, strings.Join(GetListWorkRequestsResourceTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListWorkRequestsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListWorkRequestsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListWorkRequestsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListWorkRequestsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkRequestsResponse wrapper for the ListWorkRequests operation
+type ListWorkRequestsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkRequestSummary instances
+	Items []WorkRequestSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkRequestsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkRequestsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWorkRequestsResourceTypeEnum Enum with underlying type: string
+type ListWorkRequestsResourceTypeEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsResourceTypeEnum
+const (
+	ListWorkRequestsResourceTypeCluster  ListWorkRequestsResourceTypeEnum = "CLUSTER"
+	ListWorkRequestsResourceTypeNodepool ListWorkRequestsResourceTypeEnum = "NODEPOOL"
+)
+
+var mappingListWorkRequestsResourceTypeEnum = map[string]ListWorkRequestsResourceTypeEnum{
+	"CLUSTER":  ListWorkRequestsResourceTypeCluster,
+	"NODEPOOL": ListWorkRequestsResourceTypeNodepool,
+}
+
+var mappingListWorkRequestsResourceTypeEnumLowerCase = map[string]ListWorkRequestsResourceTypeEnum{
+	"cluster":  ListWorkRequestsResourceTypeCluster,
+	"nodepool": ListWorkRequestsResourceTypeNodepool,
+}
+
+// GetListWorkRequestsResourceTypeEnumValues Enumerates the set of values for ListWorkRequestsResourceTypeEnum
+func GetListWorkRequestsResourceTypeEnumValues() []ListWorkRequestsResourceTypeEnum {
+	values := make([]ListWorkRequestsResourceTypeEnum, 0)
+	for _, v := range mappingListWorkRequestsResourceTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWorkRequestsResourceTypeEnumStringValues Enumerates the set of values in String for ListWorkRequestsResourceTypeEnum
+func GetListWorkRequestsResourceTypeEnumStringValues() []string {
+	return []string{
+		"CLUSTER",
+		"NODEPOOL",
+	}
+}
+
+// GetMappingListWorkRequestsResourceTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWorkRequestsResourceTypeEnum(val string) (ListWorkRequestsResourceTypeEnum, bool) {
+	enum, ok := mappingListWorkRequestsResourceTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListWorkRequestsSortOrderEnum Enum with underlying type: string
+type ListWorkRequestsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsSortOrderEnum
+const (
+	ListWorkRequestsSortOrderAsc  ListWorkRequestsSortOrderEnum = "ASC"
+	ListWorkRequestsSortOrderDesc ListWorkRequestsSortOrderEnum = "DESC"
+)
+
+var mappingListWorkRequestsSortOrderEnum = map[string]ListWorkRequestsSortOrderEnum{
+	"ASC":  ListWorkRequestsSortOrderAsc,
+	"DESC": ListWorkRequestsSortOrderDesc,
+}
+
+var mappingListWorkRequestsSortOrderEnumLowerCase = map[string]ListWorkRequestsSortOrderEnum{
+	"asc":  ListWorkRequestsSortOrderAsc,
+	"desc": ListWorkRequestsSortOrderDesc,
+}
+
+// GetListWorkRequestsSortOrderEnumValues Enumerates the set of values for ListWorkRequestsSortOrderEnum
+func GetListWorkRequestsSortOrderEnumValues() []ListWorkRequestsSortOrderEnum {
+	values := make([]ListWorkRequestsSortOrderEnum, 0)
+	for _, v := range mappingListWorkRequestsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWorkRequestsSortOrderEnumStringValues Enumerates the set of values in String for ListWorkRequestsSortOrderEnum
+func GetListWorkRequestsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListWorkRequestsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWorkRequestsSortOrderEnum(val string) (ListWorkRequestsSortOrderEnum, bool) {
+	enum, ok := mappingListWorkRequestsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListWorkRequestsSortByEnum Enum with underlying type: string
+type ListWorkRequestsSortByEnum string
+
+// Set of constants representing the allowable values for ListWorkRequestsSortByEnum
+const (
+	ListWorkRequestsSortById            ListWorkRequestsSortByEnum = "ID"
+	ListWorkRequestsSortByOperationType ListWorkRequestsSortByEnum = "OPERATION_TYPE"
+	ListWorkRequestsSortByStatus        ListWorkRequestsSortByEnum = "STATUS"
+	ListWorkRequestsSortByTimeAccepted  ListWorkRequestsSortByEnum = "TIME_ACCEPTED"
+	ListWorkRequestsSortByTimeStarted   ListWorkRequestsSortByEnum = "TIME_STARTED"
+	ListWorkRequestsSortByTimeFinished  ListWorkRequestsSortByEnum = "TIME_FINISHED"
+)
+
+var mappingListWorkRequestsSortByEnum = map[string]ListWorkRequestsSortByEnum{
+	"ID":             ListWorkRequestsSortById,
+	"OPERATION_TYPE": ListWorkRequestsSortByOperationType,
+	"STATUS":         ListWorkRequestsSortByStatus,
+	"TIME_ACCEPTED":  ListWorkRequestsSortByTimeAccepted,
+	"TIME_STARTED":   ListWorkRequestsSortByTimeStarted,
+	"TIME_FINISHED":  ListWorkRequestsSortByTimeFinished,
+}
+
+var mappingListWorkRequestsSortByEnumLowerCase = map[string]ListWorkRequestsSortByEnum{
+	"id":             ListWorkRequestsSortById,
+	"operation_type": ListWorkRequestsSortByOperationType,
+	"status":         ListWorkRequestsSortByStatus,
+	"time_accepted":  ListWorkRequestsSortByTimeAccepted,
+	"time_started":   ListWorkRequestsSortByTimeStarted,
+	"time_finished":  ListWorkRequestsSortByTimeFinished,
+}
+
+// GetListWorkRequestsSortByEnumValues Enumerates the set of values for ListWorkRequestsSortByEnum
+func GetListWorkRequestsSortByEnumValues() []ListWorkRequestsSortByEnum {
+	values := make([]ListWorkRequestsSortByEnum, 0)
+	for _, v := range mappingListWorkRequestsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWorkRequestsSortByEnumStringValues Enumerates the set of values in String for ListWorkRequestsSortByEnum
+func GetListWorkRequestsSortByEnumStringValues() []string {
+	return []string{
+		"ID",
+		"OPERATION_TYPE",
+		"STATUS",
+		"TIME_ACCEPTED",
+		"TIME_STARTED",
+		"TIME_FINISHED",
+	}
+}
+
+// GetMappingListWorkRequestsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWorkRequestsSortByEnum(val string) (ListWorkRequestsSortByEnum, bool) {
+	enum, ok := mappingListWorkRequestsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_workload_mappings_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/list_workload_mappings_request_response.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// ListWorkloadMappingsRequest wrapper for the ListWorkloadMappings operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/ListWorkloadMappings.go.html to see an example of how to use ListWorkloadMappingsRequest.
+type ListWorkloadMappingsRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated "List" call.
+	// 1 is the minimum, 1000 is the maximum. For important details about how pagination works,
+	// see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List" call.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The optional order in which to sort the results.
+	SortOrder ListWorkloadMappingsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// The optional field to sort the results by.
+	SortBy ListWorkloadMappingsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListWorkloadMappingsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListWorkloadMappingsRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request ListWorkloadMappingsRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListWorkloadMappingsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request ListWorkloadMappingsRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingListWorkloadMappingsSortOrderEnum(string(request.SortOrder)); !ok && request.SortOrder != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortOrder: %s. Supported values are: %s.", request.SortOrder, strings.Join(GetListWorkloadMappingsSortOrderEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingListWorkloadMappingsSortByEnum(string(request.SortBy)); !ok && request.SortBy != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for SortBy: %s. Supported values are: %s.", request.SortBy, strings.Join(GetListWorkloadMappingsSortByEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// ListWorkloadMappingsResponse wrapper for the ListWorkloadMappings operation
+type ListWorkloadMappingsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []WorkloadMappingSummary instances
+	Items []WorkloadMappingSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages of results remain.
+	// For important details about how pagination works, see List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListWorkloadMappingsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListWorkloadMappingsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListWorkloadMappingsSortOrderEnum Enum with underlying type: string
+type ListWorkloadMappingsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListWorkloadMappingsSortOrderEnum
+const (
+	ListWorkloadMappingsSortOrderAsc  ListWorkloadMappingsSortOrderEnum = "ASC"
+	ListWorkloadMappingsSortOrderDesc ListWorkloadMappingsSortOrderEnum = "DESC"
+)
+
+var mappingListWorkloadMappingsSortOrderEnum = map[string]ListWorkloadMappingsSortOrderEnum{
+	"ASC":  ListWorkloadMappingsSortOrderAsc,
+	"DESC": ListWorkloadMappingsSortOrderDesc,
+}
+
+var mappingListWorkloadMappingsSortOrderEnumLowerCase = map[string]ListWorkloadMappingsSortOrderEnum{
+	"asc":  ListWorkloadMappingsSortOrderAsc,
+	"desc": ListWorkloadMappingsSortOrderDesc,
+}
+
+// GetListWorkloadMappingsSortOrderEnumValues Enumerates the set of values for ListWorkloadMappingsSortOrderEnum
+func GetListWorkloadMappingsSortOrderEnumValues() []ListWorkloadMappingsSortOrderEnum {
+	values := make([]ListWorkloadMappingsSortOrderEnum, 0)
+	for _, v := range mappingListWorkloadMappingsSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWorkloadMappingsSortOrderEnumStringValues Enumerates the set of values in String for ListWorkloadMappingsSortOrderEnum
+func GetListWorkloadMappingsSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingListWorkloadMappingsSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWorkloadMappingsSortOrderEnum(val string) (ListWorkloadMappingsSortOrderEnum, bool) {
+	enum, ok := mappingListWorkloadMappingsSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}
+
+// ListWorkloadMappingsSortByEnum Enum with underlying type: string
+type ListWorkloadMappingsSortByEnum string
+
+// Set of constants representing the allowable values for ListWorkloadMappingsSortByEnum
+const (
+	ListWorkloadMappingsSortByNamespace   ListWorkloadMappingsSortByEnum = "NAMESPACE"
+	ListWorkloadMappingsSortByTimecreated ListWorkloadMappingsSortByEnum = "TIMECREATED"
+)
+
+var mappingListWorkloadMappingsSortByEnum = map[string]ListWorkloadMappingsSortByEnum{
+	"NAMESPACE":   ListWorkloadMappingsSortByNamespace,
+	"TIMECREATED": ListWorkloadMappingsSortByTimecreated,
+}
+
+var mappingListWorkloadMappingsSortByEnumLowerCase = map[string]ListWorkloadMappingsSortByEnum{
+	"namespace":   ListWorkloadMappingsSortByNamespace,
+	"timecreated": ListWorkloadMappingsSortByTimecreated,
+}
+
+// GetListWorkloadMappingsSortByEnumValues Enumerates the set of values for ListWorkloadMappingsSortByEnum
+func GetListWorkloadMappingsSortByEnumValues() []ListWorkloadMappingsSortByEnum {
+	values := make([]ListWorkloadMappingsSortByEnum, 0)
+	for _, v := range mappingListWorkloadMappingsSortByEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetListWorkloadMappingsSortByEnumStringValues Enumerates the set of values in String for ListWorkloadMappingsSortByEnum
+func GetListWorkloadMappingsSortByEnumStringValues() []string {
+	return []string{
+		"NAMESPACE",
+		"TIMECREATED",
+	}
+}
+
+// GetMappingListWorkloadMappingsSortByEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingListWorkloadMappingsSortByEnum(val string) (ListWorkloadMappingsSortByEnum, bool) {
+	enum, ok := mappingListWorkloadMappingsSortByEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Node The properties that define a node.
+type Node struct {
+
+	// The OCID of the compute instance backing this node.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The name of the node.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes this node is running.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// The name of the availability domain in which this node is placed.
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// The OCID of the subnet in which this node is placed.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// The OCID of the node pool to which this node belongs.
+	NodePoolId *string `mandatory:"false" json:"nodePoolId"`
+
+	// The fault domain of this node.
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// The private IP address of this node.
+	PrivateIp *string `mandatory:"false" json:"privateIp"`
+
+	// The public IP address of this node.
+	PublicIp *string `mandatory:"false" json:"publicIp"`
+
+	// An error that may be associated with the node.
+	NodeError *NodeError `mandatory:"false" json:"nodeError"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	// The state of the node.
+	LifecycleState NodeLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the node.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+}
+
+func (m Node) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m Node) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNodeLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNodeLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// NodeLifecycleStateEnum Enum with underlying type: string
+type NodeLifecycleStateEnum string
+
+// Set of constants representing the allowable values for NodeLifecycleStateEnum
+const (
+	NodeLifecycleStateCreating NodeLifecycleStateEnum = "CREATING"
+	NodeLifecycleStateActive   NodeLifecycleStateEnum = "ACTIVE"
+	NodeLifecycleStateUpdating NodeLifecycleStateEnum = "UPDATING"
+	NodeLifecycleStateDeleting NodeLifecycleStateEnum = "DELETING"
+	NodeLifecycleStateDeleted  NodeLifecycleStateEnum = "DELETED"
+	NodeLifecycleStateFailing  NodeLifecycleStateEnum = "FAILING"
+	NodeLifecycleStateInactive NodeLifecycleStateEnum = "INACTIVE"
+)
+
+var mappingNodeLifecycleStateEnum = map[string]NodeLifecycleStateEnum{
+	"CREATING": NodeLifecycleStateCreating,
+	"ACTIVE":   NodeLifecycleStateActive,
+	"UPDATING": NodeLifecycleStateUpdating,
+	"DELETING": NodeLifecycleStateDeleting,
+	"DELETED":  NodeLifecycleStateDeleted,
+	"FAILING":  NodeLifecycleStateFailing,
+	"INACTIVE": NodeLifecycleStateInactive,
+}
+
+var mappingNodeLifecycleStateEnumLowerCase = map[string]NodeLifecycleStateEnum{
+	"creating": NodeLifecycleStateCreating,
+	"active":   NodeLifecycleStateActive,
+	"updating": NodeLifecycleStateUpdating,
+	"deleting": NodeLifecycleStateDeleting,
+	"deleted":  NodeLifecycleStateDeleted,
+	"failing":  NodeLifecycleStateFailing,
+	"inactive": NodeLifecycleStateInactive,
+}
+
+// GetNodeLifecycleStateEnumValues Enumerates the set of values for NodeLifecycleStateEnum
+func GetNodeLifecycleStateEnumValues() []NodeLifecycleStateEnum {
+	values := make([]NodeLifecycleStateEnum, 0)
+	for _, v := range mappingNodeLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNodeLifecycleStateEnumStringValues Enumerates the set of values in String for NodeLifecycleStateEnum
+func GetNodeLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"UPDATING",
+		"DELETING",
+		"DELETED",
+		"FAILING",
+		"INACTIVE",
+	}
+}
+
+// GetMappingNodeLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNodeLifecycleStateEnum(val string) (NodeLifecycleStateEnum, bool) {
+	enum, ok := mappingNodeLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_error.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeError The properties that define an upstream error while managing a node.
+type NodeError struct {
+
+	// A short error code that defines the upstream error, meant for programmatic parsing. See API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+	Code *string `mandatory:"true" json:"code"`
+
+	// A human-readable error string of the upstream error.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The status of the HTTP response encountered in the upstream error.
+	Status *string `mandatory:"false" json:"status"`
+
+	// Unique Oracle-assigned identifier for the upstream request. If you need to contact Oracle about a particular upstream request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" json:"opc-request-id"`
+}
+
+func (m NodeError) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeError) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_eviction_node_pool_settings.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_eviction_node_pool_settings.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeEvictionNodePoolSettings Node Eviction Details configuration
+type NodeEvictionNodePoolSettings struct {
+
+	// Duration after which OKE will give up eviction of the pods on the node. PT0M will indicate you want to delete the node without cordon and drain.
+	// Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	EvictionGraceDuration *string `mandatory:"false" json:"evictionGraceDuration"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeleteAfterGraceDuration *bool `mandatory:"false" json:"isForceDeleteAfterGraceDuration"`
+}
+
+func (m NodeEvictionNodePoolSettings) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeEvictionNodePoolSettings) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePool A pool of compute nodes attached to a cluster. Avoid entering confidential information.
+type NodePool struct {
+
+	// The OCID of the node pool.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The state of the nodepool.
+	LifecycleState NodePoolLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the nodepool.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The OCID of the compartment in which the node pool exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The OCID of the cluster to which this node pool is attached.
+	ClusterId *string `mandatory:"false" json:"clusterId"`
+
+	// The name of the node pool.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes running on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+	NodeMetadata map[string]string `mandatory:"false" json:"nodeMetadata"`
+
+	// Deprecated. see `nodeSource`. The OCID of the image running on the nodes in the node pool.
+	NodeImageId *string `mandatory:"false" json:"nodeImageId"`
+
+	// Deprecated. see `nodeSource`. The name of the image running on the nodes in the node pool.
+	NodeImageName *string `mandatory:"false" json:"nodeImageName"`
+
+	// The shape configuration of the nodes.
+	NodeShapeConfig *NodeShapeConfig `mandatory:"false" json:"nodeShapeConfig"`
+
+	// Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
+	NodeSource NodeSourceOption `mandatory:"false" json:"nodeSource"`
+
+	// Source running on the nodes in the node pool.
+	NodeSourceDetails NodeSourceDetails `mandatory:"false" json:"nodeSourceDetails"`
+
+	// The name of the node shape of the nodes in the node pool.
+	NodeShape *string `mandatory:"false" json:"nodeShape"`
+
+	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
+
+	// The SSH public key on each node in the node pool on launch.
+	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
+
+	// The number of nodes in each subnet.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The nodes in the node pool.
+	Nodes []Node `mandatory:"false" json:"nodes"`
+
+	// The configuration of nodes in the node pool.
+	NodeConfigDetails *NodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings `mandatory:"false" json:"nodeEvictionNodePoolSettings"`
+
+	NodePoolCyclingDetails *NodePoolCyclingDetails `mandatory:"false" json:"nodePoolCyclingDetails"`
+}
+
+func (m NodePool) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePool) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNodePoolLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNodePoolLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NodePool) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                           *string                           `json:"id"`
+		LifecycleState               NodePoolLifecycleStateEnum        `json:"lifecycleState"`
+		LifecycleDetails             *string                           `json:"lifecycleDetails"`
+		CompartmentId                *string                           `json:"compartmentId"`
+		ClusterId                    *string                           `json:"clusterId"`
+		Name                         *string                           `json:"name"`
+		KubernetesVersion            *string                           `json:"kubernetesVersion"`
+		NodeMetadata                 map[string]string                 `json:"nodeMetadata"`
+		NodeImageId                  *string                           `json:"nodeImageId"`
+		NodeImageName                *string                           `json:"nodeImageName"`
+		NodeShapeConfig              *NodeShapeConfig                  `json:"nodeShapeConfig"`
+		NodeSource                   nodesourceoption                  `json:"nodeSource"`
+		NodeSourceDetails            nodesourcedetails                 `json:"nodeSourceDetails"`
+		NodeShape                    *string                           `json:"nodeShape"`
+		InitialNodeLabels            []KeyValue                        `json:"initialNodeLabels"`
+		SshPublicKey                 *string                           `json:"sshPublicKey"`
+		QuantityPerSubnet            *int                              `json:"quantityPerSubnet"`
+		SubnetIds                    []string                          `json:"subnetIds"`
+		Nodes                        []Node                            `json:"nodes"`
+		NodeConfigDetails            *NodePoolNodeConfigDetails        `json:"nodeConfigDetails"`
+		FreeformTags                 map[string]string                 `json:"freeformTags"`
+		DefinedTags                  map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags                   map[string]map[string]interface{} `json:"systemTags"`
+		NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings     `json:"nodeEvictionNodePoolSettings"`
+		NodePoolCyclingDetails       *NodePoolCyclingDetails           `json:"nodePoolCyclingDetails"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Id = model.Id
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.CompartmentId = model.CompartmentId
+
+	m.ClusterId = model.ClusterId
+
+	m.Name = model.Name
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.NodeMetadata = model.NodeMetadata
+
+	m.NodeImageId = model.NodeImageId
+
+	m.NodeImageName = model.NodeImageName
+
+	m.NodeShapeConfig = model.NodeShapeConfig
+
+	nn, e = model.NodeSource.UnmarshalPolymorphicJSON(model.NodeSource.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSource = nn.(NodeSourceOption)
+	} else {
+		m.NodeSource = nil
+	}
+
+	nn, e = model.NodeSourceDetails.UnmarshalPolymorphicJSON(model.NodeSourceDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSourceDetails = nn.(NodeSourceDetails)
+	} else {
+		m.NodeSourceDetails = nil
+	}
+
+	m.NodeShape = model.NodeShape
+
+	m.InitialNodeLabels = make([]KeyValue, len(model.InitialNodeLabels))
+	copy(m.InitialNodeLabels, model.InitialNodeLabels)
+	m.SshPublicKey = model.SshPublicKey
+
+	m.QuantityPerSubnet = model.QuantityPerSubnet
+
+	m.SubnetIds = make([]string, len(model.SubnetIds))
+	copy(m.SubnetIds, model.SubnetIds)
+	m.Nodes = make([]Node, len(model.Nodes))
+	copy(m.Nodes, model.Nodes)
+	m.NodeConfigDetails = model.NodeConfigDetails
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.NodeEvictionNodePoolSettings = model.NodeEvictionNodePoolSettings
+
+	m.NodePoolCyclingDetails = model.NodePoolCyclingDetails
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_cycling_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_cycling_details.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolCyclingDetails Node Pool Cycling Details
+type NodePoolCyclingDetails struct {
+
+	// Maximum active nodes that would be terminated from nodepool during the cycling nodepool process.
+	// OKE supports both integer and percentage input.
+	// Defaults to 0, Ranges from 0 to Nodepool size or 0% to 100%
+	MaximumUnavailable *string `mandatory:"false" json:"maximumUnavailable"`
+
+	// Maximum additional new compute instances that would be temporarily created and added to nodepool during the cycling nodepool process.
+	// OKE supports both integer and percentage input.
+	// Defaults to 1, Ranges from 0 to Nodepool size or 0% to 100%
+	MaximumSurge *string `mandatory:"false" json:"maximumSurge"`
+
+	// If nodes in the nodepool will be cycled to have new changes.
+	IsNodeCyclingEnabled *bool `mandatory:"false" json:"isNodeCyclingEnabled"`
+}
+
+func (m NodePoolCyclingDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolCyclingDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_lifecycle_state.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// NodePoolLifecycleStateEnum Enum with underlying type: string
+type NodePoolLifecycleStateEnum string
+
+// Set of constants representing the allowable values for NodePoolLifecycleStateEnum
+const (
+	NodePoolLifecycleStateDeleted        NodePoolLifecycleStateEnum = "DELETED"
+	NodePoolLifecycleStateCreating       NodePoolLifecycleStateEnum = "CREATING"
+	NodePoolLifecycleStateActive         NodePoolLifecycleStateEnum = "ACTIVE"
+	NodePoolLifecycleStateUpdating       NodePoolLifecycleStateEnum = "UPDATING"
+	NodePoolLifecycleStateDeleting       NodePoolLifecycleStateEnum = "DELETING"
+	NodePoolLifecycleStateFailed         NodePoolLifecycleStateEnum = "FAILED"
+	NodePoolLifecycleStateInactive       NodePoolLifecycleStateEnum = "INACTIVE"
+	NodePoolLifecycleStateNeedsAttention NodePoolLifecycleStateEnum = "NEEDS_ATTENTION"
+)
+
+var mappingNodePoolLifecycleStateEnum = map[string]NodePoolLifecycleStateEnum{
+	"DELETED":         NodePoolLifecycleStateDeleted,
+	"CREATING":        NodePoolLifecycleStateCreating,
+	"ACTIVE":          NodePoolLifecycleStateActive,
+	"UPDATING":        NodePoolLifecycleStateUpdating,
+	"DELETING":        NodePoolLifecycleStateDeleting,
+	"FAILED":          NodePoolLifecycleStateFailed,
+	"INACTIVE":        NodePoolLifecycleStateInactive,
+	"NEEDS_ATTENTION": NodePoolLifecycleStateNeedsAttention,
+}
+
+var mappingNodePoolLifecycleStateEnumLowerCase = map[string]NodePoolLifecycleStateEnum{
+	"deleted":         NodePoolLifecycleStateDeleted,
+	"creating":        NodePoolLifecycleStateCreating,
+	"active":          NodePoolLifecycleStateActive,
+	"updating":        NodePoolLifecycleStateUpdating,
+	"deleting":        NodePoolLifecycleStateDeleting,
+	"failed":          NodePoolLifecycleStateFailed,
+	"inactive":        NodePoolLifecycleStateInactive,
+	"needs_attention": NodePoolLifecycleStateNeedsAttention,
+}
+
+// GetNodePoolLifecycleStateEnumValues Enumerates the set of values for NodePoolLifecycleStateEnum
+func GetNodePoolLifecycleStateEnumValues() []NodePoolLifecycleStateEnum {
+	values := make([]NodePoolLifecycleStateEnum, 0)
+	for _, v := range mappingNodePoolLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNodePoolLifecycleStateEnumStringValues Enumerates the set of values in String for NodePoolLifecycleStateEnum
+func GetNodePoolLifecycleStateEnumStringValues() []string {
+	return []string{
+		"DELETED",
+		"CREATING",
+		"ACTIVE",
+		"UPDATING",
+		"DELETING",
+		"FAILED",
+		"INACTIVE",
+		"NEEDS_ATTENTION",
+	}
+}
+
+// GetMappingNodePoolLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNodePoolLifecycleStateEnum(val string) (NodePoolLifecycleStateEnum, bool) {
+	enum, ok := mappingNodePoolLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_node_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_node_config_details.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type NodePoolNodeConfigDetails struct {
+
+	// The number of nodes in the node pool.
+	Size *int `mandatory:"false" json:"size"`
+
+	// The OCIDs of the Network Security Group(s) to associate nodes for this node pool with. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The OCID of the Key Management Service key assigned to the boot volume.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"false" json:"placementConfigs"`
+
+	// The CNI related configuration of pods in the node pool.
+	NodePoolPodNetworkOptionDetails NodePoolPodNetworkOptionDetails `mandatory:"false" json:"nodePoolPodNetworkOptionDetails"`
+}
+
+func (m NodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolNodeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NodePoolNodeConfigDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Size                            *int                              `json:"size"`
+		NsgIds                          []string                          `json:"nsgIds"`
+		KmsKeyId                        *string                           `json:"kmsKeyId"`
+		IsPvEncryptionInTransitEnabled  *bool                             `json:"isPvEncryptionInTransitEnabled"`
+		FreeformTags                    map[string]string                 `json:"freeformTags"`
+		DefinedTags                     map[string]map[string]interface{} `json:"definedTags"`
+		PlacementConfigs                []NodePoolPlacementConfigDetails  `json:"placementConfigs"`
+		NodePoolPodNetworkOptionDetails nodepoolpodnetworkoptiondetails   `json:"nodePoolPodNetworkOptionDetails"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Size = model.Size
+
+	m.NsgIds = make([]string, len(model.NsgIds))
+	copy(m.NsgIds, model.NsgIds)
+	m.KmsKeyId = model.KmsKeyId
+
+	m.IsPvEncryptionInTransitEnabled = model.IsPvEncryptionInTransitEnabled
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.PlacementConfigs = make([]NodePoolPlacementConfigDetails, len(model.PlacementConfigs))
+	copy(m.PlacementConfigs, model.PlacementConfigs)
+	nn, e = model.NodePoolPodNetworkOptionDetails.UnmarshalPolymorphicJSON(model.NodePoolPodNetworkOptionDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodePoolPodNetworkOptionDetails = nn.(NodePoolPodNetworkOptionDetails)
+	} else {
+		m.NodePoolPodNetworkOptionDetails = nil
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_options.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolOptions Options for creating or updating node pools.
+type NodePoolOptions struct {
+
+	// Available Kubernetes versions.
+	KubernetesVersions []string `mandatory:"false" json:"kubernetesVersions"`
+
+	// Available shapes for nodes.
+	Shapes []string `mandatory:"false" json:"shapes"`
+
+	// Deprecated. See sources.
+	// When creating a node pool using the `CreateNodePoolDetails` object, only image names contained in this
+	// property can be passed to the `nodeImageName` property.
+	Images []string `mandatory:"false" json:"images"`
+
+	// Available source of the node.
+	Sources []NodeSourceOption `mandatory:"false" json:"sources"`
+}
+
+func (m NodePoolOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NodePoolOptions) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		KubernetesVersions []string           `json:"kubernetesVersions"`
+		Shapes             []string           `json:"shapes"`
+		Images             []string           `json:"images"`
+		Sources            []nodesourceoption `json:"sources"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.KubernetesVersions = make([]string, len(model.KubernetesVersions))
+	copy(m.KubernetesVersions, model.KubernetesVersions)
+	m.Shapes = make([]string, len(model.Shapes))
+	copy(m.Shapes, model.Shapes)
+	m.Images = make([]string, len(model.Images))
+	copy(m.Images, model.Images)
+	m.Sources = make([]NodeSourceOption, len(model.Sources))
+	for i, n := range model.Sources {
+		nn, e = n.UnmarshalPolymorphicJSON(n.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.Sources[i] = nn.(NodeSourceOption)
+		} else {
+			m.Sources[i] = nil
+		}
+	}
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_placement_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_placement_config_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolPlacementConfigDetails The location where a node pool will place nodes.
+type NodePoolPlacementConfigDetails struct {
+
+	// The availability domain in which to place nodes.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The OCID of the subnet in which to place nodes.
+	SubnetId *string `mandatory:"true" json:"subnetId"`
+
+	// The OCID of the compute capacity reservation in which to place the compute instance.
+	CapacityReservationId *string `mandatory:"false" json:"capacityReservationId"`
+
+	PreemptibleNodeConfig *PreemptibleNodeConfigDetails `mandatory:"false" json:"preemptibleNodeConfig"`
+
+	// A list of fault domains in which to place nodes.
+	FaultDomains []string `mandatory:"false" json:"faultDomains"`
+}
+
+func (m NodePoolPlacementConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolPlacementConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_pod_network_option_details.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolPodNetworkOptionDetails The CNI type and relevant network details for the pods of a given node pool
+type NodePoolPodNetworkOptionDetails interface {
+}
+
+type nodepoolpodnetworkoptiondetails struct {
+	JsonData []byte
+	CniType  string `json:"cniType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *nodepoolpodnetworkoptiondetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalernodepoolpodnetworkoptiondetails nodepoolpodnetworkoptiondetails
+	s := struct {
+		Model Unmarshalernodepoolpodnetworkoptiondetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.CniType = s.Model.CniType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *nodepoolpodnetworkoptiondetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.CniType {
+	case "OCI_VCN_IP_NATIVE":
+		mm := OciVcnIpNativeNodePoolPodNetworkOptionDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "FLANNEL_OVERLAY":
+		mm := FlannelOverlayNodePoolPodNetworkOptionDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for NodePoolPodNetworkOptionDetails: %s.", m.CniType)
+		return *m, nil
+	}
+}
+
+func (m nodepoolpodnetworkoptiondetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m nodepoolpodnetworkoptiondetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// NodePoolPodNetworkOptionDetailsCniTypeEnum Enum with underlying type: string
+type NodePoolPodNetworkOptionDetailsCniTypeEnum string
+
+// Set of constants representing the allowable values for NodePoolPodNetworkOptionDetailsCniTypeEnum
+const (
+	NodePoolPodNetworkOptionDetailsCniTypeOciVcnIpNative NodePoolPodNetworkOptionDetailsCniTypeEnum = "OCI_VCN_IP_NATIVE"
+	NodePoolPodNetworkOptionDetailsCniTypeFlannelOverlay NodePoolPodNetworkOptionDetailsCniTypeEnum = "FLANNEL_OVERLAY"
+)
+
+var mappingNodePoolPodNetworkOptionDetailsCniTypeEnum = map[string]NodePoolPodNetworkOptionDetailsCniTypeEnum{
+	"OCI_VCN_IP_NATIVE": NodePoolPodNetworkOptionDetailsCniTypeOciVcnIpNative,
+	"FLANNEL_OVERLAY":   NodePoolPodNetworkOptionDetailsCniTypeFlannelOverlay,
+}
+
+var mappingNodePoolPodNetworkOptionDetailsCniTypeEnumLowerCase = map[string]NodePoolPodNetworkOptionDetailsCniTypeEnum{
+	"oci_vcn_ip_native": NodePoolPodNetworkOptionDetailsCniTypeOciVcnIpNative,
+	"flannel_overlay":   NodePoolPodNetworkOptionDetailsCniTypeFlannelOverlay,
+}
+
+// GetNodePoolPodNetworkOptionDetailsCniTypeEnumValues Enumerates the set of values for NodePoolPodNetworkOptionDetailsCniTypeEnum
+func GetNodePoolPodNetworkOptionDetailsCniTypeEnumValues() []NodePoolPodNetworkOptionDetailsCniTypeEnum {
+	values := make([]NodePoolPodNetworkOptionDetailsCniTypeEnum, 0)
+	for _, v := range mappingNodePoolPodNetworkOptionDetailsCniTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNodePoolPodNetworkOptionDetailsCniTypeEnumStringValues Enumerates the set of values in String for NodePoolPodNetworkOptionDetailsCniTypeEnum
+func GetNodePoolPodNetworkOptionDetailsCniTypeEnumStringValues() []string {
+	return []string{
+		"OCI_VCN_IP_NATIVE",
+		"FLANNEL_OVERLAY",
+	}
+}
+
+// GetMappingNodePoolPodNetworkOptionDetailsCniTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNodePoolPodNetworkOptionDetailsCniTypeEnum(val string) (NodePoolPodNetworkOptionDetailsCniTypeEnum, bool) {
+	enum, ok := mappingNodePoolPodNetworkOptionDetailsCniTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_pool_summary.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodePoolSummary The properties that define a node pool summary.
+type NodePoolSummary struct {
+
+	// The OCID of the node pool.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The state of the nodepool.
+	LifecycleState NodePoolLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the nodepool.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The OCID of the compartment in which the node pool exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The OCID of the cluster to which this node pool is attached.
+	ClusterId *string `mandatory:"false" json:"clusterId"`
+
+	// The name of the node pool.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes running on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// Deprecated. see `nodeSource`. The OCID of the image running on the nodes in the node pool.
+	NodeImageId *string `mandatory:"false" json:"nodeImageId"`
+
+	// Deprecated. see `nodeSource`. The name of the image running on the nodes in the node pool.
+	NodeImageName *string `mandatory:"false" json:"nodeImageName"`
+
+	// The shape configuration of the nodes.
+	NodeShapeConfig *NodeShapeConfig `mandatory:"false" json:"nodeShapeConfig"`
+
+	// Deprecated. see `nodeSourceDetails`. Source running on the nodes in the node pool.
+	NodeSource NodeSourceOption `mandatory:"false" json:"nodeSource"`
+
+	// Source running on the nodes in the node pool.
+	NodeSourceDetails NodeSourceDetails `mandatory:"false" json:"nodeSourceDetails"`
+
+	// The name of the node shape of the nodes in the node pool.
+	NodeShape *string `mandatory:"false" json:"nodeShape"`
+
+	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
+
+	// The SSH public key on each node in the node pool on launch.
+	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
+
+	// The number of nodes in each subnet.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool.
+	NodeConfigDetails *NodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings `mandatory:"false" json:"nodeEvictionNodePoolSettings"`
+
+	NodePoolCyclingDetails *NodePoolCyclingDetails `mandatory:"false" json:"nodePoolCyclingDetails"`
+}
+
+func (m NodePoolSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodePoolSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingNodePoolLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetNodePoolLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *NodePoolSummary) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Id                           *string                           `json:"id"`
+		LifecycleState               NodePoolLifecycleStateEnum        `json:"lifecycleState"`
+		LifecycleDetails             *string                           `json:"lifecycleDetails"`
+		CompartmentId                *string                           `json:"compartmentId"`
+		ClusterId                    *string                           `json:"clusterId"`
+		Name                         *string                           `json:"name"`
+		KubernetesVersion            *string                           `json:"kubernetesVersion"`
+		NodeImageId                  *string                           `json:"nodeImageId"`
+		NodeImageName                *string                           `json:"nodeImageName"`
+		NodeShapeConfig              *NodeShapeConfig                  `json:"nodeShapeConfig"`
+		NodeSource                   nodesourceoption                  `json:"nodeSource"`
+		NodeSourceDetails            nodesourcedetails                 `json:"nodeSourceDetails"`
+		NodeShape                    *string                           `json:"nodeShape"`
+		InitialNodeLabels            []KeyValue                        `json:"initialNodeLabels"`
+		SshPublicKey                 *string                           `json:"sshPublicKey"`
+		QuantityPerSubnet            *int                              `json:"quantityPerSubnet"`
+		SubnetIds                    []string                          `json:"subnetIds"`
+		NodeConfigDetails            *NodePoolNodeConfigDetails        `json:"nodeConfigDetails"`
+		FreeformTags                 map[string]string                 `json:"freeformTags"`
+		DefinedTags                  map[string]map[string]interface{} `json:"definedTags"`
+		SystemTags                   map[string]map[string]interface{} `json:"systemTags"`
+		NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings     `json:"nodeEvictionNodePoolSettings"`
+		NodePoolCyclingDetails       *NodePoolCyclingDetails           `json:"nodePoolCyclingDetails"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Id = model.Id
+
+	m.LifecycleState = model.LifecycleState
+
+	m.LifecycleDetails = model.LifecycleDetails
+
+	m.CompartmentId = model.CompartmentId
+
+	m.ClusterId = model.ClusterId
+
+	m.Name = model.Name
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.NodeImageId = model.NodeImageId
+
+	m.NodeImageName = model.NodeImageName
+
+	m.NodeShapeConfig = model.NodeShapeConfig
+
+	nn, e = model.NodeSource.UnmarshalPolymorphicJSON(model.NodeSource.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSource = nn.(NodeSourceOption)
+	} else {
+		m.NodeSource = nil
+	}
+
+	nn, e = model.NodeSourceDetails.UnmarshalPolymorphicJSON(model.NodeSourceDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSourceDetails = nn.(NodeSourceDetails)
+	} else {
+		m.NodeSourceDetails = nil
+	}
+
+	m.NodeShape = model.NodeShape
+
+	m.InitialNodeLabels = make([]KeyValue, len(model.InitialNodeLabels))
+	copy(m.InitialNodeLabels, model.InitialNodeLabels)
+	m.SshPublicKey = model.SshPublicKey
+
+	m.QuantityPerSubnet = model.QuantityPerSubnet
+
+	m.SubnetIds = make([]string, len(model.SubnetIds))
+	copy(m.SubnetIds, model.SubnetIds)
+	m.NodeConfigDetails = model.NodeConfigDetails
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.SystemTags = model.SystemTags
+
+	m.NodeEvictionNodePoolSettings = model.NodeEvictionNodePoolSettings
+
+	m.NodePoolCyclingDetails = model.NodePoolCyclingDetails
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_shape_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_shape_config.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeShapeConfig The shape configuration of the nodes.
+type NodeShapeConfig struct {
+
+	// The total number of OCPUs available to each node in the node pool.
+	// See here (https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/) for details.
+	Ocpus *float32 `mandatory:"false" json:"ocpus"`
+
+	// The total amount of memory available to each node, in gigabytes.
+	MemoryInGBs *float32 `mandatory:"false" json:"memoryInGBs"`
+}
+
+func (m NodeShapeConfig) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeShapeConfig) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_details.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeSourceDetails The details of the node's source.
+type NodeSourceDetails interface {
+}
+
+type nodesourcedetails struct {
+	JsonData   []byte
+	SourceType string `json:"sourceType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *nodesourcedetails) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalernodesourcedetails nodesourcedetails
+	s := struct {
+		Model Unmarshalernodesourcedetails
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.SourceType = s.Model.SourceType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *nodesourcedetails) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.SourceType {
+	case "IMAGE":
+		mm := NodeSourceViaImageDetails{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for NodeSourceDetails: %s.", m.SourceType)
+		return *m, nil
+	}
+}
+
+func (m nodesourcedetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m nodesourcedetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_option.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_option.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeSourceOption The source option for the node.
+type NodeSourceOption interface {
+
+	// The user-friendly name of the entity corresponding to the OCID.
+	GetSourceName() *string
+}
+
+type nodesourceoption struct {
+	JsonData   []byte
+	SourceName *string `mandatory:"false" json:"sourceName"`
+	SourceType string  `json:"sourceType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *nodesourceoption) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalernodesourceoption nodesourceoption
+	s := struct {
+		Model Unmarshalernodesourceoption
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.SourceName = s.Model.SourceName
+	m.SourceType = s.Model.SourceType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *nodesourceoption) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.SourceType {
+	case "IMAGE":
+		mm := NodeSourceViaImageOption{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for NodeSourceOption: %s.", m.SourceType)
+		return *m, nil
+	}
+}
+
+// GetSourceName returns SourceName
+func (m nodesourceoption) GetSourceName() *string {
+	return m.SourceName
+}
+
+func (m nodesourceoption) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m nodesourceoption) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_type.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// NodeSourceTypeEnum Enum with underlying type: string
+type NodeSourceTypeEnum string
+
+// Set of constants representing the allowable values for NodeSourceTypeEnum
+const (
+	NodeSourceTypeImage NodeSourceTypeEnum = "IMAGE"
+)
+
+var mappingNodeSourceTypeEnum = map[string]NodeSourceTypeEnum{
+	"IMAGE": NodeSourceTypeImage,
+}
+
+var mappingNodeSourceTypeEnumLowerCase = map[string]NodeSourceTypeEnum{
+	"image": NodeSourceTypeImage,
+}
+
+// GetNodeSourceTypeEnumValues Enumerates the set of values for NodeSourceTypeEnum
+func GetNodeSourceTypeEnumValues() []NodeSourceTypeEnum {
+	values := make([]NodeSourceTypeEnum, 0)
+	for _, v := range mappingNodeSourceTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetNodeSourceTypeEnumStringValues Enumerates the set of values in String for NodeSourceTypeEnum
+func GetNodeSourceTypeEnumStringValues() []string {
+	return []string{
+		"IMAGE",
+	}
+}
+
+// GetMappingNodeSourceTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingNodeSourceTypeEnum(val string) (NodeSourceTypeEnum, bool) {
+	enum, ok := mappingNodeSourceTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_via_image_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_via_image_details.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeSourceViaImageDetails Details of the image running on the node.
+type NodeSourceViaImageDetails struct {
+
+	// The OCID of the image used to boot the node.
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// The size of the boot volume in GBs. Minimum value is 50 GB. See here (https://docs.cloud.oracle.com/en-us/iaas/Content/Block/Concepts/bootvolumes.htm) for max custom boot volume sizing and OS-specific requirements.
+	BootVolumeSizeInGBs *int64 `mandatory:"false" json:"bootVolumeSizeInGBs"`
+}
+
+func (m NodeSourceViaImageDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeSourceViaImageDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m NodeSourceViaImageDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNodeSourceViaImageDetails NodeSourceViaImageDetails
+	s := struct {
+		DiscriminatorParam string `json:"sourceType"`
+		MarshalTypeNodeSourceViaImageDetails
+	}{
+		"IMAGE",
+		(MarshalTypeNodeSourceViaImageDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_via_image_option.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/node_source_via_image_option.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// NodeSourceViaImageOption An image can be specified as the source of nodes when launching a node pool using the `nodeSourceDetails` object.
+type NodeSourceViaImageOption struct {
+
+	// The user-friendly name of the entity corresponding to the OCID.
+	SourceName *string `mandatory:"false" json:"sourceName"`
+
+	// The OCID of the image.
+	ImageId *string `mandatory:"false" json:"imageId"`
+}
+
+// GetSourceName returns SourceName
+func (m NodeSourceViaImageOption) GetSourceName() *string {
+	return m.SourceName
+}
+
+func (m NodeSourceViaImageOption) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m NodeSourceViaImageOption) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m NodeSourceViaImageOption) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeNodeSourceViaImageOption NodeSourceViaImageOption
+	s := struct {
+		DiscriminatorParam string `json:"sourceType"`
+		MarshalTypeNodeSourceViaImageOption
+	}{
+		"IMAGE",
+		(MarshalTypeNodeSourceViaImageOption)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/oci_vcn_ip_native_cluster_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/oci_vcn_ip_native_cluster_pod_network_option_details.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// OciVcnIpNativeClusterPodNetworkOptionDetails Network options specific to using the OCI VCN Native CNI
+type OciVcnIpNativeClusterPodNetworkOptionDetails struct {
+}
+
+func (m OciVcnIpNativeClusterPodNetworkOptionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m OciVcnIpNativeClusterPodNetworkOptionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m OciVcnIpNativeClusterPodNetworkOptionDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOciVcnIpNativeClusterPodNetworkOptionDetails OciVcnIpNativeClusterPodNetworkOptionDetails
+	s := struct {
+		DiscriminatorParam string `json:"cniType"`
+		MarshalTypeOciVcnIpNativeClusterPodNetworkOptionDetails
+	}{
+		"OCI_VCN_IP_NATIVE",
+		(MarshalTypeOciVcnIpNativeClusterPodNetworkOptionDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/oci_vcn_ip_native_node_pool_pod_network_option_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/oci_vcn_ip_native_node_pool_pod_network_option_details.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// OciVcnIpNativeNodePoolPodNetworkOptionDetails Network options specific to using the OCI VCN Native CNI
+type OciVcnIpNativeNodePoolPodNetworkOptionDetails struct {
+
+	// The OCIDs of the subnets in which to place pods for this node pool. This can be one of the node pool subnet IDs
+	PodSubnetIds []string `mandatory:"true" json:"podSubnetIds"`
+
+	// The max number of pods per node in the node pool. This value will be limited by the number of VNICs attachable to the node pool shape
+	MaxPodsPerNode *int `mandatory:"false" json:"maxPodsPerNode"`
+
+	// The OCIDs of the Network Security Group(s) to associate pods for this node pool with. For more information about NSGs, see NetworkSecurityGroup.
+	PodNsgIds []string `mandatory:"false" json:"podNsgIds"`
+}
+
+func (m OciVcnIpNativeNodePoolPodNetworkOptionDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m OciVcnIpNativeNodePoolPodNetworkOptionDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m OciVcnIpNativeNodePoolPodNetworkOptionDetails) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeOciVcnIpNativeNodePoolPodNetworkOptionDetails OciVcnIpNativeNodePoolPodNetworkOptionDetails
+	s := struct {
+		DiscriminatorParam string `json:"cniType"`
+		MarshalTypeOciVcnIpNativeNodePoolPodNetworkOptionDetails
+	}{
+		"OCI_VCN_IP_NATIVE",
+		(MarshalTypeOciVcnIpNativeNodePoolPodNetworkOptionDetails)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/persistent_volume_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/persistent_volume_config_details.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PersistentVolumeConfigDetails Configuration to be applied to block volumes created by Kubernetes Persistent Volume Claims (PVC)
+type PersistentVolumeConfigDetails struct {
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m PersistentVolumeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PersistentVolumeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/placement_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/placement_configuration.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PlacementConfiguration The information of virtual node placement in the virtual node pool.
+type PlacementConfiguration struct {
+
+	// The availability domain in which to place virtual nodes.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// The fault domain of this virtual node.
+	FaultDomain []string `mandatory:"false" json:"faultDomain"`
+
+	// The OCID of the subnet in which to place virtual nodes.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+}
+
+func (m PlacementConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PlacementConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_configuration.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PodConfiguration The pod configuration for pods run on virtual nodes of this virtual node pool.
+type PodConfiguration struct {
+
+	// The regional subnet where pods' VNIC will be placed.
+	SubnetId *string `mandatory:"true" json:"subnetId"`
+
+	// Shape of the pods.
+	Shape *string `mandatory:"true" json:"shape"`
+
+	// List of network security group IDs applied to the Pod VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+}
+
+func (m PodConfiguration) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PodConfiguration) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_shape.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_shape.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PodShape Pod shape.
+type PodShape struct {
+
+	// The name of the identifying shape.
+	Name *string `mandatory:"true" json:"name"`
+
+	// A short description of the VM's processor (CPU).
+	ProcessorDescription *string `mandatory:"false" json:"processorDescription"`
+
+	// Options for OCPU shape.
+	OcpuOptions []ShapeOcpuOptions `mandatory:"false" json:"ocpuOptions"`
+
+	// ShapeMemoryOptions.
+	MemoryOptions []ShapeMemoryOptions `mandatory:"false" json:"memoryOptions"`
+
+	// ShapeNetworkBandwidthOptions.
+	NetworkBandwidthOptions []ShapeNetworkBandwidthOptions `mandatory:"false" json:"networkBandwidthOptions"`
+}
+
+func (m PodShape) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PodShape) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_shape_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/pod_shape_summary.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PodShapeSummary Pod shape.
+type PodShapeSummary struct {
+
+	// The name of the identifying shape.
+	Name *string `mandatory:"true" json:"name"`
+
+	// A short description of the VM's processor (CPU).
+	ProcessorDescription *string `mandatory:"false" json:"processorDescription"`
+
+	// Options for OCPU shape.
+	OcpuOptions []ShapeOcpuOptions `mandatory:"false" json:"ocpuOptions"`
+
+	// ShapeMemoryOptions.
+	MemoryOptions []ShapeMemoryOptions `mandatory:"false" json:"memoryOptions"`
+
+	// ShapeNetworkBandwidthOptions.
+	NetworkBandwidthOptions []ShapeNetworkBandwidthOptions `mandatory:"false" json:"networkBandwidthOptions"`
+}
+
+func (m PodShapeSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PodShapeSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/preemptible_node_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/preemptible_node_config_details.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PreemptibleNodeConfigDetails Configuration options for preemptible nodes.
+type PreemptibleNodeConfigDetails struct {
+	PreemptionAction PreemptionAction `mandatory:"true" json:"preemptionAction"`
+}
+
+func (m PreemptibleNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m PreemptibleNodeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *PreemptibleNodeConfigDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		PreemptionAction preemptionaction `json:"preemptionAction"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	nn, e = model.PreemptionAction.UnmarshalPolymorphicJSON(model.PreemptionAction.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.PreemptionAction = nn.(PreemptionAction)
+	} else {
+		m.PreemptionAction = nil
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/preemption_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/preemption_action.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// PreemptionAction The action to run when the preemptible node is interrupted for eviction.
+type PreemptionAction interface {
+}
+
+type preemptionaction struct {
+	JsonData []byte
+	Type     string `json:"type"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *preemptionaction) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerpreemptionaction preemptionaction
+	s := struct {
+		Model Unmarshalerpreemptionaction
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Type = s.Model.Type
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *preemptionaction) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.Type {
+	case "TERMINATE":
+		mm := TerminatePreemptionAction{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		common.Logf("Recieved unsupported enum value for PreemptionAction: %s.", m.Type)
+		return *m, nil
+	}
+}
+
+func (m preemptionaction) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m preemptionaction) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// PreemptionActionTypeEnum Enum with underlying type: string
+type PreemptionActionTypeEnum string
+
+// Set of constants representing the allowable values for PreemptionActionTypeEnum
+const (
+	PreemptionActionTypeTerminate PreemptionActionTypeEnum = "TERMINATE"
+)
+
+var mappingPreemptionActionTypeEnum = map[string]PreemptionActionTypeEnum{
+	"TERMINATE": PreemptionActionTypeTerminate,
+}
+
+var mappingPreemptionActionTypeEnumLowerCase = map[string]PreemptionActionTypeEnum{
+	"terminate": PreemptionActionTypeTerminate,
+}
+
+// GetPreemptionActionTypeEnumValues Enumerates the set of values for PreemptionActionTypeEnum
+func GetPreemptionActionTypeEnumValues() []PreemptionActionTypeEnum {
+	values := make([]PreemptionActionTypeEnum, 0)
+	for _, v := range mappingPreemptionActionTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetPreemptionActionTypeEnumStringValues Enumerates the set of values in String for PreemptionActionTypeEnum
+func GetPreemptionActionTypeEnumStringValues() []string {
+	return []string{
+		"TERMINATE",
+	}
+}
+
+// GetMappingPreemptionActionTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingPreemptionActionTypeEnum(val string) (PreemptionActionTypeEnum, bool) {
+	enum, ok := mappingPreemptionActionTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/service_lb_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/service_lb_config_details.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ServiceLbConfigDetails Configuration to be applied to load balancers created by Kubernetes services
+type ServiceLbConfigDetails struct {
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m ServiceLbConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ServiceLbConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_memory_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_memory_options.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ShapeMemoryOptions Memory properties.
+type ShapeMemoryOptions struct {
+
+	// The minimum amount of memory, in gigabytes.
+	MinInGBs *float32 `mandatory:"false" json:"minInGBs"`
+
+	// The maximum amount of memory, in gigabytes.
+	MaxInGBs *float32 `mandatory:"false" json:"maxInGBs"`
+
+	// The default amount of memory per OCPU available for this shape, in gigabytes.
+	DefaultPerOcpuInGBs *float32 `mandatory:"false" json:"defaultPerOcpuInGBs"`
+
+	// The minimum amount of memory per OCPU available for this shape, in gigabytes.
+	MinPerOcpuInGBs *float32 `mandatory:"false" json:"minPerOcpuInGBs"`
+
+	// The maximum amount of memory per OCPU available for this shape, in gigabytes.
+	MaxPerOcpuInGBs *float32 `mandatory:"false" json:"maxPerOcpuInGBs"`
+}
+
+func (m ShapeMemoryOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ShapeMemoryOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_network_bandwidth_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_network_bandwidth_options.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ShapeNetworkBandwidthOptions Properties of network bandwidth.
+type ShapeNetworkBandwidthOptions struct {
+
+	// The minimum amount of networking bandwidth, in gigabits per second.
+	MinInGbps *float32 `mandatory:"false" json:"minInGbps"`
+
+	// The maximum amount of networking bandwidth, in gigabits per second.
+	MaxInGbps *float32 `mandatory:"false" json:"maxInGbps"`
+
+	// The default amount of networking bandwidth per OCPU, in gigabits per second.
+	DefaultPerOcpuInGbps *float32 `mandatory:"false" json:"defaultPerOcpuInGbps"`
+}
+
+func (m ShapeNetworkBandwidthOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ShapeNetworkBandwidthOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_ocpu_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/shape_ocpu_options.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// ShapeOcpuOptions Properties of OCPUs.
+type ShapeOcpuOptions struct {
+
+	// The minimum number of OCPUs.
+	Min *float32 `mandatory:"false" json:"min"`
+
+	// The maximum number of OCPUs.
+	Max *float32 `mandatory:"false" json:"max"`
+}
+
+func (m ShapeOcpuOptions) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m ShapeOcpuOptions) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/sort_order.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/sort_order.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// SortOrderEnum Enum with underlying type: string
+type SortOrderEnum string
+
+// Set of constants representing the allowable values for SortOrderEnum
+const (
+	SortOrderAsc  SortOrderEnum = "ASC"
+	SortOrderDesc SortOrderEnum = "DESC"
+)
+
+var mappingSortOrderEnum = map[string]SortOrderEnum{
+	"ASC":  SortOrderAsc,
+	"DESC": SortOrderDesc,
+}
+
+var mappingSortOrderEnumLowerCase = map[string]SortOrderEnum{
+	"asc":  SortOrderAsc,
+	"desc": SortOrderDesc,
+}
+
+// GetSortOrderEnumValues Enumerates the set of values for SortOrderEnum
+func GetSortOrderEnumValues() []SortOrderEnum {
+	values := make([]SortOrderEnum, 0)
+	for _, v := range mappingSortOrderEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetSortOrderEnumStringValues Enumerates the set of values in String for SortOrderEnum
+func GetSortOrderEnumStringValues() []string {
+	return []string{
+		"ASC",
+		"DESC",
+	}
+}
+
+// GetMappingSortOrderEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingSortOrderEnum(val string) (SortOrderEnum, bool) {
+	enum, ok := mappingSortOrderEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/start_credential_rotation_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/start_credential_rotation_details.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// StartCredentialRotationDetails Properties that define a request to start credential rotation on a kubernetes cluster.
+type StartCredentialRotationDetails struct {
+
+	// The duration in days(in ISO 8601 notation eg. P5D) after which the old credentials should be retired. Maximum delay duration is 14 days.
+	AutoCompletionDelayDuration *string `mandatory:"true" json:"autoCompletionDelayDuration"`
+}
+
+func (m StartCredentialRotationDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m StartCredentialRotationDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/start_credential_rotation_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/start_credential_rotation_request_response.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// StartCredentialRotationRequest wrapper for the StartCredentialRotation operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/StartCredentialRotation.go.html to see an example of how to use StartCredentialRotationRequest.
+type StartCredentialRotationRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details for a kubernetes cluster to start credential rotation.
+	StartCredentialRotationDetails `contributesTo:"body"`
+
+	// A token you supply to uniquely identify the request and provide idempotency if
+	// the request is retried. Idempotency tokens expire after 24 hours.
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request StartCredentialRotationRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request StartCredentialRotationRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request StartCredentialRotationRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request StartCredentialRotationRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request StartCredentialRotationRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// StartCredentialRotationResponse wrapper for the StartCredentialRotation operation
+type StartCredentialRotationResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response StartCredentialRotationResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response StartCredentialRotationResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/taint.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/taint.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// Taint taints
+type Taint struct {
+
+	// The key of the pair.
+	Key *string `mandatory:"false" json:"key"`
+
+	// The value of the pair.
+	Value *string `mandatory:"false" json:"value"`
+
+	// The effect of the pair.
+	Effect *string `mandatory:"false" json:"effect"`
+}
+
+func (m Taint) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m Taint) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/terminate_preemption_action.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/terminate_preemption_action.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// TerminatePreemptionAction Terminates the preemptible instance when it is interrupted for eviction.
+type TerminatePreemptionAction struct {
+
+	// Whether to preserve the boot volume that was used to launch the preemptible instance when the instance is terminated. Defaults to false if not specified.
+	IsPreserveBootVolume *bool `mandatory:"false" json:"isPreserveBootVolume"`
+}
+
+func (m TerminatePreemptionAction) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m TerminatePreemptionAction) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// MarshalJSON marshals to json representation
+func (m TerminatePreemptionAction) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeTerminatePreemptionAction TerminatePreemptionAction
+	s := struct {
+		DiscriminatorParam string `json:"type"`
+		MarshalTypeTerminatePreemptionAction
+	}{
+		"TERMINATE",
+		(MarshalTypeTerminatePreemptionAction)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_addon_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_addon_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateAddonDetails The properties that define to update addon details.
+type UpdateAddonDetails struct {
+
+	// The version of the installed addon.
+	Version *string `mandatory:"false" json:"version"`
+
+	// Addon configuration details.
+	Configurations []AddonConfiguration `mandatory:"false" json:"configurations"`
+}
+
+func (m UpdateAddonDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateAddonDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_addon_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_addon_request_response.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateAddonRequest wrapper for the UpdateAddon operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateAddon.go.html to see an example of how to use UpdateAddonRequest.
+type UpdateAddonRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The name of the addon.
+	AddonName *string `mandatory:"true" contributesTo:"path" name:"addonName"`
+
+	// The details of the addon to be updated.
+	UpdateAddonDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateAddonRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateAddonRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateAddonRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateAddonRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateAddonRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateAddonResponse wrapper for the UpdateAddon operation
+type UpdateAddonResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateAddonResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateAddonResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_details.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateClusterDetails The properties that define a request to update a cluster.
+type UpdateClusterDetails struct {
+
+	// The new name for the cluster. Avoid entering confidential information.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes to which the cluster masters should be upgraded.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	Options *UpdateClusterOptionsDetails `mandatory:"false" json:"options"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The image verification policy for signature validation. Once a policy is created and enabled with
+	// one or more kms keys, the policy will ensure all images deployed has been signed with the key(s)
+	// attached to the policy.
+	ImagePolicyConfig *UpdateImagePolicyConfigDetails `mandatory:"false" json:"imagePolicyConfig"`
+
+	// Type of cluster
+	Type ClusterTypeEnum `mandatory:"false" json:"type,omitempty"`
+}
+
+func (m UpdateClusterDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateClusterDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingClusterTypeEnum(string(m.Type)); !ok && m.Type != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Type: %s. Supported values are: %s.", m.Type, strings.Join(GetClusterTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_endpoint_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_endpoint_config_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateClusterEndpointConfigDetails The properties that define a request to update a cluster endpoint config.
+type UpdateClusterEndpointConfigDetails struct {
+
+	// A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster update will fail.
+	IsPublicIpEnabled *bool `mandatory:"false" json:"isPublicIpEnabled"`
+}
+
+func (m UpdateClusterEndpointConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateClusterEndpointConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_endpoint_config_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_endpoint_config_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateClusterEndpointConfigRequest wrapper for the UpdateClusterEndpointConfig operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateClusterEndpointConfig.go.html to see an example of how to use UpdateClusterEndpointConfigRequest.
+type UpdateClusterEndpointConfigRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details of the cluster's endpoint to update.
+	UpdateClusterEndpointConfigDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateClusterEndpointConfigRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateClusterEndpointConfigRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateClusterEndpointConfigRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateClusterEndpointConfigRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateClusterEndpointConfigRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateClusterEndpointConfigResponse wrapper for the UpdateClusterEndpointConfig operation
+type UpdateClusterEndpointConfigResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateClusterEndpointConfigResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateClusterEndpointConfigResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_options_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_options_details.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateClusterOptionsDetails The properties that define extra options updating a cluster.
+type UpdateClusterOptionsDetails struct {
+
+	// Configurable cluster admission controllers
+	AdmissionControllerOptions *AdmissionControllerOptions `mandatory:"false" json:"admissionControllerOptions"`
+
+	PersistentVolumeConfig *PersistentVolumeConfigDetails `mandatory:"false" json:"persistentVolumeConfig"`
+
+	ServiceLbConfig *ServiceLbConfigDetails `mandatory:"false" json:"serviceLbConfig"`
+}
+
+func (m UpdateClusterOptionsDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateClusterOptionsDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_cluster_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateClusterRequest wrapper for the UpdateCluster operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateCluster.go.html to see an example of how to use UpdateClusterRequest.
+type UpdateClusterRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The details of the cluster to update.
+	UpdateClusterDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateClusterRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateClusterRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateClusterRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateClusterRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateClusterRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateClusterResponse wrapper for the UpdateCluster operation
+type UpdateClusterResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateClusterResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateClusterResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_image_policy_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_image_policy_config_details.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateImagePolicyConfigDetails The properties that define a image verification policy.
+type UpdateImagePolicyConfigDetails struct {
+
+	// Whether the image verification policy is enabled. Defaults to false. If set to true, the images will be verified against the policy at runtime.
+	IsPolicyEnabled *bool `mandatory:"false" json:"isPolicyEnabled"`
+
+	// A list of KMS key details.
+	KeyDetails []KeyDetails `mandatory:"false" json:"keyDetails"`
+}
+
+func (m UpdateImagePolicyConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateImagePolicyConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_details.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNodePoolDetails The properties that define a request to update a node pool.
+type UpdateNodePoolDetails struct {
+
+	// The new name for the cluster. Avoid entering confidential information.
+	Name *string `mandatory:"false" json:"name"`
+
+	// The version of Kubernetes to which the nodes in the node pool should be upgraded.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// A list of key/value pairs to add to nodes after they join the Kubernetes cluster.
+	InitialNodeLabels []KeyValue `mandatory:"false" json:"initialNodeLabels"`
+
+	// The number of nodes to have in each subnet specified in the subnetIds property. This property is deprecated,
+	// use nodeConfigDetails instead. If the current value of quantityPerSubnet is greater than 0, you can only
+	// use quantityPerSubnet to scale the node pool. If the current value of quantityPerSubnet is equal to 0 and
+	// the current value of size in nodeConfigDetails is greater than 0, before you can use quantityPerSubnet,
+	// you must first scale the node pool to 0 nodes using nodeConfigDetails.
+	QuantityPerSubnet *int `mandatory:"false" json:"quantityPerSubnet"`
+
+	// The OCIDs of the subnets in which to place nodes for this node pool. This property is deprecated,
+	// use nodeConfigDetails instead. Only one of the subnetIds or nodeConfigDetails
+	// properties can be specified.
+	SubnetIds []string `mandatory:"false" json:"subnetIds"`
+
+	// The configuration of nodes in the node pool. Only one of the subnetIds or nodeConfigDetails
+	// properties should be specified. If the current value of quantityPerSubnet is greater than 0, the node
+	// pool may still be scaled using quantityPerSubnet. Before you can use nodeConfigDetails,
+	// you must first scale the node pool to 0 nodes using quantityPerSubnet.
+	NodeConfigDetails *UpdateNodePoolNodeConfigDetails `mandatory:"false" json:"nodeConfigDetails"`
+
+	// A list of key/value pairs to add to each underlying OCI instance in the node pool on launch.
+	NodeMetadata map[string]string `mandatory:"false" json:"nodeMetadata"`
+
+	// Specify the source to use to launch nodes in the node pool. Currently, image is the only supported source.
+	NodeSourceDetails NodeSourceDetails `mandatory:"false" json:"nodeSourceDetails"`
+
+	// The SSH public key to add to each node in the node pool on launch.
+	SshPublicKey *string `mandatory:"false" json:"sshPublicKey"`
+
+	// The name of the node shape of the nodes in the node pool used on launch.
+	NodeShape *string `mandatory:"false" json:"nodeShape"`
+
+	// Specify the configuration of the shape to launch nodes in the node pool.
+	NodeShapeConfig *UpdateNodeShapeConfigDetails `mandatory:"false" json:"nodeShapeConfig"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings `mandatory:"false" json:"nodeEvictionNodePoolSettings"`
+
+	NodePoolCyclingDetails *NodePoolCyclingDetails `mandatory:"false" json:"nodePoolCyclingDetails"`
+}
+
+func (m UpdateNodePoolDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateNodePoolDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateNodePoolDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Name                         *string                           `json:"name"`
+		KubernetesVersion            *string                           `json:"kubernetesVersion"`
+		InitialNodeLabels            []KeyValue                        `json:"initialNodeLabels"`
+		QuantityPerSubnet            *int                              `json:"quantityPerSubnet"`
+		SubnetIds                    []string                          `json:"subnetIds"`
+		NodeConfigDetails            *UpdateNodePoolNodeConfigDetails  `json:"nodeConfigDetails"`
+		NodeMetadata                 map[string]string                 `json:"nodeMetadata"`
+		NodeSourceDetails            nodesourcedetails                 `json:"nodeSourceDetails"`
+		SshPublicKey                 *string                           `json:"sshPublicKey"`
+		NodeShape                    *string                           `json:"nodeShape"`
+		NodeShapeConfig              *UpdateNodeShapeConfigDetails     `json:"nodeShapeConfig"`
+		FreeformTags                 map[string]string                 `json:"freeformTags"`
+		DefinedTags                  map[string]map[string]interface{} `json:"definedTags"`
+		NodeEvictionNodePoolSettings *NodeEvictionNodePoolSettings     `json:"nodeEvictionNodePoolSettings"`
+		NodePoolCyclingDetails       *NodePoolCyclingDetails           `json:"nodePoolCyclingDetails"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Name = model.Name
+
+	m.KubernetesVersion = model.KubernetesVersion
+
+	m.InitialNodeLabels = make([]KeyValue, len(model.InitialNodeLabels))
+	copy(m.InitialNodeLabels, model.InitialNodeLabels)
+	m.QuantityPerSubnet = model.QuantityPerSubnet
+
+	m.SubnetIds = make([]string, len(model.SubnetIds))
+	copy(m.SubnetIds, model.SubnetIds)
+	m.NodeConfigDetails = model.NodeConfigDetails
+
+	m.NodeMetadata = model.NodeMetadata
+
+	nn, e = model.NodeSourceDetails.UnmarshalPolymorphicJSON(model.NodeSourceDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodeSourceDetails = nn.(NodeSourceDetails)
+	} else {
+		m.NodeSourceDetails = nil
+	}
+
+	m.SshPublicKey = model.SshPublicKey
+
+	m.NodeShape = model.NodeShape
+
+	m.NodeShapeConfig = model.NodeShapeConfig
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.NodeEvictionNodePoolSettings = model.NodeEvictionNodePoolSettings
+
+	m.NodePoolCyclingDetails = model.NodePoolCyclingDetails
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_node_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_node_config_details.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNodePoolNodeConfigDetails The size and placement configuration of nodes in the node pool.
+type UpdateNodePoolNodeConfigDetails struct {
+
+	// The number of nodes in the node pool.
+	Size *int `mandatory:"false" json:"size"`
+
+	// The OCIDs of the Network Security Group(s) to associate nodes for this node pool with. For more information about NSGs, see NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The OCID of the Key Management Service key assigned to the boot volume.
+	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// The placement configurations for the node pool. Provide one placement
+	// configuration for each availability domain in which you intend to launch a node.
+	// To use the node pool with a regional subnet, provide a placement configuration for
+	// each availability domain, and include the regional subnet in each placement
+	// configuration.
+	PlacementConfigs []NodePoolPlacementConfigDetails `mandatory:"false" json:"placementConfigs"`
+
+	// The CNI related configuration of pods in the node pool.
+	NodePoolPodNetworkOptionDetails NodePoolPodNetworkOptionDetails `mandatory:"false" json:"nodePoolPodNetworkOptionDetails"`
+}
+
+func (m UpdateNodePoolNodeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateNodePoolNodeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateNodePoolNodeConfigDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Size                            *int                              `json:"size"`
+		NsgIds                          []string                          `json:"nsgIds"`
+		KmsKeyId                        *string                           `json:"kmsKeyId"`
+		IsPvEncryptionInTransitEnabled  *bool                             `json:"isPvEncryptionInTransitEnabled"`
+		FreeformTags                    map[string]string                 `json:"freeformTags"`
+		DefinedTags                     map[string]map[string]interface{} `json:"definedTags"`
+		PlacementConfigs                []NodePoolPlacementConfigDetails  `json:"placementConfigs"`
+		NodePoolPodNetworkOptionDetails nodepoolpodnetworkoptiondetails   `json:"nodePoolPodNetworkOptionDetails"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Size = model.Size
+
+	m.NsgIds = make([]string, len(model.NsgIds))
+	copy(m.NsgIds, model.NsgIds)
+	m.KmsKeyId = model.KmsKeyId
+
+	m.IsPvEncryptionInTransitEnabled = model.IsPvEncryptionInTransitEnabled
+
+	m.FreeformTags = model.FreeformTags
+
+	m.DefinedTags = model.DefinedTags
+
+	m.PlacementConfigs = make([]NodePoolPlacementConfigDetails, len(model.PlacementConfigs))
+	copy(m.PlacementConfigs, model.PlacementConfigs)
+	nn, e = model.NodePoolPodNetworkOptionDetails.UnmarshalPolymorphicJSON(model.NodePoolPodNetworkOptionDetails.JsonData)
+	if e != nil {
+		return
+	}
+	if nn != nil {
+		m.NodePoolPodNetworkOptionDetails = nn.(NodePoolPodNetworkOptionDetails)
+	} else {
+		m.NodePoolPodNetworkOptionDetails = nil
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_pool_request_response.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateNodePoolRequest wrapper for the UpdateNodePool operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateNodePool.go.html to see an example of how to use UpdateNodePoolRequest.
+type UpdateNodePoolRequest struct {
+
+	// The OCID of the node pool.
+	NodePoolId *string `mandatory:"true" contributesTo:"path" name:"nodePoolId"`
+
+	// The fields to update in a node pool.
+	UpdateNodePoolDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Duration after which OKE will give up eviction of the pods on the node.
+	// PT0M will indicate you want to delete the node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+	OverrideEvictionGraceDuration *string `mandatory:"false" contributesTo:"query" name:"overrideEvictionGraceDuration"`
+
+	// If the underlying compute instance should be deleted if you cannot evict all the pods in grace period
+	IsForceDeletionAfterOverrideGraceDuration *bool `mandatory:"false" contributesTo:"query" name:"isForceDeletionAfterOverrideGraceDuration"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateNodePoolResponse wrapper for the UpdateNodePool operation
+type UpdateNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_node_shape_config_details.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateNodeShapeConfigDetails The shape configuration of the nodes.
+type UpdateNodeShapeConfigDetails struct {
+
+	// The total number of OCPUs available to each node in the node pool.
+	// See here (https://docs.cloud.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Shape/) for details.
+	Ocpus *float32 `mandatory:"false" json:"ocpus"`
+
+	// The total amount of memory available to each node, in gigabytes.
+	MemoryInGBs *float32 `mandatory:"false" json:"memoryInGBs"`
+}
+
+func (m UpdateNodeShapeConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateNodeShapeConfigDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_pool_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_pool_details.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateVirtualNodePoolDetails The properties that define a request to update a virtual node pool.
+type UpdateVirtualNodePoolDetails struct {
+
+	// Display name of the virtual node pool. This is a non-unique value.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Initial labels that will be added to the Kubernetes Virtual Node object when it registers.
+	InitialVirtualNodeLabels []InitialVirtualNodeLabel `mandatory:"false" json:"initialVirtualNodeLabels"`
+
+	// A taint is a collection of <key, value, effect>. These taints will be applied to the Virtual Nodes of this Virtual Node Pool for Kubernetes scheduling.
+	Taints []Taint `mandatory:"false" json:"taints"`
+
+	// The number of Virtual Nodes that should be in the Virtual Node Pool. The placement configurations determine where these virtual nodes are placed.
+	Size *int `mandatory:"false" json:"size"`
+
+	// The list of placement configurations which determines where Virtual Nodes will be provisioned across as it relates to the subnet and availability domains. The size attribute determines how many we evenly spread across these placement configurations
+	PlacementConfigurations []PlacementConfiguration `mandatory:"false" json:"placementConfigurations"`
+
+	// List of network security group id's applied to the Virtual Node VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The pod configuration for pods run on virtual nodes of this virtual node pool.
+	PodConfiguration *PodConfiguration `mandatory:"false" json:"podConfiguration"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	VirtualNodeTags *VirtualNodeTags `mandatory:"false" json:"virtualNodeTags"`
+}
+
+func (m UpdateVirtualNodePoolDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateVirtualNodePoolDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_pool_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_virtual_node_pool_request_response.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateVirtualNodePoolRequest wrapper for the UpdateVirtualNodePool operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateVirtualNodePool.go.html to see an example of how to use UpdateVirtualNodePoolRequest.
+type UpdateVirtualNodePoolRequest struct {
+
+	// The OCID of the virtual node pool.
+	VirtualNodePoolId *string `mandatory:"true" contributesTo:"path" name:"virtualNodePoolId"`
+
+	// The fields to update in a virtual node pool.
+	UpdateVirtualNodePoolDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateVirtualNodePoolRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateVirtualNodePoolRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateVirtualNodePoolRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateVirtualNodePoolRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateVirtualNodePoolRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateVirtualNodePoolResponse wrapper for the UpdateVirtualNodePool operation
+type UpdateVirtualNodePoolResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The OCID of the work request handling the operation.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateVirtualNodePoolResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateVirtualNodePoolResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_workload_mapping_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_workload_mapping_details.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// UpdateWorkloadMappingDetails The properties that define a workloadMapping
+type UpdateWorkloadMappingDetails struct {
+
+	// The OCID of the mapped customer compartment.
+	MappedCompartmentId *string `mandatory:"false" json:"mappedCompartmentId"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateWorkloadMappingDetails) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m UpdateWorkloadMappingDetails) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_workload_mapping_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/update_workload_mapping_request_response.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"net/http"
+	"strings"
+)
+
+// UpdateWorkloadMappingRequest wrapper for the UpdateWorkloadMapping operation
+//
+// # See also
+//
+// Click https://docs.cloud.oracle.com/en-us/iaas/tools/go-sdk-examples/latest/containerengine/UpdateWorkloadMapping.go.html to see an example of how to use UpdateWorkloadMappingRequest.
+type UpdateWorkloadMappingRequest struct {
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" contributesTo:"path" name:"clusterId"`
+
+	// The OCID of the workloadMapping.
+	WorkloadMappingId *string `mandatory:"true" contributesTo:"path" name:"workloadMappingId"`
+
+	// The details of the workloadMapping to be updated.
+	UpdateWorkloadMappingDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateWorkloadMappingRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateWorkloadMappingRequest) HTTPRequest(method, path string, binaryRequestBody *common.OCIReadSeekCloser, extraHeaders map[string]string) (http.Request, error) {
+
+	_, err := request.ValidateEnumValue()
+	if err != nil {
+		return http.Request{}, err
+	}
+	return common.MakeDefaultHTTPRequestWithTaggedStructAndExtraHeaders(method, path, request, extraHeaders)
+}
+
+// BinaryRequestBody implements the OCIRequest interface
+func (request UpdateWorkloadMappingRequest) BinaryRequestBody() (*common.OCIReadSeekCloser, bool) {
+
+	return nil, false
+
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateWorkloadMappingRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (request UpdateWorkloadMappingRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// UpdateWorkloadMappingResponse wrapper for the UpdateWorkloadMapping operation
+type UpdateWorkloadMappingResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The WorkloadMapping instance
+	WorkloadMapping `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+	// particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateWorkloadMappingResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateWorkloadMappingResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNode The properties that define a virtual node.
+type VirtualNode struct {
+
+	// The ocid of the virtual node.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The name of the virtual node.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The ocid of the virtual node pool this virtual node belongs to.
+	VirtualNodePoolId *string `mandatory:"true" json:"virtualNodePoolId"`
+
+	// The version of Kubernetes this virtual node is running.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// The name of the availability domain in which this virtual node is placed
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// The fault domain of this virtual node.
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// The OCID of the subnet in which this Virtual Node is placed.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// NSG Ids applied to virtual node vnic.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The private IP address of this Virtual Node.
+	PrivateIp *string `mandatory:"false" json:"privateIp"`
+
+	// An error that may be associated with the virtual node.
+	VirtualNodeError *string `mandatory:"false" json:"virtualNodeError"`
+
+	// The state of the Virtual Node.
+	LifecycleState VirtualNodeLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the Virtual Node.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time at which the virtual node was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m VirtualNode) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNode) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodeLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodeLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_lifecycle_state.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// VirtualNodeLifecycleStateEnum Enum with underlying type: string
+type VirtualNodeLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VirtualNodeLifecycleStateEnum
+const (
+	VirtualNodeLifecycleStateCreating       VirtualNodeLifecycleStateEnum = "CREATING"
+	VirtualNodeLifecycleStateActive         VirtualNodeLifecycleStateEnum = "ACTIVE"
+	VirtualNodeLifecycleStateUpdating       VirtualNodeLifecycleStateEnum = "UPDATING"
+	VirtualNodeLifecycleStateDeleting       VirtualNodeLifecycleStateEnum = "DELETING"
+	VirtualNodeLifecycleStateDeleted        VirtualNodeLifecycleStateEnum = "DELETED"
+	VirtualNodeLifecycleStateFailed         VirtualNodeLifecycleStateEnum = "FAILED"
+	VirtualNodeLifecycleStateNeedsAttention VirtualNodeLifecycleStateEnum = "NEEDS_ATTENTION"
+)
+
+var mappingVirtualNodeLifecycleStateEnum = map[string]VirtualNodeLifecycleStateEnum{
+	"CREATING":        VirtualNodeLifecycleStateCreating,
+	"ACTIVE":          VirtualNodeLifecycleStateActive,
+	"UPDATING":        VirtualNodeLifecycleStateUpdating,
+	"DELETING":        VirtualNodeLifecycleStateDeleting,
+	"DELETED":         VirtualNodeLifecycleStateDeleted,
+	"FAILED":          VirtualNodeLifecycleStateFailed,
+	"NEEDS_ATTENTION": VirtualNodeLifecycleStateNeedsAttention,
+}
+
+var mappingVirtualNodeLifecycleStateEnumLowerCase = map[string]VirtualNodeLifecycleStateEnum{
+	"creating":        VirtualNodeLifecycleStateCreating,
+	"active":          VirtualNodeLifecycleStateActive,
+	"updating":        VirtualNodeLifecycleStateUpdating,
+	"deleting":        VirtualNodeLifecycleStateDeleting,
+	"deleted":         VirtualNodeLifecycleStateDeleted,
+	"failed":          VirtualNodeLifecycleStateFailed,
+	"needs_attention": VirtualNodeLifecycleStateNeedsAttention,
+}
+
+// GetVirtualNodeLifecycleStateEnumValues Enumerates the set of values for VirtualNodeLifecycleStateEnum
+func GetVirtualNodeLifecycleStateEnumValues() []VirtualNodeLifecycleStateEnum {
+	values := make([]VirtualNodeLifecycleStateEnum, 0)
+	for _, v := range mappingVirtualNodeLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetVirtualNodeLifecycleStateEnumStringValues Enumerates the set of values in String for VirtualNodeLifecycleStateEnum
+func GetVirtualNodeLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"UPDATING",
+		"DELETING",
+		"DELETED",
+		"FAILED",
+		"NEEDS_ATTENTION",
+	}
+}
+
+// GetMappingVirtualNodeLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingVirtualNodeLifecycleStateEnum(val string) (VirtualNodeLifecycleStateEnum, bool) {
+	enum, ok := mappingVirtualNodeLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNodePool A pool of virtual nodes attached to a cluster.
+type VirtualNodePool struct {
+
+	// The OCID of the virtual node pool.
+	Id *string `mandatory:"true" json:"id"`
+
+	// Compartment of the virtual node pool.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The cluster the virtual node pool is associated with. A virtual node pool can only be associated with one cluster.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// Display name of the virtual node pool. This is a non-unique value.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The version of Kubernetes running on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"true" json:"kubernetesVersion"`
+
+	// The list of placement configurations which determines where Virtual Nodes will be provisioned across as it relates to the subnet and availability domains. The size attribute determines how many we evenly spread across these placement configurations
+	PlacementConfigurations []PlacementConfiguration `mandatory:"true" json:"placementConfigurations"`
+
+	// Initial labels that will be added to the Kubernetes Virtual Node object when it registers. This is the same as virtualNodePool resources.
+	InitialVirtualNodeLabels []InitialVirtualNodeLabel `mandatory:"false" json:"initialVirtualNodeLabels"`
+
+	// A taint is a collection of <key, value, effect>. These taints will be applied to the Virtual Nodes of this Virtual Node Pool for Kubernetes scheduling.
+	Taints []Taint `mandatory:"false" json:"taints"`
+
+	// The number of Virtual Nodes that should be in the Virtual Node Pool. The placement configurations determine where these virtual nodes are placed.
+	Size *int `mandatory:"false" json:"size"`
+
+	// List of network security group id's applied to the Virtual Node VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The pod configuration for pods run on virtual nodes of this virtual node pool.
+	PodConfiguration *PodConfiguration `mandatory:"false" json:"podConfiguration"`
+
+	// The state of the Virtual Node Pool.
+	LifecycleState VirtualNodePoolLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the Virtual Node Pool.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time the virtual node pool was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time the virtual node pool was updated.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	VirtualNodeTags *VirtualNodeTags `mandatory:"false" json:"virtualNodeTags"`
+}
+
+func (m VirtualNodePool) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNodePool) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodePoolLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodePoolLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool_lifecycle_state.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// VirtualNodePoolLifecycleStateEnum Enum with underlying type: string
+type VirtualNodePoolLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VirtualNodePoolLifecycleStateEnum
+const (
+	VirtualNodePoolLifecycleStateCreating       VirtualNodePoolLifecycleStateEnum = "CREATING"
+	VirtualNodePoolLifecycleStateActive         VirtualNodePoolLifecycleStateEnum = "ACTIVE"
+	VirtualNodePoolLifecycleStateUpdating       VirtualNodePoolLifecycleStateEnum = "UPDATING"
+	VirtualNodePoolLifecycleStateDeleting       VirtualNodePoolLifecycleStateEnum = "DELETING"
+	VirtualNodePoolLifecycleStateDeleted        VirtualNodePoolLifecycleStateEnum = "DELETED"
+	VirtualNodePoolLifecycleStateFailed         VirtualNodePoolLifecycleStateEnum = "FAILED"
+	VirtualNodePoolLifecycleStateNeedsAttention VirtualNodePoolLifecycleStateEnum = "NEEDS_ATTENTION"
+)
+
+var mappingVirtualNodePoolLifecycleStateEnum = map[string]VirtualNodePoolLifecycleStateEnum{
+	"CREATING":        VirtualNodePoolLifecycleStateCreating,
+	"ACTIVE":          VirtualNodePoolLifecycleStateActive,
+	"UPDATING":        VirtualNodePoolLifecycleStateUpdating,
+	"DELETING":        VirtualNodePoolLifecycleStateDeleting,
+	"DELETED":         VirtualNodePoolLifecycleStateDeleted,
+	"FAILED":          VirtualNodePoolLifecycleStateFailed,
+	"NEEDS_ATTENTION": VirtualNodePoolLifecycleStateNeedsAttention,
+}
+
+var mappingVirtualNodePoolLifecycleStateEnumLowerCase = map[string]VirtualNodePoolLifecycleStateEnum{
+	"creating":        VirtualNodePoolLifecycleStateCreating,
+	"active":          VirtualNodePoolLifecycleStateActive,
+	"updating":        VirtualNodePoolLifecycleStateUpdating,
+	"deleting":        VirtualNodePoolLifecycleStateDeleting,
+	"deleted":         VirtualNodePoolLifecycleStateDeleted,
+	"failed":          VirtualNodePoolLifecycleStateFailed,
+	"needs_attention": VirtualNodePoolLifecycleStateNeedsAttention,
+}
+
+// GetVirtualNodePoolLifecycleStateEnumValues Enumerates the set of values for VirtualNodePoolLifecycleStateEnum
+func GetVirtualNodePoolLifecycleStateEnumValues() []VirtualNodePoolLifecycleStateEnum {
+	values := make([]VirtualNodePoolLifecycleStateEnum, 0)
+	for _, v := range mappingVirtualNodePoolLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetVirtualNodePoolLifecycleStateEnumStringValues Enumerates the set of values in String for VirtualNodePoolLifecycleStateEnum
+func GetVirtualNodePoolLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"UPDATING",
+		"DELETING",
+		"DELETED",
+		"FAILED",
+		"NEEDS_ATTENTION",
+	}
+}
+
+// GetMappingVirtualNodePoolLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingVirtualNodePoolLifecycleStateEnum(val string) (VirtualNodePoolLifecycleStateEnum, bool) {
+	enum, ok := mappingVirtualNodePoolLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_pool_summary.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNodePoolSummary The properties that define a virtual node pool summary.
+type VirtualNodePoolSummary struct {
+
+	// The OCID of the virtual node pool.
+	Id *string `mandatory:"true" json:"id"`
+
+	// Compartment of the virtual node pool.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The cluster the virtual node pool is associated with. A virtual node pool can only be associated with one cluster.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// Display name of the virtual node pool. This is a non-unique value.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The version of Kubernetes running on the nodes in the node pool.
+	KubernetesVersion *string `mandatory:"true" json:"kubernetesVersion"`
+
+	// The list of placement configurations which determines where Virtual Nodes will be provisioned across as it relates to the subnet and availability domains. The size attribute determines how many we evenly spread across these placement configurations
+	PlacementConfigurations []PlacementConfiguration `mandatory:"true" json:"placementConfigurations"`
+
+	// Initial labels that will be added to the Kubernetes Virtual Node object when it registers. This is the same as virtualNodePool resources.
+	InitialVirtualNodeLabels []InitialVirtualNodeLabel `mandatory:"false" json:"initialVirtualNodeLabels"`
+
+	// A taint is a collection of <key, value, effect>. These taints will be applied to the Virtual Nodes of this Virtual Node Pool for Kubernetes scheduling.
+	Taints []Taint `mandatory:"false" json:"taints"`
+
+	// The number of Virtual Nodes that should be in the Virtual Node Pool. The placement configurations determine where these virtual nodes are placed.
+	Size *int `mandatory:"false" json:"size"`
+
+	// List of network security group id's applied to the Virtual Node VNIC.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The pod configuration for pods run on virtual nodes of this virtual node pool.
+	PodConfiguration *PodConfiguration `mandatory:"false" json:"podConfiguration"`
+
+	// The state of the Virtual Node Pool.
+	LifecycleState VirtualNodePoolLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the Virtual Node Pool.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time the virtual node pool was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// The time the virtual node pool was updated.
+	TimeUpdated *common.SDKTime `mandatory:"false" json:"timeUpdated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+
+	VirtualNodeTags *VirtualNodeTags `mandatory:"false" json:"virtualNodeTags"`
+}
+
+func (m VirtualNodePoolSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNodePoolSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodePoolLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodePoolLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_summary.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNodeSummary The properties that define a virtual node summary.
+type VirtualNodeSummary struct {
+
+	// The ocid of the virtual node.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The name of the virtual node.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The ocid of the virtual node pool this virtual node belongs to.
+	VirtualNodePoolId *string `mandatory:"true" json:"virtualNodePoolId"`
+
+	// The version of Kubernetes this virtual node is running.
+	KubernetesVersion *string `mandatory:"false" json:"kubernetesVersion"`
+
+	// The name of the availability domain in which this virtual node is placed
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// The fault domain of this virtual node.
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// The OCID of the subnet in which this Virtual Node is placed.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// NSG Ids applied to virtual node vnic.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The private IP address of this Virtual Node.
+	PrivateIp *string `mandatory:"false" json:"privateIp"`
+
+	// An error that may be associated with the virtual node.
+	VirtualNodeError *string `mandatory:"false" json:"virtualNodeError"`
+
+	// The state of the Virtual Node.
+	LifecycleState VirtualNodeLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
+
+	// Details about the state of the Virtual Node.
+	LifecycleDetails *string `mandatory:"false" json:"lifecycleDetails"`
+
+	// The time at which the virtual node was created.
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Usage of system tag keys. These predefined keys are scoped to namespaces.
+	// Example: `{"orcl-cloud": {"free-tier-retained": "true"}}`
+	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
+}
+
+func (m VirtualNodeSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNodeSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingVirtualNodeLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetVirtualNodeLifecycleStateEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_tags.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/virtual_node_tags.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// VirtualNodeTags The tags associated to the virtual nodes in this virtual node pool.
+type VirtualNodeTags struct {
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m VirtualNodeTags) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m VirtualNodeTags) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequest An asynchronous work request.
+type WorkRequest struct {
+
+	// The OCID of the work request.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The type of work the work request is doing.
+	OperationType WorkRequestOperationTypeEnum `mandatory:"false" json:"operationType,omitempty"`
+
+	// The current status of the work request.
+	Status WorkRequestStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// The OCID of the compartment in which the work request exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The resources this work request affects.
+	Resources []WorkRequestResource `mandatory:"false" json:"resources"`
+
+	// The time the work request was accepted.
+	TimeAccepted *common.SDKTime `mandatory:"false" json:"timeAccepted"`
+
+	// The time the work request was started.
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// The time the work request was finished.
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+}
+
+func (m WorkRequest) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequest) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWorkRequestOperationTypeEnum(string(m.OperationType)); !ok && m.OperationType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for OperationType: %s. Supported values are: %s.", m.OperationType, strings.Join(GetWorkRequestOperationTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingWorkRequestStatusEnum(string(m.Status)); !ok && m.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", m.Status, strings.Join(GetWorkRequestStatusEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_error.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_error.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestError Errors related to a specific work request.
+type WorkRequestError struct {
+
+	// A short error code that defines the error, meant for programmatic parsing. See API Errors (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+	Code *string `mandatory:"true" json:"code"`
+
+	// A human-readable error string.
+	Message *string `mandatory:"true" json:"message"`
+
+	// The date and time the error occurred.
+	Timestamp *common.SDKTime `mandatory:"true" json:"timestamp"`
+}
+
+func (m WorkRequestError) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestError) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_log_entry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_log_entry.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestLogEntry Log entries related to a specific work request.
+type WorkRequestLogEntry struct {
+
+	// The description of an action that occurred.
+	Message *string `mandatory:"false" json:"message"`
+
+	// The date and time the log entry occurred.
+	Timestamp *string `mandatory:"false" json:"timestamp"`
+}
+
+func (m WorkRequestLogEntry) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestLogEntry) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_operation_type.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_operation_type.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// WorkRequestOperationTypeEnum Enum with underlying type: string
+type WorkRequestOperationTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestOperationTypeEnum
+const (
+	WorkRequestOperationTypeClusterCreate         WorkRequestOperationTypeEnum = "CLUSTER_CREATE"
+	WorkRequestOperationTypeClusterUpdate         WorkRequestOperationTypeEnum = "CLUSTER_UPDATE"
+	WorkRequestOperationTypeClusterDelete         WorkRequestOperationTypeEnum = "CLUSTER_DELETE"
+	WorkRequestOperationTypeNodepoolCreate        WorkRequestOperationTypeEnum = "NODEPOOL_CREATE"
+	WorkRequestOperationTypeNodepoolUpdate        WorkRequestOperationTypeEnum = "NODEPOOL_UPDATE"
+	WorkRequestOperationTypeNodepoolDelete        WorkRequestOperationTypeEnum = "NODEPOOL_DELETE"
+	WorkRequestOperationTypeNodepoolReconcile     WorkRequestOperationTypeEnum = "NODEPOOL_RECONCILE"
+	WorkRequestOperationTypeNodepoolCycling       WorkRequestOperationTypeEnum = "NODEPOOL_CYCLING"
+	WorkRequestOperationTypeWorkrequestCancel     WorkRequestOperationTypeEnum = "WORKREQUEST_CANCEL"
+	WorkRequestOperationTypeVirtualnodepoolCreate WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_CREATE"
+	WorkRequestOperationTypeVirtualnodepoolUpdate WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_UPDATE"
+	WorkRequestOperationTypeVirtualnodepoolDelete WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_DELETE"
+	WorkRequestOperationTypeVirtualnodeDelete     WorkRequestOperationTypeEnum = "VIRTUALNODE_DELETE"
+	WorkRequestOperationTypeEnableAddon           WorkRequestOperationTypeEnum = "ENABLE_ADDON"
+	WorkRequestOperationTypeUpdateAddon           WorkRequestOperationTypeEnum = "UPDATE_ADDON"
+	WorkRequestOperationTypeDisableAddon          WorkRequestOperationTypeEnum = "DISABLE_ADDON"
+	WorkRequestOperationTypeReconcileAddon        WorkRequestOperationTypeEnum = "RECONCILE_ADDON"
+)
+
+var mappingWorkRequestOperationTypeEnum = map[string]WorkRequestOperationTypeEnum{
+	"CLUSTER_CREATE":         WorkRequestOperationTypeClusterCreate,
+	"CLUSTER_UPDATE":         WorkRequestOperationTypeClusterUpdate,
+	"CLUSTER_DELETE":         WorkRequestOperationTypeClusterDelete,
+	"NODEPOOL_CREATE":        WorkRequestOperationTypeNodepoolCreate,
+	"NODEPOOL_UPDATE":        WorkRequestOperationTypeNodepoolUpdate,
+	"NODEPOOL_DELETE":        WorkRequestOperationTypeNodepoolDelete,
+	"NODEPOOL_RECONCILE":     WorkRequestOperationTypeNodepoolReconcile,
+	"NODEPOOL_CYCLING":       WorkRequestOperationTypeNodepoolCycling,
+	"WORKREQUEST_CANCEL":     WorkRequestOperationTypeWorkrequestCancel,
+	"VIRTUALNODEPOOL_CREATE": WorkRequestOperationTypeVirtualnodepoolCreate,
+	"VIRTUALNODEPOOL_UPDATE": WorkRequestOperationTypeVirtualnodepoolUpdate,
+	"VIRTUALNODEPOOL_DELETE": WorkRequestOperationTypeVirtualnodepoolDelete,
+	"VIRTUALNODE_DELETE":     WorkRequestOperationTypeVirtualnodeDelete,
+	"ENABLE_ADDON":           WorkRequestOperationTypeEnableAddon,
+	"UPDATE_ADDON":           WorkRequestOperationTypeUpdateAddon,
+	"DISABLE_ADDON":          WorkRequestOperationTypeDisableAddon,
+	"RECONCILE_ADDON":        WorkRequestOperationTypeReconcileAddon,
+}
+
+var mappingWorkRequestOperationTypeEnumLowerCase = map[string]WorkRequestOperationTypeEnum{
+	"cluster_create":         WorkRequestOperationTypeClusterCreate,
+	"cluster_update":         WorkRequestOperationTypeClusterUpdate,
+	"cluster_delete":         WorkRequestOperationTypeClusterDelete,
+	"nodepool_create":        WorkRequestOperationTypeNodepoolCreate,
+	"nodepool_update":        WorkRequestOperationTypeNodepoolUpdate,
+	"nodepool_delete":        WorkRequestOperationTypeNodepoolDelete,
+	"nodepool_reconcile":     WorkRequestOperationTypeNodepoolReconcile,
+	"nodepool_cycling":       WorkRequestOperationTypeNodepoolCycling,
+	"workrequest_cancel":     WorkRequestOperationTypeWorkrequestCancel,
+	"virtualnodepool_create": WorkRequestOperationTypeVirtualnodepoolCreate,
+	"virtualnodepool_update": WorkRequestOperationTypeVirtualnodepoolUpdate,
+	"virtualnodepool_delete": WorkRequestOperationTypeVirtualnodepoolDelete,
+	"virtualnode_delete":     WorkRequestOperationTypeVirtualnodeDelete,
+	"enable_addon":           WorkRequestOperationTypeEnableAddon,
+	"update_addon":           WorkRequestOperationTypeUpdateAddon,
+	"disable_addon":          WorkRequestOperationTypeDisableAddon,
+	"reconcile_addon":        WorkRequestOperationTypeReconcileAddon,
+}
+
+// GetWorkRequestOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum
+func GetWorkRequestOperationTypeEnumValues() []WorkRequestOperationTypeEnum {
+	values := make([]WorkRequestOperationTypeEnum, 0)
+	for _, v := range mappingWorkRequestOperationTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestOperationTypeEnumStringValues Enumerates the set of values in String for WorkRequestOperationTypeEnum
+func GetWorkRequestOperationTypeEnumStringValues() []string {
+	return []string{
+		"CLUSTER_CREATE",
+		"CLUSTER_UPDATE",
+		"CLUSTER_DELETE",
+		"NODEPOOL_CREATE",
+		"NODEPOOL_UPDATE",
+		"NODEPOOL_DELETE",
+		"NODEPOOL_RECONCILE",
+		"NODEPOOL_CYCLING",
+		"WORKREQUEST_CANCEL",
+		"VIRTUALNODEPOOL_CREATE",
+		"VIRTUALNODEPOOL_UPDATE",
+		"VIRTUALNODEPOOL_DELETE",
+		"VIRTUALNODE_DELETE",
+		"ENABLE_ADDON",
+		"UPDATE_ADDON",
+		"DISABLE_ADDON",
+		"RECONCILE_ADDON",
+	}
+}
+
+// GetMappingWorkRequestOperationTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestOperationTypeEnum(val string) (WorkRequestOperationTypeEnum, bool) {
+	enum, ok := mappingWorkRequestOperationTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_resource.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_resource.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestResource The properties that define a work request resource.
+type WorkRequestResource struct {
+
+	// The way in which this resource was affected by the work tracked by the work request.
+	ActionType WorkRequestResourceActionTypeEnum `mandatory:"false" json:"actionType,omitempty"`
+
+	// The resource type the work request affects.
+	EntityType *string `mandatory:"false" json:"entityType"`
+
+	// The OCID of the resource the work request affects.
+	Identifier *string `mandatory:"false" json:"identifier"`
+
+	// The URI path on which the user can issue a GET request to access the resource metadata.
+	EntityUri *string `mandatory:"false" json:"entityUri"`
+}
+
+func (m WorkRequestResource) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestResource) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWorkRequestResourceActionTypeEnum(string(m.ActionType)); !ok && m.ActionType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for ActionType: %s. Supported values are: %s.", m.ActionType, strings.Join(GetWorkRequestResourceActionTypeEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// WorkRequestResourceActionTypeEnum Enum with underlying type: string
+type WorkRequestResourceActionTypeEnum string
+
+// Set of constants representing the allowable values for WorkRequestResourceActionTypeEnum
+const (
+	WorkRequestResourceActionTypeCreated        WorkRequestResourceActionTypeEnum = "CREATED"
+	WorkRequestResourceActionTypeUpdated        WorkRequestResourceActionTypeEnum = "UPDATED"
+	WorkRequestResourceActionTypeDeleted        WorkRequestResourceActionTypeEnum = "DELETED"
+	WorkRequestResourceActionTypeRelated        WorkRequestResourceActionTypeEnum = "RELATED"
+	WorkRequestResourceActionTypeInProgress     WorkRequestResourceActionTypeEnum = "IN_PROGRESS"
+	WorkRequestResourceActionTypeFailed         WorkRequestResourceActionTypeEnum = "FAILED"
+	WorkRequestResourceActionTypeCanceledCreate WorkRequestResourceActionTypeEnum = "CANCELED_CREATE"
+	WorkRequestResourceActionTypeCanceledUpdate WorkRequestResourceActionTypeEnum = "CANCELED_UPDATE"
+	WorkRequestResourceActionTypeCanceledDelete WorkRequestResourceActionTypeEnum = "CANCELED_DELETE"
+)
+
+var mappingWorkRequestResourceActionTypeEnum = map[string]WorkRequestResourceActionTypeEnum{
+	"CREATED":         WorkRequestResourceActionTypeCreated,
+	"UPDATED":         WorkRequestResourceActionTypeUpdated,
+	"DELETED":         WorkRequestResourceActionTypeDeleted,
+	"RELATED":         WorkRequestResourceActionTypeRelated,
+	"IN_PROGRESS":     WorkRequestResourceActionTypeInProgress,
+	"FAILED":          WorkRequestResourceActionTypeFailed,
+	"CANCELED_CREATE": WorkRequestResourceActionTypeCanceledCreate,
+	"CANCELED_UPDATE": WorkRequestResourceActionTypeCanceledUpdate,
+	"CANCELED_DELETE": WorkRequestResourceActionTypeCanceledDelete,
+}
+
+var mappingWorkRequestResourceActionTypeEnumLowerCase = map[string]WorkRequestResourceActionTypeEnum{
+	"created":         WorkRequestResourceActionTypeCreated,
+	"updated":         WorkRequestResourceActionTypeUpdated,
+	"deleted":         WorkRequestResourceActionTypeDeleted,
+	"related":         WorkRequestResourceActionTypeRelated,
+	"in_progress":     WorkRequestResourceActionTypeInProgress,
+	"failed":          WorkRequestResourceActionTypeFailed,
+	"canceled_create": WorkRequestResourceActionTypeCanceledCreate,
+	"canceled_update": WorkRequestResourceActionTypeCanceledUpdate,
+	"canceled_delete": WorkRequestResourceActionTypeCanceledDelete,
+}
+
+// GetWorkRequestResourceActionTypeEnumValues Enumerates the set of values for WorkRequestResourceActionTypeEnum
+func GetWorkRequestResourceActionTypeEnumValues() []WorkRequestResourceActionTypeEnum {
+	values := make([]WorkRequestResourceActionTypeEnum, 0)
+	for _, v := range mappingWorkRequestResourceActionTypeEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestResourceActionTypeEnumStringValues Enumerates the set of values in String for WorkRequestResourceActionTypeEnum
+func GetWorkRequestResourceActionTypeEnumStringValues() []string {
+	return []string{
+		"CREATED",
+		"UPDATED",
+		"DELETED",
+		"RELATED",
+		"IN_PROGRESS",
+		"FAILED",
+		"CANCELED_CREATE",
+		"CANCELED_UPDATE",
+		"CANCELED_DELETE",
+	}
+}
+
+// GetMappingWorkRequestResourceActionTypeEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestResourceActionTypeEnum(val string) (WorkRequestResourceActionTypeEnum, bool) {
+	enum, ok := mappingWorkRequestResourceActionTypeEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_status.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// WorkRequestStatusEnum Enum with underlying type: string
+type WorkRequestStatusEnum string
+
+// Set of constants representing the allowable values for WorkRequestStatusEnum
+const (
+	WorkRequestStatusAccepted   WorkRequestStatusEnum = "ACCEPTED"
+	WorkRequestStatusInProgress WorkRequestStatusEnum = "IN_PROGRESS"
+	WorkRequestStatusFailed     WorkRequestStatusEnum = "FAILED"
+	WorkRequestStatusSucceeded  WorkRequestStatusEnum = "SUCCEEDED"
+	WorkRequestStatusCanceling  WorkRequestStatusEnum = "CANCELING"
+	WorkRequestStatusCanceled   WorkRequestStatusEnum = "CANCELED"
+)
+
+var mappingWorkRequestStatusEnum = map[string]WorkRequestStatusEnum{
+	"ACCEPTED":    WorkRequestStatusAccepted,
+	"IN_PROGRESS": WorkRequestStatusInProgress,
+	"FAILED":      WorkRequestStatusFailed,
+	"SUCCEEDED":   WorkRequestStatusSucceeded,
+	"CANCELING":   WorkRequestStatusCanceling,
+	"CANCELED":    WorkRequestStatusCanceled,
+}
+
+var mappingWorkRequestStatusEnumLowerCase = map[string]WorkRequestStatusEnum{
+	"accepted":    WorkRequestStatusAccepted,
+	"in_progress": WorkRequestStatusInProgress,
+	"failed":      WorkRequestStatusFailed,
+	"succeeded":   WorkRequestStatusSucceeded,
+	"canceling":   WorkRequestStatusCanceling,
+	"canceled":    WorkRequestStatusCanceled,
+}
+
+// GetWorkRequestStatusEnumValues Enumerates the set of values for WorkRequestStatusEnum
+func GetWorkRequestStatusEnumValues() []WorkRequestStatusEnum {
+	values := make([]WorkRequestStatusEnum, 0)
+	for _, v := range mappingWorkRequestStatusEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkRequestStatusEnumStringValues Enumerates the set of values in String for WorkRequestStatusEnum
+func GetWorkRequestStatusEnumStringValues() []string {
+	return []string{
+		"ACCEPTED",
+		"IN_PROGRESS",
+		"FAILED",
+		"SUCCEEDED",
+		"CANCELING",
+		"CANCELED",
+	}
+}
+
+// GetMappingWorkRequestStatusEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkRequestStatusEnum(val string) (WorkRequestStatusEnum, bool) {
+	enum, ok := mappingWorkRequestStatusEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/work_request_summary.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkRequestSummary The properties that define a work request summary.
+type WorkRequestSummary struct {
+
+	// The OCID of the work request.
+	Id *string `mandatory:"false" json:"id"`
+
+	// The type of work the work request is doing.
+	OperationType WorkRequestOperationTypeEnum `mandatory:"false" json:"operationType,omitempty"`
+
+	// The current status of the work request.
+	Status WorkRequestStatusEnum `mandatory:"false" json:"status,omitempty"`
+
+	// The OCID of the compartment in which the work request exists.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The resources this work request affects.
+	Resources []WorkRequestResource `mandatory:"false" json:"resources"`
+
+	// The time the work request was accepted.
+	TimeAccepted *common.SDKTime `mandatory:"false" json:"timeAccepted"`
+
+	// The time the work request was started.
+	TimeStarted *common.SDKTime `mandatory:"false" json:"timeStarted"`
+
+	// The time the work request was finished.
+	TimeFinished *common.SDKTime `mandatory:"false" json:"timeFinished"`
+}
+
+func (m WorkRequestSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkRequestSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+
+	if _, ok := GetMappingWorkRequestOperationTypeEnum(string(m.OperationType)); !ok && m.OperationType != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for OperationType: %s. Supported values are: %s.", m.OperationType, strings.Join(GetWorkRequestOperationTypeEnumStringValues(), ",")))
+	}
+	if _, ok := GetMappingWorkRequestStatusEnum(string(m.Status)); !ok && m.Status != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for Status: %s. Supported values are: %s.", m.Status, strings.Join(GetWorkRequestStatusEnumStringValues(), ",")))
+	}
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}
+
+// WorkRequestSummaryOperationTypeEnum is an alias to type: WorkRequestOperationTypeEnum
+// Consider using WorkRequestOperationTypeEnum instead
+// Deprecated
+type WorkRequestSummaryOperationTypeEnum = WorkRequestOperationTypeEnum
+
+// Set of constants representing the allowable values for WorkRequestOperationTypeEnum
+// Deprecated
+const (
+	WorkRequestSummaryOperationTypeClusterCreate         WorkRequestOperationTypeEnum = "CLUSTER_CREATE"
+	WorkRequestSummaryOperationTypeClusterUpdate         WorkRequestOperationTypeEnum = "CLUSTER_UPDATE"
+	WorkRequestSummaryOperationTypeClusterDelete         WorkRequestOperationTypeEnum = "CLUSTER_DELETE"
+	WorkRequestSummaryOperationTypeNodepoolCreate        WorkRequestOperationTypeEnum = "NODEPOOL_CREATE"
+	WorkRequestSummaryOperationTypeNodepoolUpdate        WorkRequestOperationTypeEnum = "NODEPOOL_UPDATE"
+	WorkRequestSummaryOperationTypeNodepoolDelete        WorkRequestOperationTypeEnum = "NODEPOOL_DELETE"
+	WorkRequestSummaryOperationTypeNodepoolReconcile     WorkRequestOperationTypeEnum = "NODEPOOL_RECONCILE"
+	WorkRequestSummaryOperationTypeNodepoolCycling       WorkRequestOperationTypeEnum = "NODEPOOL_CYCLING"
+	WorkRequestSummaryOperationTypeWorkrequestCancel     WorkRequestOperationTypeEnum = "WORKREQUEST_CANCEL"
+	WorkRequestSummaryOperationTypeVirtualnodepoolCreate WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_CREATE"
+	WorkRequestSummaryOperationTypeVirtualnodepoolUpdate WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_UPDATE"
+	WorkRequestSummaryOperationTypeVirtualnodepoolDelete WorkRequestOperationTypeEnum = "VIRTUALNODEPOOL_DELETE"
+	WorkRequestSummaryOperationTypeVirtualnodeDelete     WorkRequestOperationTypeEnum = "VIRTUALNODE_DELETE"
+	WorkRequestSummaryOperationTypeEnableAddon           WorkRequestOperationTypeEnum = "ENABLE_ADDON"
+	WorkRequestSummaryOperationTypeUpdateAddon           WorkRequestOperationTypeEnum = "UPDATE_ADDON"
+	WorkRequestSummaryOperationTypeDisableAddon          WorkRequestOperationTypeEnum = "DISABLE_ADDON"
+	WorkRequestSummaryOperationTypeReconcileAddon        WorkRequestOperationTypeEnum = "RECONCILE_ADDON"
+)
+
+// GetWorkRequestSummaryOperationTypeEnumValues Enumerates the set of values for WorkRequestOperationTypeEnum
+// Consider using GetWorkRequestOperationTypeEnumValue
+// Deprecated
+var GetWorkRequestSummaryOperationTypeEnumValues = GetWorkRequestOperationTypeEnumValues
+
+// WorkRequestSummaryStatusEnum is an alias to type: WorkRequestStatusEnum
+// Consider using WorkRequestStatusEnum instead
+// Deprecated
+type WorkRequestSummaryStatusEnum = WorkRequestStatusEnum
+
+// Set of constants representing the allowable values for WorkRequestStatusEnum
+// Deprecated
+const (
+	WorkRequestSummaryStatusAccepted   WorkRequestStatusEnum = "ACCEPTED"
+	WorkRequestSummaryStatusInProgress WorkRequestStatusEnum = "IN_PROGRESS"
+	WorkRequestSummaryStatusFailed     WorkRequestStatusEnum = "FAILED"
+	WorkRequestSummaryStatusSucceeded  WorkRequestStatusEnum = "SUCCEEDED"
+	WorkRequestSummaryStatusCanceling  WorkRequestStatusEnum = "CANCELING"
+	WorkRequestSummaryStatusCanceled   WorkRequestStatusEnum = "CANCELED"
+)
+
+// GetWorkRequestSummaryStatusEnumValues Enumerates the set of values for WorkRequestStatusEnum
+// Consider using GetWorkRequestStatusEnumValue
+// Deprecated
+var GetWorkRequestSummaryStatusEnumValues = GetWorkRequestStatusEnumValues

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/workload_mapping.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/workload_mapping.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkloadMapping The properties that define an workloadMapping.
+type WorkloadMapping struct {
+
+	// The ocid of the workloadMapping.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// The namespace of the workloadMapping.
+	Namespace *string `mandatory:"true" json:"namespace"`
+
+	// The OCID of the mapped customer tenancy.
+	MappedTenancyId *string `mandatory:"true" json:"mappedTenancyId"`
+
+	// The OCID of the mapped customer compartment.
+	MappedCompartmentId *string `mandatory:"true" json:"mappedCompartmentId"`
+
+	// The time the cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The state of the workloadMapping.
+	LifecycleState WorkloadMappingLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m WorkloadMapping) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkloadMapping) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingWorkloadMappingLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetWorkloadMappingLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/workload_mapping_lifecycle_state.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/workload_mapping_lifecycle_state.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"strings"
+)
+
+// WorkloadMappingLifecycleStateEnum Enum with underlying type: string
+type WorkloadMappingLifecycleStateEnum string
+
+// Set of constants representing the allowable values for WorkloadMappingLifecycleStateEnum
+const (
+	WorkloadMappingLifecycleStateCreating WorkloadMappingLifecycleStateEnum = "CREATING"
+	WorkloadMappingLifecycleStateActive   WorkloadMappingLifecycleStateEnum = "ACTIVE"
+	WorkloadMappingLifecycleStateFailed   WorkloadMappingLifecycleStateEnum = "FAILED"
+	WorkloadMappingLifecycleStateDeleting WorkloadMappingLifecycleStateEnum = "DELETING"
+	WorkloadMappingLifecycleStateDeleted  WorkloadMappingLifecycleStateEnum = "DELETED"
+	WorkloadMappingLifecycleStateUpdating WorkloadMappingLifecycleStateEnum = "UPDATING"
+)
+
+var mappingWorkloadMappingLifecycleStateEnum = map[string]WorkloadMappingLifecycleStateEnum{
+	"CREATING": WorkloadMappingLifecycleStateCreating,
+	"ACTIVE":   WorkloadMappingLifecycleStateActive,
+	"FAILED":   WorkloadMappingLifecycleStateFailed,
+	"DELETING": WorkloadMappingLifecycleStateDeleting,
+	"DELETED":  WorkloadMappingLifecycleStateDeleted,
+	"UPDATING": WorkloadMappingLifecycleStateUpdating,
+}
+
+var mappingWorkloadMappingLifecycleStateEnumLowerCase = map[string]WorkloadMappingLifecycleStateEnum{
+	"creating": WorkloadMappingLifecycleStateCreating,
+	"active":   WorkloadMappingLifecycleStateActive,
+	"failed":   WorkloadMappingLifecycleStateFailed,
+	"deleting": WorkloadMappingLifecycleStateDeleting,
+	"deleted":  WorkloadMappingLifecycleStateDeleted,
+	"updating": WorkloadMappingLifecycleStateUpdating,
+}
+
+// GetWorkloadMappingLifecycleStateEnumValues Enumerates the set of values for WorkloadMappingLifecycleStateEnum
+func GetWorkloadMappingLifecycleStateEnumValues() []WorkloadMappingLifecycleStateEnum {
+	values := make([]WorkloadMappingLifecycleStateEnum, 0)
+	for _, v := range mappingWorkloadMappingLifecycleStateEnum {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetWorkloadMappingLifecycleStateEnumStringValues Enumerates the set of values in String for WorkloadMappingLifecycleStateEnum
+func GetWorkloadMappingLifecycleStateEnumStringValues() []string {
+	return []string{
+		"CREATING",
+		"ACTIVE",
+		"FAILED",
+		"DELETING",
+		"DELETED",
+		"UPDATING",
+	}
+}
+
+// GetMappingWorkloadMappingLifecycleStateEnum performs case Insensitive comparison on enum value and return the desired enum
+func GetMappingWorkloadMappingLifecycleStateEnum(val string) (WorkloadMappingLifecycleStateEnum, bool) {
+	enum, ok := mappingWorkloadMappingLifecycleStateEnumLowerCase[strings.ToLower(val)]
+	return enum, ok
+}

--- a/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/workload_mapping_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/v65/containerengine/workload_mapping_summary.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2024, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Container Engine for Kubernetes API
+//
+// API for the Container Engine for Kubernetes service. Use this API to build, deploy,
+// and manage cloud-native applications. For more information, see
+// Overview of Container Engine for Kubernetes (https://docs.cloud.oracle.com/iaas/Content/ContEng/Concepts/contengoverview.htm).
+//
+
+package containerengine
+
+import (
+	"fmt"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"strings"
+)
+
+// WorkloadMappingSummary The properties that define an workloadMapping summary.
+type WorkloadMappingSummary struct {
+
+	// The ocid of the workloadMapping.
+	Id *string `mandatory:"true" json:"id"`
+
+	// The OCID of the cluster.
+	ClusterId *string `mandatory:"true" json:"clusterId"`
+
+	// The namespace of the workloadMapping.
+	Namespace *string `mandatory:"true" json:"namespace"`
+
+	// The OCID of the mapped customer tenancy.
+	MappedTenancyId *string `mandatory:"true" json:"mappedTenancyId"`
+
+	// The OCID of the mapped customer compartment.
+	MappedCompartmentId *string `mandatory:"true" json:"mappedCompartmentId"`
+
+	// The time the cluster was created.
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The state of the workloadMapping.
+	LifecycleState WorkloadMappingLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a namespace.
+	// For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m WorkloadMappingSummary) String() string {
+	return common.PointerString(m)
+}
+
+// ValidateEnumValue returns an error when providing an unsupported enum value
+// This function is being called during constructing API request process
+// Not recommended for calling this function directly
+func (m WorkloadMappingSummary) ValidateEnumValue() (bool, error) {
+	errMessage := []string{}
+	if _, ok := GetMappingWorkloadMappingLifecycleStateEnum(string(m.LifecycleState)); !ok && m.LifecycleState != "" {
+		errMessage = append(errMessage, fmt.Sprintf("unsupported enum value for LifecycleState: %s. Supported values are: %s.", m.LifecycleState, strings.Join(GetWorkloadMappingLifecycleStateEnumStringValues(), ",")))
+	}
+
+	if len(errMessage) > 0 {
+		return true, fmt.Errorf(strings.Join(errMessage, "\n"))
+	}
+	return false, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -272,6 +272,7 @@ github.com/opencontainers/selinux/pkg/pwalkdir
 github.com/oracle/oci-go-sdk/v65/common
 github.com/oracle/oci-go-sdk/v65/common/auth
 github.com/oracle/oci-go-sdk/v65/common/utils
+github.com/oracle/oci-go-sdk/v65/containerengine
 github.com/oracle/oci-go-sdk/v65/core
 github.com/oracle/oci-go-sdk/v65/filestorage
 github.com/oracle/oci-go-sdk/v65/identity


### PR DESCRIPTION
Summary of Changes:

- Added wait in volume expansion for volume to become available
- fix security list rule clean up flow for OCI loadbalancer delete calls
- for externalTrafficPolicy local the healthcheck port security rule should be retained
- skip healthcheck port in use for services that are deleted or not of type loadbalancer
- Added fix to check length of consistent device paths available before attempting read
- process updateLoadbalancer if NLB is in failed state
- Fix CVEs
- Separating UpdateLoadBalancer flow for Backends from Ensure Load Balancer flow in CCM
- Moved listener and backendset updates before shape change & other customer error prone operations
- Changes to parallelise e2e test runs
- add opc-retry-token
- Do not record events for failure to acquire lock for lb sync
- Add unit test to for merging common tags tags at the time of creation of LB & storage resources
- Use topology.kubernetes.io labels
- set serviceUid as opc-retry-token
- Bugfix: Ensure backend ssl certificates during Update LoadBalancer Backendsets flow
- Fix response when no size change in ControllerExpandVolume
- Avoid change service type in update shape test cases
- List instances to check for authorization issues