### PR TITLE
External-ccm: Fix go formatting

### DIFF
--- a/cmd/oci-csi-controller-driver/csi-controller-driver/oci-csi-controller-driver.go
+++ b/cmd/oci-csi-controller-driver/csi-controller-driver/oci-csi-controller-driver.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	bvCsiDriver      = "BV"
-	lustreCsiDriver  = "Lustre"
+	bvCsiDriver     = "BV"
+	lustreCsiDriver = "Lustre"
 )
 
 // StartControllerDriver main function to start CSI Controller Driver

--- a/cmd/oci-csi-controller-driver/csioptions/csioptions.go
+++ b/cmd/oci-csi-controller-driver/csioptions/csioptions.go
@@ -23,14 +23,14 @@ import (
 )
 
 const (
-	fssAddressSuffix               = "-fss.sock"
-	fssVolumeNameAppendedPrefix    = "-fss"
+	fssAddressSuffix            = "-fss.sock"
+	fssVolumeNameAppendedPrefix = "-fss"
 
 	lustreAddressSuffix            = "-lustre.sock"
 	lustreVolumeNameAppendedPrefix = "-lustre"
 
 	CrossNamespaceVolumeDataSource = "CrossNamespaceVolumeDataSource"
-	VolumeAttributesClass		   = "VolumeAttributesClass"
+	VolumeAttributesClass          = "VolumeAttributesClass"
 )
 
 // CSIOptions structure which contains flag values
@@ -43,9 +43,9 @@ type CSIOptions struct {
 	FssEndpoint                 string
 	VolumeNamePrefix            string
 	FssVolumeNamePrefix         string
-	LustreCsiAddress           string
-	LustreEndpoint             string
-	LustreVolumeNamePrefix     string
+	LustreCsiAddress            string
+	LustreEndpoint              string
+	LustreVolumeNamePrefix      string
 	VolumeNameUUIDLength        int
 	ShowVersion                 bool
 	RetryIntervalStart          time.Duration
@@ -71,44 +71,42 @@ type CSIOptions struct {
 	DefaultFSType               string
 	GroupSnapshotNamePrefix     string
 	GroupSnapshotNameUUIDLength int
-
 }
 
 // NewCSIOptions initializes the flag
 func NewCSIOptions() *CSIOptions {
 	csioptions := CSIOptions{
-		Master:                  *flag.String("master", "", "kube master"),
-		Kubeconfig:              *flag.String("kubeconfig", "", "cluster kube config"),
-		CsiAddress:              *flag.String("csi-address", "/run/csi/socket", "Address of the CSI BV driver socket."),
-		Endpoint:                *flag.String("csi-endpoint", "unix://tmp/csi.sock", "CSI BV endpoint"),
-		FssCsiAddress:           *flag.String("fss-csi-address", "/run/fss/socket", "Address of the CSI FSS driver socket."),
-		FssEndpoint:             *flag.String("fss-csi-endpoint", "unix://tmp/csi-fss.sock", "CSI FSS endpoint"),
-		VolumeNamePrefix:        *flag.String("csi-volume-name-prefix", "pvc", "Prefix to apply to the name of a created volume."),
-		FssVolumeNamePrefix:     *flag.String("fss-csi-volume-name-prefix", "pvc", "Prefix to apply to the name of a volume created for FSS."),
-		LustreCsiAddress:        *flag.String("lustre-csi-address", "/run/lustre/socket", "Address of the CSI Lustre driver socket."),
-		LustreEndpoint:          *flag.String("lustre-csi-endpoint", "unix://tmp/csi-lustre.sock", "CSI Lustre endpoint"),
-		LustreVolumeNamePrefix:  *flag.String("lustre-csi-volume-name-prefix", "pvc", "Prefix to apply to the name of a volume created for Lustre."),
-		VolumeNameUUIDLength:    *flag.Int("csi-volume-name-uuid-length", -1, "Truncates generated UUID of a created volume to this length. Defaults behavior is to NOT truncate."),
-		ShowVersion:             *flag.Bool("csi-version", false, "Show version."),
-		RetryIntervalStart:      *flag.Duration("csi-retry-interval-start", time.Second, "Initial retry interval of failed provisioning or deletion. It doubles with each failure, up to retry-interval-max."),
-		RetryIntervalMax:        *flag.Duration("csi-retry-interval-max", 5*time.Minute, "Maximum retry interval of failed provisioning or deletion."),
-		WorkerThreads:           *flag.Uint("csi-worker-threads", 100, "Number of provisioner worker threads, in other words nr. of simultaneous CSI calls."),
-		OperationTimeout:        *flag.Duration("csi-op-timeout", 10*time.Second, "Timeout for waiting for creation or deletion of a volume"),
-		EnableLeaderElection:    *flag.Bool("csi-enable-leader-election", false, "Enables leader election. If leader election is enabled, additional RBAC rules are required. Please refer to the Kubernetes CSI documentation for instructions on setting up these RBAC rules."),
-		LeaderElectionType:      *flag.String("csi-leader-election-type", "endpoints", "the type of leader election, options are 'endpoints' (default) or 'leases' (strongly recommended). The 'endpoints' option is deprecated in favor of 'leases'."),
-		LeaderElectionNamespace: *flag.String("csi-leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set."),
-		StrictTopology:          *flag.Bool("csi-strict-topology", false, "Passes only selected node topology to CreateVolume Request, unlike default behavior of passing aggregated cluster topologies that match with topology keys of the selected node."),
-		Resync:                  *flag.Duration("csi-resync", 10*time.Minute, "Resync interval of the controller."),
-		Timeout:                 *flag.Duration("csi-timeout", 15*time.Second, "Timeout for waiting for attaching or detaching the volume."),
-		FinalizerThreads:        *flag.Uint("cloning-protection-threads", 1, "Number of simultaniously running threads, handling cloning finalizer removal"),
-		MetricsAddress:          *flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled."),
-		MetricsPath:             *flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`."),
-		ExtraCreateMetadata:     *flag.Bool("extra-create-metadata", false, "If set, add pv/pvc metadata to plugin create requests as parameters."),
-		ReconcileSync:           *flag.Duration("reconcile-sync", 1*time.Minute, "Resync interval of the VolumeAttachment reconciler."),
-		EnableResizer:           *flag.Bool("csi-bv-expansion-enabled", false, "Enables go routine csi-resizer."),
-		GroupSnapshotNamePrefix:   *flag.String("groupsnapshot-name-prefix", "groupsnapshot", "Prefix to apply to the name of a created group snapshot"),
+		Master:                      *flag.String("master", "", "kube master"),
+		Kubeconfig:                  *flag.String("kubeconfig", "", "cluster kube config"),
+		CsiAddress:                  *flag.String("csi-address", "/run/csi/socket", "Address of the CSI BV driver socket."),
+		Endpoint:                    *flag.String("csi-endpoint", "unix://tmp/csi.sock", "CSI BV endpoint"),
+		FssCsiAddress:               *flag.String("fss-csi-address", "/run/fss/socket", "Address of the CSI FSS driver socket."),
+		FssEndpoint:                 *flag.String("fss-csi-endpoint", "unix://tmp/csi-fss.sock", "CSI FSS endpoint"),
+		VolumeNamePrefix:            *flag.String("csi-volume-name-prefix", "pvc", "Prefix to apply to the name of a created volume."),
+		FssVolumeNamePrefix:         *flag.String("fss-csi-volume-name-prefix", "pvc", "Prefix to apply to the name of a volume created for FSS."),
+		LustreCsiAddress:            *flag.String("lustre-csi-address", "/run/lustre/socket", "Address of the CSI Lustre driver socket."),
+		LustreEndpoint:              *flag.String("lustre-csi-endpoint", "unix://tmp/csi-lustre.sock", "CSI Lustre endpoint"),
+		LustreVolumeNamePrefix:      *flag.String("lustre-csi-volume-name-prefix", "pvc", "Prefix to apply to the name of a volume created for Lustre."),
+		VolumeNameUUIDLength:        *flag.Int("csi-volume-name-uuid-length", -1, "Truncates generated UUID of a created volume to this length. Defaults behavior is to NOT truncate."),
+		ShowVersion:                 *flag.Bool("csi-version", false, "Show version."),
+		RetryIntervalStart:          *flag.Duration("csi-retry-interval-start", time.Second, "Initial retry interval of failed provisioning or deletion. It doubles with each failure, up to retry-interval-max."),
+		RetryIntervalMax:            *flag.Duration("csi-retry-interval-max", 5*time.Minute, "Maximum retry interval of failed provisioning or deletion."),
+		WorkerThreads:               *flag.Uint("csi-worker-threads", 100, "Number of provisioner worker threads, in other words nr. of simultaneous CSI calls."),
+		OperationTimeout:            *flag.Duration("csi-op-timeout", 10*time.Second, "Timeout for waiting for creation or deletion of a volume"),
+		EnableLeaderElection:        *flag.Bool("csi-enable-leader-election", false, "Enables leader election. If leader election is enabled, additional RBAC rules are required. Please refer to the Kubernetes CSI documentation for instructions on setting up these RBAC rules."),
+		LeaderElectionType:          *flag.String("csi-leader-election-type", "endpoints", "the type of leader election, options are 'endpoints' (default) or 'leases' (strongly recommended). The 'endpoints' option is deprecated in favor of 'leases'."),
+		LeaderElectionNamespace:     *flag.String("csi-leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set."),
+		StrictTopology:              *flag.Bool("csi-strict-topology", false, "Passes only selected node topology to CreateVolume Request, unlike default behavior of passing aggregated cluster topologies that match with topology keys of the selected node."),
+		Resync:                      *flag.Duration("csi-resync", 10*time.Minute, "Resync interval of the controller."),
+		Timeout:                     *flag.Duration("csi-timeout", 15*time.Second, "Timeout for waiting for attaching or detaching the volume."),
+		FinalizerThreads:            *flag.Uint("cloning-protection-threads", 1, "Number of simultaniously running threads, handling cloning finalizer removal"),
+		MetricsAddress:              *flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled."),
+		MetricsPath:                 *flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`."),
+		ExtraCreateMetadata:         *flag.Bool("extra-create-metadata", false, "If set, add pv/pvc metadata to plugin create requests as parameters."),
+		ReconcileSync:               *flag.Duration("reconcile-sync", 1*time.Minute, "Resync interval of the VolumeAttachment reconciler."),
+		EnableResizer:               *flag.Bool("csi-bv-expansion-enabled", false, "Enables go routine csi-resizer."),
+		GroupSnapshotNamePrefix:     *flag.String("groupsnapshot-name-prefix", "groupsnapshot", "Prefix to apply to the name of a created group snapshot"),
 		GroupSnapshotNameUUIDLength: *flag.Int("groupsnapshot-name-uuid-length", -1, "Length in characters for the generated uuid of a created group snapshot. Defaults behavior is to NOT truncate."),
-
 	}
 	return &csioptions
 }

--- a/cmd/oci-csi-node-driver/nodedriver/nodedriver.go
+++ b/cmd/oci-csi-node-driver/nodedriver/nodedriver.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//RunNodeDriver main function to start node driver
+// RunNodeDriver main function to start node driver
 func RunNodeDriver(nodeOptions nodedriveroptions.NodeOptions, stopCh <-chan struct{}) error {
 	logger := logging.Logger().Sugar()
 	logger.Sync()

--- a/cmd/oci-csi-node-driver/nodedriveroptions/nodecsioptions.go
+++ b/cmd/oci-csi-node-driver/nodedriveroptions/nodecsioptions.go
@@ -14,7 +14,7 @@
 
 package nodedriveroptions
 
-//NodeCSIOptions contains details about the flag
+// NodeCSIOptions contains details about the flag
 type NodeCSIOptions struct {
 	Endpoint   string // Used for Block Volume CSI driver
 	NodeID     string
@@ -22,8 +22,8 @@ type NodeCSIOptions struct {
 	Master     string
 	Kubeconfig string
 
-	EnableFssDriver            bool
-	FssEndpoint                string
+	EnableFssDriver               bool
+	FssEndpoint                   string
 	LustreCsiAddress              string
 	LustreKubeletRegistrationPath string
 	LustreEndpoint                string

--- a/pkg/cloudprovider/providers/oci/load_balancer_util_test.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_util_test.go
@@ -25,9 +25,9 @@ import (
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/oracle/oci-cloud-controller-manager/pkg/oci/client"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
-	"github.com/oracle/oci-cloud-controller-manager/pkg/oci/client"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/csi-util/lustre_lnet_helper.go
+++ b/pkg/csi-util/lustre_lnet_helper.go
@@ -42,7 +42,8 @@ type Parameter map[string]interface{}
 /*
 ValidateLustreVolumeId takes lustreVolumeId as input and returns if its valid or not along with lnetLabel
 Ex. volume handle :  10.112.10.6@tcp1:/fsname
- volume handle : <MGS NID>[:<MGS NID>]:/<fsname>
+
+	volume handle : <MGS NID>[:<MGS NID>]:/<fsname>
 */
 func ValidateLustreVolumeId(lusterVolumeId string) (bool, string) {
 	const minNumOfParamsFromVolumeHandle = 2
@@ -91,9 +92,9 @@ type LnetService struct {
 
 type OCILnetConfigurator struct{}
 
-func NewLnetService() *LnetService{
+func NewLnetService() *LnetService {
 	return &LnetService{
-		Configurator:  &OCILnetConfigurator{},
+		Configurator: &OCILnetConfigurator{},
 	}
 }
 
@@ -331,7 +332,7 @@ func (ls *LnetService) IsLnetActive(logger *zap.SugaredLogger, lnetLabel string)
 }
 
 func (olc *OCILnetConfigurator) ExecuteCommandOnWorkerNode(args ...string) (string, error) {
-	
+
 	command := exec.Command("chroot-bash", args...)
 
 	output, err := command.CombinedOutput()
@@ -374,7 +375,7 @@ func isValidShellInput(input string) bool {
 		return false
 	}
 	// List of forbidden characters
-	forbiddenChars := []string{";", "&", "|", "<", ">", "(", ")", "`", "'", "\"","$","!"}
+	forbiddenChars := []string{";", "&", "|", "<", ">", "(", ")", "`", "'", "\"", "$", "!"}
 	for _, char := range forbiddenChars {
 		if strings.Contains(input, char) {
 			return false
@@ -382,7 +383,7 @@ func isValidShellInput(input string) bool {
 	}
 	return true
 }
-func  ValidateLustreParameters(logger *zap.SugaredLogger, lustreParamsJson string) error {
+func ValidateLustreParameters(logger *zap.SugaredLogger, lustreParamsJson string) error {
 	if lustreParamsJson == "" {
 		logger.Debug("No lustre parameters specified.")
 		return nil
@@ -401,7 +402,7 @@ func  ValidateLustreParameters(logger *zap.SugaredLogger, lustreParamsJson strin
 		for key, value := range param {
 			logger.Infof("Validating lustre param %s=%s", key, fmt.Sprintf("%v", value))
 			if !isValidShellInput(key) || !isValidShellInput(fmt.Sprintf("%v", value)) {
-				invalidParams = append(invalidParams, fmt.Sprintf("%v=%v",key, value))
+				invalidParams = append(invalidParams, fmt.Sprintf("%v=%v", key, value))
 			}
 		}
 	}
@@ -411,4 +412,3 @@ func  ValidateLustreParameters(logger *zap.SugaredLogger, lustreParamsJson strin
 	logger.Infof("Successfully validated lustre parameters.")
 	return nil
 }
-

--- a/pkg/csi-util/utils_test.go
+++ b/pkg/csi-util/utils_test.go
@@ -356,21 +356,21 @@ func Test_DiskByPathPatternForPV(t *testing.T) {
 func Test_LoadNodeMetadataFromApiServer(t *testing.T) {
 
 	tests := []struct {
-		name     string
-		nodeName string
-		want     *NodeMetadata
-		kubeclient 		 kubernetes.Interface
-		err      error
+		name       string
+		nodeName   string
+		want       *NodeMetadata
+		kubeclient kubernetes.Interface
+		err        error
 	}{
 		{
 			name:     "should return ipv6 for ipv6 preferred node",
 			nodeName: "ipv6Preferred",
 			want: &NodeMetadata{
 				FullAvailabilityDomain: "xyz:PHX-AD-3",
-				AvailabilityDomain: "PHX-AD-3",
-				PreferredNodeIpFamily: Ipv6Stack,
-				Ipv4Enabled:           true,
-				Ipv6Enabled:           true,
+				AvailabilityDomain:     "PHX-AD-3",
+				PreferredNodeIpFamily:  Ipv6Stack,
+				Ipv4Enabled:            true,
+				Ipv6Enabled:            true,
 			},
 		},
 		{
@@ -378,7 +378,7 @@ func Test_LoadNodeMetadataFromApiServer(t *testing.T) {
 			nodeName: "ipv4Preferred",
 			want: &NodeMetadata{
 				PreferredNodeIpFamily: Ipv4Stack,
-				AvailabilityDomain: "PHX-AD-3",
+				AvailabilityDomain:    "PHX-AD-3",
 				Ipv4Enabled:           true,
 				Ipv6Enabled:           true,
 			},
@@ -387,7 +387,7 @@ func Test_LoadNodeMetadataFromApiServer(t *testing.T) {
 			name:     "should return default IPv4 family for no ip preference",
 			nodeName: "noIpPreference",
 			want: &NodeMetadata{
-				AvailabilityDomain: "PHX-AD-3",
+				AvailabilityDomain:    "PHX-AD-3",
 				PreferredNodeIpFamily: Ipv4Stack,
 				Ipv4Enabled:           true,
 				Ipv6Enabled:           false,
@@ -414,7 +414,7 @@ func Test_LoadNodeMetadataFromApiServer(t *testing.T) {
 			nodeName: "ipv4Preferred",
 			want: &NodeMetadata{
 				PreferredNodeIpFamily: Ipv4Stack,
-				AvailabilityDomain: "PHX-AD-3",
+				AvailabilityDomain:    "PHX-AD-3",
 				Ipv4Enabled:           true,
 				Ipv6Enabled:           true,
 			},
@@ -428,8 +428,8 @@ func Test_LoadNodeMetadataFromApiServer(t *testing.T) {
 			want:     &NodeMetadata{},
 			err:      fmt.Errorf("Failed to get node information from kube api server, please check if kube api server is accessible."),
 			kubeclient: &util.MockKubeClientWithFailingRestClient{
-			CoreClient: &util.MockCoreClientWithFailingRestClient{},
-		},
+				CoreClient: &util.MockCoreClientWithFailingRestClient{},
+			},
 		},
 	}
 
@@ -442,12 +442,10 @@ func Test_LoadNodeMetadataFromApiServer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-
 			log.SetOutput(os.Stdout)
 			nodeMetadata := &NodeMetadata{}
-			ctx, cancel := context.WithTimeout(context.Background(), 10 * time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-
 
 			var k kubernetes.Interface
 			if tt.kubeclient != nil {
@@ -813,25 +811,24 @@ func Test_ValidateDNSName(t *testing.T) {
 func Test_LoadCSIConfigFromConfigMap(t *testing.T) {
 
 	tests := []struct {
-		name     string
+		name          string
 		configMapName string
-		want     *util.CSIConfig
+		want          *util.CSIConfig
 	}{
 		{
-			name:     "Parse Configs correctly when csi config map is present",
+			name:          "Parse Configs correctly when csi config map is present",
 			configMapName: "oci-csi-config",
 			want: &util.CSIConfig{
 				Lustre: &util.DriverConfig{
-					SkipNodeUnstage: true,
+					SkipNodeUnstage:      true,
 					SkipLustreParameters: true,
 				},
 			},
 		},
 		{
-			name:     "Return default config if config map is not present",
+			name:          "Return default config if config map is not present",
 			configMapName: "invalid",
-			want: &util.CSIConfig{
-			},
+			want:          &util.CSIConfig{},
 		},
 	}
 
@@ -860,29 +857,29 @@ type mockServiceError struct {
 	MessageArgument         map[string]string `json:"messageArguments"`
 	OpcRequestID            string            `json:"opc-request-id"`
 	// debugging information
-	TargetService string  `json:"target-service"`
-	OperationName string  `json:"operation-name"`
+	TargetService string         `json:"target-service"`
+	OperationName string         `json:"operation-name"`
 	Timestamp     common.SDKTime `json:"timestamp"`
-	RequestTarget string  `json:"request-target"`
-	ClientVersion string  `json:"client-version"`
+	RequestTarget string         `json:"request-target"`
+	ClientVersion string         `json:"client-version"`
 
 	// troubleshooting guidance
 	OperationReferenceLink   string `json:"operation-reference-link"`
 	ErrorTroubleshootingLink string `json:"error-troubleshooting-link"`
 }
 
-func (m *mockServiceError) GetTargetService() string                { return m.TargetService }
-func (m *mockServiceError) GetHTTPStatusCode() int                  { return m.StatusCode }
-func (m *mockServiceError) GetCode() string                         { return m.Code }
-func (m *mockServiceError) GetOpcRequestID() string                 { return m.OpcRequestID }
-func (m *mockServiceError) GetMessage() string                      { return m.Message }
-func (m *mockServiceError) GetOperationName() string                { return m.OperationName }
-func (m *mockServiceError) GetTimestamp() common.SDKTime            { return m.Timestamp }
-func (m *mockServiceError) GetRequestTarget() string                { return m.RequestTarget }
-func (m *mockServiceError) GetClientVersion() string                { return m.ClientVersion }
-func (m *mockServiceError) GetOperationReferenceLink() string       { return m.OperationReferenceLink }
-func (m *mockServiceError) GetErrorTroubleshootingLink() string     { return m.ErrorTroubleshootingLink }
-func (m *mockServiceError) Error() string                           { return m.Message }
+func (m *mockServiceError) GetTargetService() string            { return m.TargetService }
+func (m *mockServiceError) GetHTTPStatusCode() int              { return m.StatusCode }
+func (m *mockServiceError) GetCode() string                     { return m.Code }
+func (m *mockServiceError) GetOpcRequestID() string             { return m.OpcRequestID }
+func (m *mockServiceError) GetMessage() string                  { return m.Message }
+func (m *mockServiceError) GetOperationName() string            { return m.OperationName }
+func (m *mockServiceError) GetTimestamp() common.SDKTime        { return m.Timestamp }
+func (m *mockServiceError) GetRequestTarget() string            { return m.RequestTarget }
+func (m *mockServiceError) GetClientVersion() string            { return m.ClientVersion }
+func (m *mockServiceError) GetOperationReferenceLink() string   { return m.OperationReferenceLink }
+func (m *mockServiceError) GetErrorTroubleshootingLink() string { return m.ErrorTroubleshootingLink }
+func (m *mockServiceError) Error() string                       { return m.Message }
 
 func TestGetOCIServiceError(t *testing.T) {
 	tests := []struct {

--- a/pkg/csi/driver/bv_node_test.go
+++ b/pkg/csi/driver/bv_node_test.go
@@ -130,10 +130,10 @@ func Test_alreadyDeletedPathCheck(t *testing.T) {
 
 // mockMounter implements Interface.
 type mockMounter struct {
-	runner  exec.Interface
-	mounter mount.Interface
-	logger  *zap.SugaredLogger
-	devicePathExistWaitError error
+	runner                    exec.Interface
+	mounter                   mount.Interface
+	logger                    *zap.SugaredLogger
+	devicePathExistWaitError  error
 	ISCSILogoutOnFailureError error
 }
 
@@ -246,7 +246,7 @@ func TestNodeStageVolume(t *testing.T) {
 	multiPathDevicesJson, err = json.Marshal([]core.MultipathDevice{
 		{
 			Ipv4: common.String("1.2.3.4"),
-			Iqn: common.String("iqn.2016-09.com.oraclecloud"),
+			Iqn:  common.String("iqn.2016-09.com.oraclecloud"),
 			Port: common.Int(3034),
 		},
 	})
@@ -256,14 +256,14 @@ func TestNodeStageVolume(t *testing.T) {
 	multipathDevicesString := string(multiPathDevicesJson)
 
 	testCases := []struct {
-		name         string
-		req          *csi.NodeStageVolumeRequest
-		setup  		 func(m *mockMounter)
-		expectedErr  error
+		name        string
+		req         *csi.NodeStageVolumeRequest
+		setup       func(m *mockMounter)
+		expectedErr error
 	}{
 		{
-			name: "Volume ID not present",
-			req: &csi.NodeStageVolumeRequest{},
+			name:        "Volume ID not present",
+			req:         &csi.NodeStageVolumeRequest{},
 			expectedErr: status.Error(codes.InvalidArgument, "Volume ID must be provided"),
 		},
 		{
@@ -276,17 +276,16 @@ func TestNodeStageVolume(t *testing.T) {
 		{
 			name: "Staging path not present",
 			req: &csi.NodeStageVolumeRequest{
-				VolumeId: "ocid.abcd",
+				VolumeId:       "ocid.abcd",
 				PublishContext: map[string]string{"attach-type": "iscsi"},
-
 			},
 			expectedErr: status.Error(codes.InvalidArgument, "Staging Target Path must be provided"),
 		},
 		{
 			name: "Volume Capability not present",
 			req: &csi.NodeStageVolumeRequest{
-				VolumeId: "ocid.abcd",
-				PublishContext: map[string]string{"attach-type": "iscsi"},
+				VolumeId:          "ocid.abcd",
+				PublishContext:    map[string]string{"attach-type": "iscsi"},
 				StagingTargetPath: "/staging-path",
 			},
 			expectedErr: status.Error(codes.InvalidArgument, "Volume Capability must be provided"),
@@ -294,8 +293,8 @@ func TestNodeStageVolume(t *testing.T) {
 		{
 			name: "Wrong value for multipath enabled",
 			req: &csi.NodeStageVolumeRequest{
-				VolumeId: "ocid.abcd",
-				PublishContext: map[string]string{multipathEnabled: "yes"},
+				VolumeId:          "ocid.abcd",
+				PublishContext:    map[string]string{multipathEnabled: "yes"},
 				StagingTargetPath: "/staging-path",
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -308,8 +307,8 @@ func TestNodeStageVolume(t *testing.T) {
 		{
 			name: "UHP - Invalid multipath device list",
 			req: &csi.NodeStageVolumeRequest{
-				VolumeId: "ocid.abcd",
-				PublishContext: map[string]string{multipathEnabled: "true", multipathDevices: "Not a valid device list"},
+				VolumeId:          "ocid.abcd",
+				PublishContext:    map[string]string{multipathEnabled: "true", multipathDevices: "Not a valid device list"},
 				StagingTargetPath: "/staging-path",
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -337,8 +336,8 @@ func TestNodeStageVolume(t *testing.T) {
 		{
 			name: "ISCSI - Information missing in publish context",
 			req: &csi.NodeStageVolumeRequest{
-				VolumeId: "ocid.abcd",
-				PublishContext: map[string]string{disk.ISCSIPORT: "3043", disk.ISCSIIP: "1.2.3.4"},
+				VolumeId:          "ocid.abcd",
+				PublishContext:    map[string]string{disk.ISCSIPORT: "3043", disk.ISCSIIP: "1.2.3.4"},
 				StagingTargetPath: "/staging-path",
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -351,8 +350,8 @@ func TestNodeStageVolume(t *testing.T) {
 		{
 			name: "ISCSI - Error getting target IP in IPv6 single stack cluster",
 			req: &csi.NodeStageVolumeRequest{
-				VolumeId: "ocid.abcd",
-				PublishContext: map[string]string{disk.ISCSIPORT: "3043", disk.ISCSIIP: "fd00:c1::a9fe:a9fe", disk.ISCSIIQN: "iqn.2016-09.com.oraclecloud"},
+				VolumeId:          "ocid.abcd",
+				PublishContext:    map[string]string{disk.ISCSIPORT: "3043", disk.ISCSIIP: "fd00:c1::a9fe:a9fe", disk.ISCSIIQN: "iqn.2016-09.com.oraclecloud"},
 				StagingTargetPath: "/staging-path",
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{
@@ -489,19 +488,19 @@ func TestNodeStageVolume(t *testing.T) {
 			if tc.name == "ISCSI - Error getting target IP in IPv6 single stack cluster" {
 				driver = &BlockVolumeNodeDriver{
 					NodeDriver: NodeDriver{
-						logger: logging.Logger().Sugar(),
+						logger:         logging.Logger().Sugar(),
 						mounterFactory: testMounterFactory,
 						nodeMetadata: &csi_util.NodeMetadata{
 							PreferredNodeIpFamily: "IPv6",
 						},
 					},
 				}
-			} else if  tc.name == "Error acquiring lock" {
+			} else if tc.name == "Error acquiring lock" {
 				driver = &BlockVolumeNodeDriver{
 					NodeDriver: NodeDriver{
-						logger: logging.Logger().Sugar(),
+						logger:         logging.Logger().Sugar(),
 						mounterFactory: testMounterFactory,
-						volumeLocks:  csi_util.NewVolumeLocks(),
+						volumeLocks:    csi_util.NewVolumeLocks(),
 						nodeMetadata: &csi_util.NodeMetadata{
 							PreferredNodeIpFamily: "IPv4",
 						},
@@ -513,9 +512,9 @@ func TestNodeStageVolume(t *testing.T) {
 			} else {
 				driver = &BlockVolumeNodeDriver{
 					NodeDriver: NodeDriver{
-						logger: logging.Logger().Sugar(),
+						logger:         logging.Logger().Sugar(),
 						mounterFactory: testMounterFactory,
-						volumeLocks:  csi_util.NewVolumeLocks(),
+						volumeLocks:    csi_util.NewVolumeLocks(),
 						nodeMetadata: &csi_util.NodeMetadata{
 							PreferredNodeIpFamily: "IPv4",
 						},

--- a/pkg/csi/driver/fss_controller.go
+++ b/pkg/csi/driver/fss_controller.go
@@ -149,7 +149,7 @@ func (d *FSSControllerDriver) CreateVolume(ctx context.Context, req *csi.CreateV
 		serviceAccountToken = serviceAccountTokenCreated
 	}
 
-	ociClientConfig := &client.OCIClientConfig{ SaToken: serviceAccountToken, ParentRptURL: secretParameters.parentRptURL, TenancyId: d.config.Auth.TenancyID }
+	ociClientConfig := &client.OCIClientConfig{SaToken: serviceAccountToken, ParentRptURL: secretParameters.parentRptURL, TenancyId: d.config.Auth.TenancyID}
 
 	networkingClient := d.client.Networking(ociClientConfig)
 	if networkingClient == nil {
@@ -628,7 +628,7 @@ func extractStorageClassParameters(ctx context.Context, d *FSSControllerDriver, 
 	}
 
 	if client.IsIpv6SingleStackCluster() {
-		if !strings.Contains(availabilityDomain,":") {
+		if !strings.Contains(availabilityDomain, ":") {
 			log.Errorf("Full AvailabilityDomain with prefix not provided in storage class for IPv6 single stack cluster.")
 			dimensionsMap[metrics.ComponentDimension] = util.GetMetricDimensionForComponent(util.ErrValidation, util.CSIStorageType)
 			metrics.SendMetricData(d.metricPusher, metrics.FssAllProvision, time.Since(startTime).Seconds(), dimensionsMap)
@@ -793,7 +793,7 @@ func provisionMountTarget(ctx context.Context, log *zap.SugaredLogger, c client.
 		SubnetId:           &storageClassParameters.mountTargetSubnetOcid,
 		FreeformTags:       storageClassParameters.scTags.FreeformTags,
 		DefinedTags:        storageClassParameters.scTags.DefinedTags,
-		NsgIds: 			storageClassParameters.nsgOcids,
+		NsgIds:             storageClassParameters.nsgOcids,
 	}
 	return fssClient.CreateMountTarget(ctx, createMountTargetDetails)
 }
@@ -833,7 +833,7 @@ func (d *FSSControllerDriver) DeleteVolume(ctx context.Context, req *csi.DeleteV
 		serviceAccountToken = serviceAccountTokenGenerated
 	}
 
-	ociClientConfig := &client.OCIClientConfig{ SaToken: serviceAccountToken, ParentRptURL: secretParameters.parentRptURL, TenancyId: d.config.Auth.TenancyID }
+	ociClientConfig := &client.OCIClientConfig{SaToken: serviceAccountToken, ParentRptURL: secretParameters.parentRptURL, TenancyId: d.config.Auth.TenancyID}
 
 	fssClient := d.client.FSS(ociClientConfig)
 
@@ -1041,7 +1041,7 @@ func (d *FSSControllerDriver) ValidateVolumeCapabilities(ctx context.Context, re
 		serviceAccountToken = serviceAccountTokenGenerated
 	}
 
-	ociClientConfig := &client.OCIClientConfig{ SaToken: serviceAccountToken, ParentRptURL: secretParameters.parentRptURL, TenancyId: d.config.Auth.TenancyID }
+	ociClientConfig := &client.OCIClientConfig{SaToken: serviceAccountToken, ParentRptURL: secretParameters.parentRptURL, TenancyId: d.config.Auth.TenancyID}
 
 	networkingClient := d.client.Networking(ociClientConfig)
 	if networkingClient == nil {

--- a/pkg/csi/driver/fss_controller_test.go
+++ b/pkg/csi/driver/fss_controller_test.go
@@ -403,6 +403,7 @@ func (p *MockProvisionerClient) FSS(ociClientConfig *client.OCIClientConfig) cli
 type MockFSSProvisionerClient struct {
 	Storage *MockFileStorageClient
 }
+
 func (m MockFSSProvisionerClient) Lustre() client.LustreInterface {
 	return nil
 }
@@ -545,12 +546,12 @@ func TestFSSControllerDriver_CreateVolume(t *testing.T) {
 			wantErr: errors.New("Neither Mount Target Ocid nor Mount Target Subnet Ocid provided in storage class"),
 		},
 		{
-			name: "Error when invalid JSON string provided for mount target NSGs",
+			name:   "Error when invalid JSON string provided for mount target NSGs",
 			fields: fields{},
 			args: args{
 				ctx: context.Background(),
 				req: &csi.CreateVolumeRequest{
-					Name: "ut-volume",
+					Name:       "ut-volume",
 					Parameters: map[string]string{"availabilityDomain": "US-ASHBURN-AD-1", "mountTargetSubnetOcid": "oc1.subnet.xxxx", "nsgOcids": ""},
 					VolumeCapabilities: []*csi.VolumeCapability{{
 						AccessMode: &csi.VolumeCapability_AccessMode{
@@ -559,7 +560,7 @@ func TestFSSControllerDriver_CreateVolume(t *testing.T) {
 					}},
 				},
 			},
-			want: nil,
+			want:    nil,
 			wantErr: errors.New("Failed to parse nsgOcids provided in storage class. Please provide valid input."),
 		},
 		{

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -193,7 +193,7 @@ type client struct {
 	bs                  blockstorageClient
 	identity            identityClient
 	//compartment 		compartmentClient
-	lustre              lustrefilestorage.LustreFileStorageClient
+	lustre lustrefilestorage.LustreFileStorageClient
 
 	requestMetadata common.RequestMetadata
 	rateLimiter     RateLimiter
@@ -311,7 +311,7 @@ func New(logger *zap.SugaredLogger, cp common.ConfigurationProvider, opRateLimit
 		bs:                  &bs,
 		filestorage:         &fss,
 		//compartment:     	 &compartment,
-		lustre:              lustreClient,
+		lustre:          lustreClient,
 		rateLimiter:     *opRateLimiter,
 		requestMetadata: requestMetadata,
 

--- a/pkg/oci/client/generic_load_balancer_types.go
+++ b/pkg/oci/client/generic_load_balancer_types.go
@@ -118,7 +118,7 @@ type GenericCreateLoadBalancerDetails struct {
 
 	// Only needed for LB
 	Certificates map[string]GenericCertificate
-	RuleSets map[string]loadbalancer.RuleSetDetails
+	RuleSets     map[string]loadbalancer.RuleSetDetails
 	// Supported only in NLB
 	AssignedPrivateIpv4 *string
 	AssignedIpv6        *string

--- a/pkg/oci/client/volume_attachment_test.go
+++ b/pkg/oci/client/volume_attachment_test.go
@@ -11,28 +11,27 @@ import (
 
 func Test_getDevicePath(t *testing.T) {
 	var tests = map[string]struct {
-		instanceID   string
-		want         string
-		wantErr      error
+		instanceID string
+		want       string
+		wantErr    error
 	}{
 		"getDevicePathNoDeviceAvailable": {
 			instanceID: "ocid1.device-path-not-available",
-			wantErr: fmt.Errorf("Max number of volumes are already attached to instance %s. Please schedule workload on different node.", "ocid1.device-path-not-available"),
-
+			wantErr:    fmt.Errorf("Max number of volumes are already attached to instance %s. Please schedule workload on different node.", "ocid1.device-path-not-available"),
 		},
 		"getDevicePathOneDeviceAvailable": {
 			instanceID: "ocid1.one-device-path-available",
-			want: "/dev/oracleoci/oraclevdac",
+			want:       "/dev/oracleoci/oraclevdac",
 		},
 		"getDevicePathReturnsError": {
 			instanceID: "ocid1.device-path-returns-error",
-			wantErr: errNotFound,
+			wantErr:    errNotFound,
 		},
 	}
-	
+
 	vaClient := &client{
 		compute: &mockComputeClient{},
-		logger: zap.S(),
+		logger:  zap.S(),
 	}
 
 	for name, tc := range tests {

--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -169,7 +169,6 @@ type CSIConfig struct {
 	IsLoaded bool
 }
 
-
 // DriverConfig represents driver-specific configurations.
 type DriverConfig struct {
 	SkipNodeUnstage      bool `yaml:"skipNodeUnstage"`

--- a/pkg/util/disk/iscsi.go
+++ b/pkg/util/disk/iscsi.go
@@ -91,7 +91,7 @@ type Interface interface {
 
 	DeviceOpened(pathname string) (bool, error)
 
-	IsMounted(devicePath string, targetPath string)	(bool, error)
+	IsMounted(devicePath string, targetPath string) (bool, error)
 
 	// updates the queue depth for iSCSI target
 	UpdateQueueDepth() error
@@ -504,7 +504,7 @@ func (c *iSCSIMounter) IsMounted(devicePath string, targetPath string) (bool, er
 	var diskByPath string
 	notMnt, err := c.mounter.IsLikelyNotMountPoint(targetPath)
 	if err != nil {
-		if os.IsNotExist(err){
+		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to check if %s is a mount point: %v", targetPath, err)
@@ -619,7 +619,7 @@ func diskByPathsForMountPoint(mountPoint mount.MountPoint, logger *zap.SugaredLo
 			// Sample ISCSI path - ip-169.254.2.14:3260-iscsi-iqn.2015-12.com.oracleiaas:c47b5be3-d2fb-40a5-978b-a793c4ff4806-lun-3
 			// Sample PV path - pci-0000:02:00.0-scsi-0:0:1:2
 			base := filepath.Base(path)
-			if strings.HasPrefix(base, "ip-") && strings.Contains(base, "-iscsi-"){
+			if strings.HasPrefix(base, "ip-") && strings.Contains(base, "-iscsi-") {
 				// include only if ISCSI session active
 				if !isISCSISessionActive(path, logger) {
 					logger.Infof("Ignoring path %s due to no active ISCSI session", path)
@@ -690,7 +690,7 @@ func isISCSISessionActive(path string, logger *zap.SugaredLogger) bool {
 			continue
 		}
 
-		portal := m[1]+":"+m[2]
+		portal := m[1] + ":" + m[2]
 		portalMatch := strings.Contains(line, portal)
 
 		if portalMatch && strings.Contains(line, m[3]) {

--- a/pkg/util/disk/paravirtualized.go
+++ b/pkg/util/disk/paravirtualized.go
@@ -37,8 +37,6 @@ type pvMounter struct {
 	logger       *zap.SugaredLogger
 }
 
-
-
 // NewFromPVDisk creates a new PV handler from PVDisk.
 func NewFromPVDisk(logger *zap.SugaredLogger) Interface {
 	return &pvMounter{
@@ -111,7 +109,7 @@ func (c *pvMounter) DeviceOpened(pathname string) (bool, error) {
 func (c *pvMounter) IsMounted(devicePath string, targetPath string) (bool, error) {
 	notMnt, err := c.mounter.IsLikelyNotMountPoint(targetPath)
 	if err != nil {
-		if os.IsNotExist(err){
+		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to check if %s is a mount point: %v", targetPath, err)

--- a/pkg/util/osinfo/osinfo.go
+++ b/pkg/util/osinfo/osinfo.go
@@ -12,9 +12,9 @@ var OsName = ""
 const (
 	LinuxOsReleaseFile = "/host/etc/os-release"
 
-	DebianOSName       = "Debian GNU/Linux"
+	DebianOSName = "Debian GNU/Linux"
 
-	UbuntuOSName       = "Ubuntu"
+	UbuntuOSName = "Ubuntu"
 )
 
 func GetOsName() (name string) {
@@ -22,8 +22,8 @@ func GetOsName() (name string) {
 		return OsName
 	}
 
-	OsName =  parseLinuxReleaseFile(LinuxOsReleaseFile)
-	return OsName;
+	OsName = parseLinuxReleaseFile(LinuxOsReleaseFile)
+	return OsName
 }
 
 func readLines(path string) ([]string, error) {
@@ -57,7 +57,6 @@ func parseLinuxReleaseFile(releaseFile string) (name string) {
 	}
 	return osName
 }
-
 
 func IsUbuntu() bool {
 	return strings.EqualFold(UbuntuOSName, GetOsName())

--- a/pkg/util/signals/signal_posix.go
+++ b/pkg/util/signals/signal_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/test/e2e/cloud-provider-oci/boot_volume.go
+++ b/test/e2e/cloud-provider-oci/boot_volume.go
@@ -84,7 +84,7 @@ var _ = Describe("Boot volume tests", func() {
 				}
 
 				pvcJig.DeletePod(f.Namespace.Name, "app1", 7*time.Minute)
-				pvcJig.DeleteBootVolume(f.BlockStorageClient, bootvolumeId, 5 * time.Minute)
+				pvcJig.DeleteBootVolume(f.BlockStorageClient, bootvolumeId, 5*time.Minute)
 				_ = f.DeleteStorageClass(f.Namespace.Name)
 			})
 		})

--- a/test/e2e/framework/pvc_util.go
+++ b/test/e2e/framework/pvc_util.go
@@ -2054,7 +2054,7 @@ func (j *PVCTestJig) CheckDataPersistenceWithDeploymentImpl(pvcName string, ns s
 		taintIsMaster := false
 		if node.Spec.Unschedulable == false {
 			for _, taint := range node.Spec.Taints {
-				taintIsMaster = (taint.Key == "node-role.kubernetes.io/master" || taint.Key == "node-role.kubernetes.io/control-plane" ||(taint.Key == "dedicated" && taint.Value == "lustre"))
+				taintIsMaster = (taint.Key == "node-role.kubernetes.io/master" || taint.Key == "node-role.kubernetes.io/control-plane" || (taint.Key == "dedicated" && taint.Value == "lustre"))
 			}
 			if !taintIsMaster {
 				schedulableNodeFound = true

--- a/test/e2e/framework/volumesnapshotclass_util.go
+++ b/test/e2e/framework/volumesnapshotclass_util.go
@@ -49,17 +49,17 @@ func (f *CloudProviderFramework) CreateVolumeSnapshotClassOrFail(name string, dr
 // does not actually create the storage class. The default storage class has the same name
 // as the jig
 func (f *CloudProviderFramework) NewVolumeSnapshotClassTemplate(name string, parameters map[string]string,
-	driverType string,deletionPolicy snapshot.DeletionPolicy) *snapshot.VolumeSnapshotClass {
+	driverType string, deletionPolicy snapshot.DeletionPolicy) *snapshot.VolumeSnapshotClass {
 	return &snapshot.VolumeSnapshotClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VolumeSnapshotClass",
 			APIVersion: "snapshot.storage.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
+			Name: name,
 		},
 		Driver:         driverType,
-		Parameters:		parameters,
+		Parameters:     parameters,
 		DeletionPolicy: deletionPolicy,
 	}
 }


### PR DESCRIPTION
Go source files are currently not properly formatted, making `make gofmt` fail. This PR addresses that.