### PR TITLE
External-ccm: Use appropriate method for printf-style log calls

### DIFF
--- a/cmd/oci-csi-controller-driver/csi-controller-driver/oci-csi-controller-driver.go
+++ b/cmd/oci-csi-controller-driver/csi-controller-driver/oci-csi-controller-driver.go
@@ -54,10 +54,10 @@ func StartControllerDriver(csioptions csioptions.CSIOptions, csiDriver driver.CS
 		drv, err = driver.NewControllerDriver(logger, *controllerDriverConfig)
 	}
 	if err != nil {
-		logger.With(zap.Error(err)).Fatal("Failed to create %s controller driver.", csiDriver)
+		logger.With(zap.Error(err)).Fatalf("Failed to create %s controller driver.", csiDriver)
 	}
 	if err := drv.Run(); err != nil {
-		logger.With(zap.Error(err)).Fatal("Failed to run the CSI driver for %s.", csiDriver)
+		logger.With(zap.Error(err)).Fatalf("Failed to run the CSI driver for %s.", csiDriver)
 	}
 
 	logger.Info("CSI driver exited")

--- a/pkg/cloudprovider/providers/oci/load_balancer_spec.go
+++ b/pkg/cloudprovider/providers/oci/load_balancer_spec.go
@@ -696,7 +696,7 @@ func getPreserveSource(logger *zap.SugaredLogger, svc *v1.Service) (bool, error)
 	if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
 		_, ok := svc.Annotations[ServiceAnnotationNetworkLoadBalancerIsPreserveSource]
 		if ok {
-			logger.Error("error : externalTrafficPolicy is set to Cluster and the %s annotation is set", ServiceAnnotationNetworkLoadBalancerIsPreserveSource)
+			logger.Errorf("error : externalTrafficPolicy is set to Cluster and the %s annotation is set", ServiceAnnotationNetworkLoadBalancerIsPreserveSource)
 			return false, fmt.Errorf("%s annotation cannot be set when externalTrafficPolicy is set to Cluster", ServiceAnnotationNetworkLoadBalancerIsPreserveSource)
 		}
 	}
@@ -715,7 +715,7 @@ func getPreserveSourceAnnotation(logger *zap.SugaredLogger, svc *v1.Service) (bo
 	if annotationString, ok := svc.Annotations[ServiceAnnotationNetworkLoadBalancerIsPreserveSource]; ok {
 		enable, err := strconv.ParseBool(annotationString)
 		if err != nil {
-			logger.Error("failed to to parse %s annotation value - %s", ServiceAnnotationNetworkLoadBalancerIsPreserveSource, annotationString)
+			logger.Errorf("failed to to parse %s annotation value - %s", ServiceAnnotationNetworkLoadBalancerIsPreserveSource, annotationString)
 			return false, fmt.Errorf("failed to to parse %s annotation value - %s", ServiceAnnotationNetworkLoadBalancerIsPreserveSource, annotationString)
 		}
 		return enable, nil

--- a/pkg/cloudprovider/providers/oci/node_info_controller.go
+++ b/pkg/cloudprovider/providers/oci/node_info_controller.go
@@ -188,7 +188,7 @@ func (nic *NodeInfoController) processItem(key string) error {
 		return err
 	})
 	if err != nil {
-		logger.With(zap.Error(err)).Error("Error in applying patch in node %v", err)
+		logger.With(zap.Error(err)).Error("Error in applying patch in node")
 		return err
 	}
 

--- a/pkg/oci/client/client.go
+++ b/pkg/oci/client/client.go
@@ -403,7 +403,7 @@ func (c *client) Networking(ociClientConfig *OCIClientConfig) NetworkingInterfac
 
 		err = configureCustomTransport(c.logger, &network.BaseClient)
 		if err != nil {
-			c.logger.Error("Failed configure custom transport for Network Client %v", err)
+			c.logger.Errorf("Failed configure custom transport for Network Client %v", err)
 			return nil
 		}
 
@@ -443,7 +443,7 @@ func (c *client) Identity(ociClientConfig *OCIClientConfig) IdentityInterface {
 
 		err = configureCustomTransport(c.logger, &identity.BaseClient)
 		if err != nil {
-			c.logger.Error("Failed configure custom transport for Identity Client %v", err)
+			c.logger.Errorf("Failed configure custom transport for Identity Client %v", err)
 			return nil
 		}
 

--- a/pkg/oci/client/load_balancer.go
+++ b/pkg/oci/client/load_balancer.go
@@ -115,7 +115,7 @@ func (c *loadbalancerClientStruct) GetLoadBalancerByName(ctx context.Context, co
 				if *lb.DisplayName == name && *lb.CompartmentId == compartmentID {
 					return lb, err
 				}
-				logger.Info("LB name to OCID cache stale record. Actual display name: %s, compartment %s", *lb.DisplayName, *lb.CompartmentId)
+				logger.Infof("LB name to OCID cache stale record. Actual display name: %s, compartment %s", *lb.DisplayName, *lb.CompartmentId)
 			} else {
 				logger.Info("LB name to OCID cache failed to get LB or the response contained unexpected nil value")
 			}

--- a/pkg/oci/client/network_load_balancer.go
+++ b/pkg/oci/client/network_load_balancer.go
@@ -88,7 +88,7 @@ func (c *networkLoadbalancer) GetLoadBalancerByName(ctx context.Context, compart
 				if *lb.DisplayName == name && *lb.CompartmentId == compartmentID {
 					return lb, err
 				}
-				logger.Info("NLB name to OCID cache stale record. Actual display name: %s, compartment %s", *lb.DisplayName, *lb.CompartmentId)
+				logger.Infof("NLB name to OCID cache stale record. Actual display name: %s, compartment %s", *lb.DisplayName, *lb.CompartmentId)
 			} else {
 				logger.Info("NLB name to OCID cache failed to get LB or the response contained unexpected nil value")
 			}

--- a/pkg/util/disk/mount_helper.go
+++ b/pkg/util/disk/mount_helper.go
@@ -49,7 +49,7 @@ func MountWithEncrypt(logger *zap.SugaredLogger, source string, target string, f
 	mountArgs, mountArgsLogStr := MakeMountArgs(source, target, fstype, options)
 	mountArgsLogStr = EncryptionMountCommand + " " + mountArgsLogStr
 
-	logger.Debug("Mounting cmd (%s) with arguments (%s)", EncryptionMountCommand, mountArgsLogStr)
+	logger.Debugf("Mounting cmd (%s) with arguments (%s)", EncryptionMountCommand, mountArgsLogStr)
 	command := exec.Command(EncryptionMountCommand, mountArgs...)
 	output, err := command.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
zap's sugared logger `Fatal`/`Error`/`Info`/`Debug` methods treat their first argument as a plain string, not a format string. Passing format verbs like `%s`/`%v` without the 'f' suffix causes them to appear literally in log output instead of being interpolated.

Example of a log with no printf formatting we can see today:
```
2026-03-06T21:08:01.983Z        FATAL   FSS     csi-controller-driver/oci-csi-controller-driver.go:56 Failed to run the CSI driver for %s.FSS {"component": "csi-controller", "error": "failed to remove unix domain socket file /var/run/shared-tmpfs/csi-fss.sock"}
```

Also removed a duplicated error from a log in `node_info_controller.go` where `err` was attached to the log both with `zap.Error(err)` and through a (broken) printf-style `%v`.